### PR TITLE
fix(types): a source-only map stops laundering recovered identifiers into valid syntax

### DIFF
--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -379,10 +379,34 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
     self.ident
   }
 
-  /// Maps the source string to a new type, preserving the span and language.
+  /// Maps the source string to a new type, preserving the span, the language, and the
+  /// recovery status.
+  ///
+  /// Recovery status is orthogonal to the source representation: mapping
+  /// `Ident<&str>` to `Ident<String>` changes how the spelling is stored, not whether the
+  /// parser actually found an identifier there. An [`error`](ErrorNode::error) or
+  /// [`missing`](ErrorNode::missing) placeholder therefore stays one across the map.
+  ///
+  /// The body destructures `Self` exhaustively instead of rebuilding through
+  /// [`Self::new`], and that shape is the point. `new` always produces a valid identifier,
+  /// so a `new`-based body silently laundered recovery placeholders into valid syntax with
+  /// nothing to flag the omission; the destructuring form fails to compile the next time a
+  /// field is added rather than dropping it.
   #[inline(always)]
   pub fn map<U>(self, f: impl FnOnce(S) -> U) -> Ident<U, Span, Lang> {
-    Ident::new(self.span, f(self.ident))
+    let Self {
+      _lang,
+      status,
+      span,
+      ident,
+    } = self;
+
+    Ident {
+      _lang,
+      status,
+      span,
+      ident: f(ident),
+    }
   }
 }
 

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -161,9 +161,21 @@ pub struct Keyword<S: ?Sized, Span = SimpleSpan, Lang: ?Sized = ()> {
 }
 
 impl<S, Span, Lang: ?Sized> From<Keyword<S, Span, Lang>> for super::Ident<S, Span, Lang> {
+  /// The resulting identifier is reported as valid unconditionally. `Keyword` has no field
+  /// that can hold a recovery status and no predicate that can report one, so there is
+  /// nothing to carry across. This conversion therefore cannot distinguish a keyword that
+  /// was spelled out in the source from one built by `Keyword::error` or `Keyword::missing`,
+  /// and it reports the latter as valid too — that gap is tracked as tokora#301 and is not
+  /// fixable here, because the information does not exist on the source side.
+  ///
+  /// The source is destructured exhaustively so that a `Keyword` field added later stops this
+  /// impl from compiling — a cross-type rebuild cannot be made total on the target side, but it
+  /// can be made total on the side whose fields it reads.
   #[inline(always)]
   fn from(keyword: Keyword<S, Span, Lang>) -> Self {
-    Self::new(keyword.span, keyword.ident)
+    let Keyword { _lang, span, ident } = keyword;
+
+    Self::new(span, ident)
   }
 }
 
@@ -357,9 +369,21 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   }
 
   /// Maps the source string to a new type, preserving the span and language.
+  ///
+  /// Destructures `Self` exhaustively rather than rebuilding through [`Self::new`]. Today
+  /// the two are equivalent, because `Keyword` carries nothing beyond the span, the source
+  /// and the language marker — but a `new`-based body drops any field added later without
+  /// a diagnostic, which is exactly how [`Ident::map`](super::Ident::map) came to launder
+  /// recovery placeholders into valid syntax. This form fails to compile instead.
   #[inline(always)]
   pub fn map<U>(self, f: impl FnOnce(S) -> U) -> Keyword<U, Span, Lang> {
-    Keyword::new(self.span, f(self.ident))
+    let Self { _lang, span, ident } = self;
+
+    Keyword {
+      _lang,
+      span,
+      ident: f(ident),
+    }
   }
 }
 

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -84,6 +84,62 @@ fn ident_map() {
 }
 
 #[test]
+fn ident_map_preserves_recovery_status() {
+  struct MyLang;
+
+  type Borrowed = Ident<&'static str, SimpleSpan, MyLang>;
+  type Owned = Ident<String, SimpleSpan, MyLang>;
+
+  let span = SimpleSpan::new(4, 7);
+
+  // Recovery status is orthogonal to the source representation, so a source-only `map` must
+  // carry it across. The valid row is the non-vacuity control: it passes both before and after
+  // the fix, so a green table is evidence about the two recovery rows.
+  let rows: [(&str, Borrowed, &str, [bool; 3]); 3] = [
+    (
+      "valid",
+      Borrowed::new(span, "name"),
+      "NAME",
+      [true, false, false],
+    ),
+    (
+      "error",
+      Borrowed::error(span),
+      "<ERROR>",
+      [false, true, false],
+    ),
+    (
+      "missing",
+      Borrowed::missing(span),
+      "<MISSING>",
+      [false, false, true],
+    ),
+  ];
+
+  for (label, ident, expected_source, [valid, error, missing]) in rows {
+    let mapped: Owned = ident.map(str::to_uppercase);
+    assert_eq!(mapped.source_ref(), expected_source, "{label}: source");
+    assert_eq!(mapped.span(), span, "{label}: span");
+    assert_eq!(mapped.is_valid(), valid, "{label}: is_valid");
+    assert_eq!(mapped.is_error(), error, "{label}: is_error");
+    assert_eq!(mapped.is_missing(), missing, "{label}: is_missing");
+  }
+}
+
+#[test]
+fn ident_list_of_mapped_recovery_segments_is_not_valid() {
+  let span = SimpleSpan::new(4, 7);
+
+  let error = Ident::<&str>::error(span).map(str::to_uppercase);
+  let missing = Ident::<&str>::missing(span).map(str::to_uppercase);
+
+  let path = IdentList::<String>::new(span, vec![error, missing]);
+  assert!(!path.is_valid());
+  assert!(path.is_error());
+  assert!(path.is_missing());
+}
+
+#[test]
 fn ident_into_components() {
   use crate::utils::IntoComponents;
   let ident = Ident::<&str>::new(SimpleSpan::new(0, 3), "foo");


### PR DESCRIPTION
Closes #266.
