### PR TITLE
fix(emitter): a Verbose write takes both map descents before it writes either map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -734,6 +734,105 @@ and will red until they do.
 
 ### Fixed
 
+- **`Verbose` recorded and rewound through two `BTreeMap`s that unwinding caller code could leave
+  disagreeing — twice over a map descent that had not finished, and once over a value the rollback
+  destroyed on the spot** (#249, #254). A `BTreeMap` insertion is two operations, not one: `entry`
+  searches — which is the only part that runs the caller's `S: Ord` — and `or_default` then fills
+  the handle without comparing again. Both write paths fused them, so the *first* map was already
+  mutated when the second descent ran, and a span type whose comparison unwinds tore the pair
+  apart.
+
+  On the record side (#249) the residue was an **empty label group under a span key the payload
+  map does not have**, published through `Verbose::labels`, unreachable by `rewind` because no log
+  entry names it, and left in place by the rewind the previous matrix ran as part of its
+  assertion. Measured over the error, warning and skipped-region channels alike, arming the second
+  descent: `labels={…, BombSpan(25): [], …}` against a payload map still holding four keys. The
+  record path documented itself as leaving "no payload, no label entry and no log entry" two lines
+  above conceding that this residue "is publicly visible"; the code now meets the contract instead
+  of the contract retreating to the code.
+
+  On the rollback side (#254) `rewind_to` popped the log entry **first** and then ran two to four
+  further descents, each of which could unwind after the mark had already moved. The residues were
+  a sheared emitter that no later call repairs — `mark=0` with both maps still full, or a payload
+  group removed while its label group survived — and the shape differed between profiles, because
+  two of the six comparisons were `debug_assert` lookups that release does not run (six armable
+  comparisons in debug against four in release for a group that empties; four against two for one
+  that does not). Popping the log *last* around map work that is still fallible would have been
+  **worse**, not better: it leaves the log naming a slot the payload group no longer has, and
+  `Diagnostics` indexes by that slot. What makes the ordering safe is that the fallible half is
+  hoisted out of it.
+
+  **And hoisting the descents did not make the rest of the rollback infallible.** Taking both
+  handles first removes every comparison and every clone from the commit, but a commit that
+  *destroys* what it removes still runs caller code, because a generic parameter is the caller's
+  type in every position it appears and destruction is one of those positions. Discarding what
+  `Vec::pop` returns runs `Error::drop` after the payload group has been shortened and before the
+  label group has; `btree_map::OccupiedEntry::remove` runs `S::drop` on the key it throws away,
+  after one map has lost the span and before its twin has. Either leaves the log naming a slot or
+  a key that is no longer there, and `Diagnostics` indexes by exactly that — the corruption the
+  descent ordering was fixed to prevent, reached through the one kind of caller code the census
+  had not listed, because the commit had been *defined* as infallible and then not re-derived.
+  Swept across three channels, three rollback shapes and both record shapes, **38 of the 107
+  armed destructor positions corrupted the channel and 0 of the 216 comparison and clone
+  positions did** — the two emptied-group key removals on every channel including the
+  payload-less skipped-region one, and the payload destructor on the error and warning channels.
+  The destructor positions that stay clean are clean for a reason and are pinned as such rather
+  than fixed: the two `S::drop`s that `BTreeMap::entry` runs on a key it did not need to store
+  are above the commit point, and the `S::drop` from popping the log entry is below it.
+
+  Both paths now take **every** map handle before they mutate anything, and the rollback **moves
+  rather than destroys**: `pop_group` hands back the popped element and the whole removed entry
+  (`remove_entry`, not `remove`, so the key returns instead of being dropped), the popped
+  `LogEntry` joins them, and all of it is released only once both maps and the log name the same
+  emissions again. The commit therefore runs no caller code whatsoever — no comparison, no clone,
+  no destructor. The release is **per unwound entry, not per call**: a rollback that collected a
+  whole suffix would satisfy every state assertion while moving its destructors into a later
+  entry's unwind, where a panic is a second panic. A caught panic now leaves a record with
+  nothing written, and a rollback with the entry either untouched (a comparison or clone) or
+  completely unwound (a destructor); a retried `rewind` still reaches the clean result. The
+  rollback resolves its handles through owned keys, so `Store::rewind_to` gains `S: Clone`
+  (already required by the `Emitter` impl, so no public bound moves) and spends two descents per
+  unwound entry rather than two-to-four, dropping the two debug-only lookups as well — which is
+  also why the residue no longer differs by profile: with no `debug_assert` lookup left on the
+  path, the sweep measures identical call counts and identical verdicts in debug and release.
+
+  **The matrix is a sweep now, not a sample, and its axes are what the code does to a caller
+  value rather than what has already gone wrong.** The previous one armed a single hand-picked
+  comparison and then read only `payload_len` — it never looked at the map the failed operation
+  had actually mutated. Each cell now measures how many `S::Ord`, `S::Clone`, `S::drop` and
+  `Error::drop` calls its path makes and arms each of them in turn, comparing both maps, the mark
+  and the replay against what they were:
+  `record_{,warning_,hole_}is_atomic_under_a_panicking_{ord,span_clone}` and
+  `record_is_atomic_under_a_panicking_span_drop` over a fresh span and an existing one, and
+  `rewind_{,warning_,hole_}is_atomic_under_a_panicking_ord`,
+  `rewind_is_atomic_under_a_panicking_span_clone`, `rewind_is_atomic_under_a_panicking_span_drop`
+  and `rewind_is_atomic_under_a_panicking_payload_drop` over three rollback shapes — a group that
+  empties, a group that only shortens, and a multi-entry suffix where a panic can land after
+  earlier entries have already committed. Two things a state oracle cannot see get their own
+  cells. `the_cells_with_no_caller_destructor_have_none` pins at zero the paths that genuinely
+  destroy nothing — a record over a fresh span, a record's payload on any shape, the hole
+  channel's non-existent `Error` — so that "this cell measures nothing" stops being
+  indistinguishable from "this cell measures a property", which is how the destructor axis went
+  missing in the first place. And `an_escaping_panic_destroys_no_payload_on_the_way_out` pins the
+  *timing* of the release: the payload-destructor count sampled when a panic is raised must
+  already equal the count when it is caught, which is false for exactly the collected-suffix
+  shape and true for nothing else the state assertions distinguish.
+
+  **What is not fixed, and cannot be by ordering.** `Emitter::rewind` may run from a guard's
+  `Drop` while a panic is already unwinding, where a second panic aborts the process, and it is
+  reachable for `Verbose` (`ScanScope::drop` → `on_incomplete` → `InputRef::restore_entry`).
+  Atomicity is not totality: a rollback that descends a map keyed by a caller-supplied `S` and
+  destroys values the caller owns runs caller code no matter how it is ordered. Running none of
+  it would take both a group identifier the log carries instead of the span, and somewhere
+  outside the rollback to hand the removed values to — a `rewind` that returns `()` has nowhere.
+  This round does not move that boundary: caller destructors could already escape `rewind_to`
+  before it, they merely corrupted the channel on the way out. `Emitter::rewind`'s clause claimed
+  all built-in emitters were structurally non-panicking there — true of `Fatal`, `Silent` and
+  `Ignored`, whose rollbacks are empty, and never true of `Verbose` — and now says so, naming all
+  four kinds of caller code, as does `Verbose::rewind`'s own documentation. Every span and error
+  type this crate ships, and any user type whose `Ord`, `Clone` and `Drop` are total, is
+  unaffected.
+
 - **An at-limit refusal on a *second* entry could be decided and then not recorded, and the
   analysis that was supposed to have found it looked at the wrong set of sites.** Once the one-shot
   probe is spent, the input carries a **recorded** decision that it already refused an item — a

--- a/tokora/src/emitter/impl_/verbose/mod.rs
+++ b/tokora/src/emitter/impl_/verbose/mod.rs
@@ -445,6 +445,35 @@ where
   /// while an earlier zero-width error at the *same* offset is kept — a
   /// distinction the former span-end offset heuristic could not make. `cursor`
   /// is unused.
+  ///
+  /// # Caller code on the rollback path, and what that costs mid-unwind
+  ///
+  /// The storage is keyed by `S` and holds the caller's error values, so undoing an emission
+  /// means descending a `BTreeMap` with the caller's `S: Ord`, taking the group handle through
+  /// the caller's `S: Clone`, and then **destroying** what it detaches — the error payload, the
+  /// span key of a group that has emptied, and the span key inside the log entry that named it.
+  /// Comparison, clone and destructor are all caller code, and this method cannot suppress a
+  /// panic raised inside any of them. A generic parameter is the caller's type in every position
+  /// it appears, and destruction is one of those positions.
+  ///
+  /// Each unwound entry is **panic-atomic**: every descent is taken before anything moves, and
+  /// the pops, the emptied-group removals and the log pop that follow compare nothing, clone
+  /// nothing and destroy nothing — what they detach is carried past the log pop and released
+  /// only once the channel is consistent again. So a caught panic leaves the entry either
+  /// untouched (a comparison or a clone that unwinds) or completely unwound (a destructor that
+  /// unwinds), never half-undone, with [`checkpoint`](Emitter::checkpoint) matching whichever it
+  /// is, and a retried `rewind` still reaches the clean result. That is what a caller who
+  /// catches the unwind gets.
+  ///
+  /// It is not what [`Emitter::rewind`]'s mid-unwind clause asks for. That clause needs
+  /// *totality* — a rollback running from a guard's `Drop` while a panic is already in flight
+  /// cannot raise a second one — and no ordering inside this method can deliver totality while
+  /// the map is keyed by a type the caller supplies and stores values the caller owns. So: a
+  /// span type whose `Ord`, `Clone` or `Drop` can panic, or an error type whose `Drop` can
+  /// panic, gives up the crate's rollback-on-drop guarantee when paired with `Verbose`, and the
+  /// process aborts on that path. Every span and error type this crate ships is unaffected, and
+  /// so is any user type whose comparison, clone and destructor are total — which is the
+  /// ordinary case, not a concession.
   #[inline(always)]
   fn rewind(&mut self, cursor: &Cursor<'inp, '_, L>, checkpoint: u64)
   where

--- a/tokora/src/emitter/impl_/verbose/store.rs
+++ b/tokora/src/emitter/impl_/verbose/store.rs
@@ -16,24 +16,122 @@
 //! parent. The only way in from a channel file is [`Store::record`] and its two mirrors, and
 //! reaching for the raw map there is `error[E0616]`, not a review comment.
 
-use std::{collections::BTreeMap, vec::Vec};
+use std::{
+  collections::{BTreeMap, btree_map::Entry},
+  vec::Vec,
+};
 
 use crate::emitter::Severity;
 
 use super::{Channel, Diagnostics};
 
-/// Pops the newest entry of `span`'s group in a channel map, dropping the emptied group — the
-/// shared per-channel step of [`rewind_to`](Store::rewind_to)'s newest-first unwind.
-fn pop_group<S, T>(groups: &mut BTreeMap<S, Vec<T>>, span: &S)
+/// What one [`pop_group`] step carries **out** of a channel rather than destroying in place: the
+/// element the pop took off the group, and the whole map entry — key included — when the pop
+/// emptied it.
+///
+/// Both halves are caller-supplied values, and the only reason to hand them back is that
+/// destroying them is caller code. See [`pop_group`].
+type Detached<S, T> = (Option<T>, Option<(S, Vec<T>)>);
+
+/// Pops the newest entry of an **already-resolved** channel group and hands back everything it
+/// detached — the shared per-channel step of [`rewind_to`](Store::rewind_to)'s newest-first
+/// unwind.
+///
+/// Takes a resolved [`Entry`] rather than a map and a key, and that is half the point: every
+/// `S: Ord` comparison this step needs was already spent by the descent that produced the
+/// handle, and [`Vec::pop`] and
+/// [`OccupiedEntry::remove_entry`](std::collections::btree_map::OccupiedEntry::remove_entry)
+/// both work off that handle without comparing again. Reaching for the map by key here instead
+/// (`get_mut` then `remove`, as this did) puts a second descent *between* two halves of one
+/// rollback, which is precisely the tear [`rewind_to`](Store::rewind_to) documents itself as not
+/// having.
+///
+/// The other half is that **nothing is dropped here.** A generic parameter is the caller's type
+/// in every position it appears, and destruction is one of those positions: discarding what
+/// `Vec::pop` returns runs `Error::drop`, and `remove()` — as opposed to
+/// [`remove_entry`](std::collections::btree_map::OccupiedEntry::remove_entry) — runs `S::drop` on
+/// the key it throws away. Both are caller code executing *on the spot*, between one map's
+/// mutation and its twin's, so a rollback that drops in place is not panic-atomic however
+/// carefully its descents are ordered: an unwinding destructor leaves the payload group short
+/// while the log still names the slot, or the payload key gone while the label map still has it,
+/// and [`Diagnostics`] indexes by exactly those. Moving the values out instead makes the whole
+/// commit run *no* caller code at all — no comparison, no clone, no destructor — and leaves the
+/// caller to release them once the log has been popped and the channel is consistent again.
+fn pop_group<S, T>(entry: Entry<'_, S, Vec<T>>, slot: usize) -> Detached<S, T>
 where
   S: Ord,
 {
-  if let Some(group) = groups.get_mut(span) {
-    group.pop();
-    if group.is_empty() {
-      groups.remove(span);
+  debug_assert_eq!(
+    match &entry {
+      Entry::Occupied(group) => Some(group.get().len()),
+      Entry::Vacant(_) => None,
+    },
+    Some(slot + 1),
+    "the newest-first unwind must meet the emit-time slot, in lockstep across a payload group \
+     and its label snapshots"
+  );
+  match entry {
+    Entry::Occupied(mut group) => {
+      let popped = group.get_mut().pop();
+      let removed = group.get().is_empty().then(|| group.remove_entry());
+      (popped, removed)
     }
+    // Unreachable above the assert, and reachable below it: `debug_assert` fails open, so a
+    // release build that somehow logged a span this map does not have arrives here. There is no
+    // group to pop, but the vacant handle owns the key it was built from, and letting *that*
+    // fall out of scope would run `S::drop` inside the interval — the one destructor this arm
+    // can reach. It leaves with everything else.
+    Entry::Vacant(vacant) => (None, Some((vacant.into_key(), Vec::new()))),
   }
+}
+
+/// Unwinds the newest log entry off one channel's two parallel maps and the log — **one
+/// complete panic-atomic interval**, from the first descent to the last release.
+///
+/// The shape is the same one [`record`](Store::record) uses, extended to cover destruction: take
+/// every handle first, because a descent is where `S: Ord` and `S: Clone` run; then commit
+/// through those handles, which compare nothing; then, with the maps and the log agreeing again,
+/// let go of the values the commit detached, because releasing them is where `Error::drop` and
+/// `S::drop` run.
+///
+/// **Why the release is inside this function rather than after the caller's loop.** The interval
+/// is per unwound entry, and it has to stay that way. Collecting the detached values across a
+/// whole suffix would fuse every entry into one interval: a panic on entry *k+1*'s descent would
+/// unwind through entry *k*'s still-held values, running their destructors during an unwind that
+/// is already in flight — a double panic, which aborts, and it would need an allocation to do
+/// it. Releasing per entry means a destructor that unwinds strands nothing: the entries already
+/// unwound are cleanly unwound, the one that panicked is fully unwound too, and a retried
+/// `rewind_to` finishes the rest.
+///
+/// What it does **not** do is keep the panic inside. A destructor that unwinds here escapes
+/// [`rewind_to`](Store::rewind_to) exactly as a panicking comparison does, and the only way to
+/// stop that would be to hand the values out to `rewind_to`'s caller — a signature change, and
+/// the caller has the same problem one frame up. See
+/// [`Verbose::rewind`](super::Emitter::rewind) for what that costs mid-unwind, which this
+/// change does not move: caller destructors could already escape this path, they merely
+/// corrupted the channel on the way out.
+fn unwind_one<S, T>(
+  groups: &mut BTreeMap<S, Vec<T>>,
+  labels: &mut BTreeMap<S, Vec<Vec<&'static str>>>,
+  log: &mut Vec<LogEntry<S>>,
+) where
+  S: Ord + Clone,
+{
+  let newest = log
+    .last()
+    .expect("`rewind_to` only unwinds while the log is longer than the mark");
+  let slot = newest.slot;
+  // ── every fallible step, with nothing yet unwound ──
+  let group_entry = groups.entry(newest.span.clone());
+  let label_entry = labels.entry(newest.span.clone());
+  // ── commit point: nothing below compares, clones or destroys ──
+  let detached_group = pop_group(group_entry, slot);
+  let detached_labels = pop_group(label_entry, slot);
+  let popped_log = log.pop();
+  // ── interval closed: both maps and the log name the same emissions again ──
+  drop(detached_group);
+  drop(detached_labels);
+  drop(popped_log);
 }
 
 /// One emission-log entry: the channel tag, the span key, and the entry's slot within its
@@ -64,6 +162,13 @@ pub(super) struct Store<Error, S> {
   /// context stack that was open when `errs[span][i]` was emitted. A separate map
   /// (rather than pairing the label into the error) keeps
   /// [`errors()`](super::Verbose::errors) returning exactly `&BTreeMap<S, Vec<Error>>`.
+  ///
+  /// That choice is paid for rather than free, and the price is an ordering discipline: two
+  /// maps agree key-for-key only if every write and every rollback takes **both** descents
+  /// before it touches either one. [`record`](Self::record) and
+  /// [`rewind_to`](Self::rewind_to) are the only two places that can, and both do — a third
+  /// that grew a group and then went looking for its twin would publish a span key through
+  /// one accessor that the other does not have.
   label_snapshots: BTreeMap<S, Vec<Vec<&'static str>>>,
   /// The warning channel: mirrors `errs` in shape but is fed by
   /// [`emit_warning`](super::Emitter::emit_warning) rather than the error emit paths. Kept
@@ -155,32 +260,46 @@ impl<Error, S> Store<Error, S> {
   ///
   /// # A record is panic-atomic
   ///
-  /// Every step that can unwind runs **before** the first observable write, and the writes
-  /// themselves are made infallible by pre-reservation — so a panic anywhere in this body
-  /// leaves no payload, no label entry and no log entry: [`errors`](Self::errors), replay,
-  /// [`mark`](Self::mark) and [`rewind_to`](Self::rewind_to) all behave as if the call never
-  /// happened. The three fallible inputs are the two `S: Clone`s, the `S: Ord` comparisons the
-  /// two map descents run, and the `Vec` grows; all four are hoisted above the commit point,
-  /// and nothing below it allocates, compares or clones. (Allocation *failure* aborts rather
-  /// than unwinding, so it is not among the cases defended here.)
+  /// Every step that can run **caller code** runs before the first observable write, so a panic
+  /// anywhere in this body leaves no payload, no label entry and no log entry:
+  /// [`errors`](Self::errors), [`labels`](Self::labels), replay, [`mark`](Self::mark) and
+  /// [`rewind_to`](Self::rewind_to) all behave as if the call never happened. The caller code a
+  /// record can run is exactly two `S: Clone`s, the `S: Ord` comparisons of the two map descents,
+  /// and — when the span is one the channel already holds — the two `S::drop`s that
+  /// [`entry`](BTreeMap::entry) runs on the key it was handed and did not need to store. All of
+  /// it is above the commit point. The destructors belong in that list even though this path
+  /// happens to keep them above the line: a generic parameter is the caller's type wherever it
+  /// appears, and a census that lists only comparison and cloning is the census that let the
+  /// *rollback* destroy an `Error` mid-commit while reading as complete.
   ///
-  /// Two orderings inside that are load bearing rather than incidental:
+  /// Below the commit point the body **moves** every caller value it still holds — the payload
+  /// into the group, the snapshot into the labels, the last span clone into the log entry — so
+  /// there is nothing left down there to destroy.
   ///
-  /// - **Labels before payloads.** The last user-code step is the `errs` descent, so a
-  ///   panicking `S: Ord` fires before the payload map is touched at all. The one sub-observable
-  ///   residue this leaves is an **empty group** under the span key in `label_snapshots` — and
-  ///   that residue *is* publicly visible, through
-  ///   [`Verbose::labels`](super::Verbose::labels), which hands out the whole map. It is
-  ///   invariant-consistent everywhere it can be seen: it carries no entries, the parallel-map
-  ///   assert still holds at the next record on that span (`0 == 0` whether one or both maps
-  ///   hold the empty group), no log entry names it, and `rewind_to`/replay never visit it.
-  ///   Keeping it out of `errors()` — the primary consumer surface — is what buys it.
-  /// - **The log last.** The log entry is appended after both maps, so it can never name a slot
-  ///   that was never filled; under the reverse order an unwind mid-record would leave a
-  ///   dangling entry that replay, which indexes by the logged slot, would panic on.
+  /// The load-bearing move is that a [`BTreeMap`] **descent and its insertion are separate
+  /// operations**, and only the descent runs caller code.
+  /// [`entry`](BTreeMap::entry) searches and hands back a handle without touching the map — a
+  /// [`Vacant`](Entry::Vacant) handle that is *dropped* rather than filled inserts nothing — and
+  /// [`or_default`](Entry::or_default) then fills it with no further comparison. So both
+  /// descents are taken first, and only once both have succeeded does either map grow. Calling
+  /// `entry(..).or_default()` on the label map *before* descending the payload map — as this did
+  /// — interleaves them the other way, and a panicking `S: Ord` on the second descent leaves an
+  /// empty group under the new span key in `label_snapshots` that
+  /// [`Verbose::labels`](super::Verbose::labels) publishes and no
+  /// [`rewind_to`](Self::rewind_to) can reach, because no log entry names it. Reversing the two
+  /// maps only moves that orphan into [`errors()`](super::Verbose::errors); taking both handles
+  /// first is what removes it.
   ///
-  /// The remaining undefended case is `group.reserve(1)` overflowing at `len ≈ isize::MAX` — a
-  /// process already out of address space.
+  /// One ordering below the commit point is still deliberate: **the log last.** The log entry is
+  /// appended after both maps, so it can never name a slot that was never filled — a discipline
+  /// that costs nothing here and is what keeps replay, which indexes by the logged slot, total.
+  ///
+  /// Allocation is the one thing that remains below the commit point, and it cannot tear a
+  /// record. Allocation *failure* aborts rather than unwinding, and the reserves are ordered so
+  /// that the one case that does unwind — a `Vec::reserve` capacity overflow at
+  /// `len ≈ isize::MAX`, in a process already out of address space — happens after **both**
+  /// groups exist, leaving the two maps holding a matching pair of empty groups rather than one
+  /// orphan.
   #[inline(always)]
   pub(super) fn record(&mut self, span: S, err: Error)
   where
@@ -191,9 +310,12 @@ impl<Error, S> Store<Error, S> {
     let label_key = span.clone();
     let log_key = span.clone();
     self.log.reserve(1);
-    let labels = self.label_snapshots.entry(label_key).or_default();
+    let label_entry = self.label_snapshots.entry(label_key);
+    let group_entry = self.errs.entry(span);
+    // ── commit point: nothing below compares or clones ──
+    let labels = label_entry.or_default();
+    let group = group_entry.or_default();
     labels.reserve(1);
-    let group = self.errs.entry(span).or_default();
     group.reserve(1);
     let slot = group.len();
     debug_assert_eq!(
@@ -202,7 +324,6 @@ impl<Error, S> Store<Error, S> {
       "the error group and its label snapshots must be parallel before a record: a span \
        where they have drifted apart was written outside this chokepoint"
     );
-    // ── commit point: nothing below allocates, compares, or clones ──
     group.push(err);
     labels.push(snapshot);
     self.log.push(LogEntry {
@@ -222,14 +343,18 @@ impl<Error, S> Store<Error, S> {
   where
     S: Ord + Clone,
   {
-    // Panic-atomic by the same recipe as [`record`](Self::record): every fallible step first.
+    // Panic-atomic by the same recipe as [`record`](Self::record): both descents first, then a
+    // commit that neither compares nor clones.
     let snapshot = self.stack.clone();
     let label_key = span.clone();
     let log_key = span.clone();
     self.log.reserve(1);
-    let labels = self.warn_label_snapshots.entry(label_key).or_default();
+    let label_entry = self.warn_label_snapshots.entry(label_key);
+    let group_entry = self.warns.entry(span);
+    // ── commit point ──
+    let labels = label_entry.or_default();
+    let group = group_entry.or_default();
     labels.reserve(1);
-    let group = self.warns.entry(span).or_default();
     group.reserve(1);
     let slot = group.len();
     debug_assert_eq!(
@@ -238,7 +363,6 @@ impl<Error, S> Store<Error, S> {
       "the warning group and its label snapshots must be parallel before a record: a span \
        where they have drifted apart was written outside this chokepoint"
     );
-    // ── commit point ──
     group.push(warning);
     labels.push(snapshot);
     self.log.push(LogEntry {
@@ -264,9 +388,12 @@ impl<Error, S> Store<Error, S> {
     let label_key = span.clone();
     let log_key = span.clone();
     self.log.reserve(1);
-    let labels = self.hole_label_snapshots.entry(label_key).or_default();
+    let label_entry = self.hole_label_snapshots.entry(label_key);
+    let group_entry = self.holes.entry(span);
+    // ── commit point ──
+    let labels = label_entry.or_default();
+    let group = group_entry.or_default();
     labels.reserve(1);
-    let group = self.holes.entry(span).or_default();
     group.reserve(1);
     let slot = group.len();
     debug_assert_eq!(
@@ -275,7 +402,6 @@ impl<Error, S> Store<Error, S> {
       "the hole group and its label snapshots must be parallel before a record: a span \
        where they have drifted apart was written outside this chokepoint"
     );
-    // ── commit point ──
     group.push(skipped);
     labels.push(snapshot);
     self.log.push(LogEntry {
@@ -300,50 +426,68 @@ impl<Error, S> Store<Error, S> {
   /// captured into an entry are rewound together with it, and any later re-emission re-derives
   /// labels from the then-current stack. A mark beyond the current length is clamped: `Verbose`
   /// keeps no per-mark bookkeeping, so a stale mark can only name a suffix that is already gone.
+  ///
+  /// # One unwound entry is panic-atomic
+  ///
+  /// Each turn of the loop is one [`unwind_one`] interval, and the interval runs **no caller
+  /// code at all**. Both channel handles are taken before anything moves, exactly as
+  /// [`record`](Self::record) takes both descents before it inserts anything, because a
+  /// [`BTreeMap`] descent is where the caller's `S: Ord` and `S: Clone` run. Everything after
+  /// that — popping each group, taking out the entry when a group empties, popping the log —
+  /// compares nothing, clones nothing, and **destroys nothing**: the detached payload, the
+  /// removed keys and the popped [`LogEntry`] are carried out of the interval and released only
+  /// once the maps and the log name the same emissions again (see [`pop_group`]). So a panicking
+  /// comparison leaves the entry logged, both of its groups intact and [`mark`](Self::mark) where
+  /// it was, and a panicking destructor leaves the entry cleanly and completely unwound.
+  ///
+  /// Three orderings are wrong here and it is worth naming all three, because the second is the
+  /// obvious repair for the first and the third hid behind both. Popping the log *first* shears
+  /// the mark away from maps that were never touched. Popping it *last* around map work that is
+  /// still fallible is worse — it leaves the log naming a slot the payload group no longer has,
+  /// and [`Diagnostics`] indexes by that slot. And committing through handles that *drop* what
+  /// they detach reintroduces the same tear through the one kind of caller code a census of
+  /// comparisons and clones does not list: `Error::drop` between the payload pop and the label
+  /// pop, `S::drop` between one map's removal and its twin's.
+  ///
+  /// Two prices are worth naming. The span key is **cloned** per handle, so `S: Clone` joins the
+  /// bound and `S::Clone` joins the caller code this path can run; in exchange the whole rollback
+  /// spends exactly two descents per unwound entry rather than the two-to-four a
+  /// `get_mut`-then-`remove` pair spends, and drops the two debug-only lookups entirely. And
+  /// caller code on this path is *unavoidable* — comparison, clone and destructor alike — which
+  /// matters because [`Emitter::rewind`](super::Emitter::rewind) may run from a guard's `Drop`
+  /// while a panic is already unwinding, where any panic is a second panic and aborts. Atomicity
+  /// is what this method can offer there; totality it cannot, and
+  /// [`Verbose::rewind`](super::Emitter::rewind)'s own documentation says so rather than leaving
+  /// the trait's "structurally non-panicking" reading to cover types it does not.
   #[inline(always)]
   pub(super) fn rewind_to(&mut self, mark: u64)
   where
-    S: Ord,
+    S: Ord + Clone,
   {
     let mark = (mark as usize).min(self.log.len());
     while self.log.len() > mark {
-      let LogEntry {
-        channel,
-        span,
-        slot,
-      } = self.log.pop().expect("log length exceeds the mark");
-      match channel {
-        Channel::Diagnostic(severity) => {
-          let (groups, labels) = match severity {
-            Severity::Error => (&mut self.errs, &mut self.label_snapshots),
-            Severity::Warning => (&mut self.warns, &mut self.warn_label_snapshots),
-          };
-          debug_assert_eq!(
-            groups.get(&span).map(Vec::len),
-            Some(slot + 1),
-            "the newest-first unwind must meet the emit-time slot"
+      match self
+        .log
+        .last()
+        .expect("log length exceeds the mark")
+        .channel
+      {
+        Channel::Diagnostic(Severity::Error) => {
+          unwind_one(&mut self.errs, &mut self.label_snapshots, &mut self.log);
+        }
+        Channel::Diagnostic(Severity::Warning) => {
+          unwind_one(
+            &mut self.warns,
+            &mut self.warn_label_snapshots,
+            &mut self.log,
           );
-          debug_assert_eq!(
-            labels.get(&span).map(Vec::len),
-            Some(slot + 1),
-            "the label group unwinds in lockstep with its payload group"
-          );
-          pop_group(groups, &span);
-          pop_group(labels, &span);
         }
         Channel::SkippedRegion => {
-          debug_assert_eq!(
-            self.holes.get(&span).map(Vec::len),
-            Some(slot + 1),
-            "the newest-first unwind must meet the emit-time slot"
+          unwind_one(
+            &mut self.holes,
+            &mut self.hole_label_snapshots,
+            &mut self.log,
           );
-          debug_assert_eq!(
-            self.hole_label_snapshots.get(&span).map(Vec::len),
-            Some(slot + 1),
-            "the label group unwinds in lockstep with its payload group"
-          );
-          pop_group(&mut self.holes, &span);
-          pop_group(&mut self.hole_label_snapshots, &span);
         }
       }
     }
@@ -413,18 +557,42 @@ impl<Error, S> Store<Error, S> {
   }
 }
 
-/// The record chokepoints are **panic-atomic**: a panic anywhere inside one of the three
-/// bodies leaves no payload, no label entry and no log entry.
+/// The write paths are **panic-atomic**: a caught panic from caller code leaves the channel
+/// exactly as it was, on both the record side and the rollback side.
 ///
-/// Each cell drives a record whose *second* user-code step (a `S: Clone`, or a `S: Ord`
-/// comparison on the second map descent) panics, catches it, rewinds to a mark taken before,
-/// and asserts the channel is exactly as it was. The rewind is part of the assertion on
-/// purpose: a payload appended without its log entry is precisely what a rewind cannot remove.
+/// The matrix is a sweep rather than a sample. A cell names a channel, a write path, and one of
+/// the four kinds of caller code the store can run (`S: Clone`, `S: Ord`, `S::drop`,
+/// `Error::drop`); it *measures* how many calls of that kind the path makes, then arms each of
+/// them in turn and checks the whole observable surface — both maps, the mark, and the
+/// [`Diagnostics`] replay — against what it was before. Sweeping matters because these defects
+/// live at a *particular* call: the record orphan needed the last comparison of the second map
+/// descent, and the rewind shear needed the comparison after the log had already moved. A matrix
+/// that arms one hand-picked index measures the index, not the property.
+///
+/// The two destructor axes are here because **a generic parameter is the caller's type in every
+/// position it appears**, and the axis list is the census that decides what a "commit" is
+/// allowed to contain. A census taken over comparisons and clones alone called the rollback's
+/// second half infallible and let it destroy an `Error` between one map's pop and its twin's;
+/// the axes are enumerated by *what the code does to a caller value* — compare it, copy it,
+/// destroy it — rather than by which of those has already gone wrong. Cells where an axis has
+/// nothing to arm are pinned at zero by `the_cells_with_no_caller_destructor_have_none` rather
+/// than omitted, so "this path destroys nothing" stays a checked claim.
+///
+/// The rollback cells assert two things at each armed call. The state after the caught unwind is
+/// exactly the state a clean rewind to the mark it actually reached would have produced — so the
+/// entries already unwound stay unwound and the one that panicked is untouched, with nothing
+/// half-done in between. And a retried rewind still lands on exactly the clean result, because a
+/// rollback that cannot be resumed is not a rollback.
 #[cfg(all(test, feature = "std"))]
 mod atomicity_tests {
   use super::Store;
   use core::cell::Cell;
-  use std::panic::{AssertUnwindSafe, catch_unwind};
+  use std::{
+    format,
+    panic::{AssertUnwindSafe, catch_unwind},
+    string::String,
+    vec::Vec,
+  };
 
   thread_local! {
     /// `Clone` calls seen since the last arm, and the call index that panics (0 = disarmed).
@@ -433,6 +601,15 @@ mod atomicity_tests {
     /// `Ord::cmp` calls seen since the last arm, and the call index that panics.
     static CMPS: Cell<usize> = const { Cell::new(0) };
     static CMP_BOMB: Cell<usize> = const { Cell::new(0) };
+    /// `S::drop` calls seen since the last arm, and the call index that panics.
+    static SPAN_DROPS: Cell<usize> = const { Cell::new(0) };
+    static SPAN_DROP_BOMB: Cell<usize> = const { Cell::new(0) };
+    /// `Error::drop` calls seen since the last arm, and the call index that panics.
+    static PAYLOAD_DROPS: Cell<usize> = const { Cell::new(0) };
+    static PAYLOAD_DROP_BOMB: Cell<usize> = const { Cell::new(0) };
+    /// `PAYLOAD_DROPS` sampled at the instant a bomb fires, so a sweep can tell a destructor
+    /// that ran *before* the panic from one the unwind dragged along behind it.
+    static PAYLOAD_DROPS_AT_PANIC: Cell<usize> = const { Cell::new(0) };
   }
 
   fn arm_clone(at: usize) {
@@ -445,26 +622,83 @@ mod atomicity_tests {
     CMP_BOMB.with(|c| c.set(at));
   }
 
+  fn arm_span_drop(at: usize) {
+    SPAN_DROPS.with(|c| c.set(0));
+    SPAN_DROP_BOMB.with(|c| c.set(at));
+  }
+
+  fn arm_payload_drop(at: usize) {
+    PAYLOAD_DROPS.with(|c| c.set(0));
+    PAYLOAD_DROP_BOMB.with(|c| c.set(at));
+  }
+
   fn disarm() {
     CLONE_BOMB.with(|c| c.set(0));
     CMP_BOMB.with(|c| c.set(0));
+    SPAN_DROP_BOMB.with(|c| c.set(0));
+    PAYLOAD_DROP_BOMB.with(|c| c.set(0));
   }
 
-  /// A span whose `Clone` and `Ord` are the two user-code steps a record runs.
+  /// Counts one call of a bombed hook and panics if it is the armed one.
+  ///
+  /// Exactly *one* index is ever armed, which is what keeps a destructor bomb usable at all: the
+  /// drops the unwind itself then runs are later indices, so they count and return, and the test
+  /// sees one panic rather than a double-panic abort.
+  ///
+  /// Firing also samples the payload-destructor counter, which is what makes the *timing* of a
+  /// destructor observable and not just its effect.
+  fn tick(
+    seen: &'static std::thread::LocalKey<Cell<usize>>,
+    bomb: &'static std::thread::LocalKey<Cell<usize>>,
+    what: &str,
+  ) {
+    let n = seen.with(|c| {
+      let v = c.get() + 1;
+      c.set(v);
+      v
+    });
+    if n == bomb.with(Cell::get) {
+      PAYLOAD_DROPS_AT_PANIC.with(|c| c.set(PAYLOAD_DROPS.with(Cell::get)));
+      panic!("the armed {what} (#{n}) panics");
+    }
+  }
+
+  /// A span whose `Clone`, `Ord` **and `Drop`** are user-code steps the store can run. `Drop` is
+  /// in here because a generic parameter is the caller's type in every position it appears: the
+  /// rollback path does not only compare and clone spans, it destroys them — when a group empties
+  /// and when the log entry naming it is popped.
   #[derive(Debug, PartialEq, Eq)]
   struct BombSpan(usize);
 
+  impl Drop for BombSpan {
+    fn drop(&mut self) {
+      tick(&SPAN_DROPS, &SPAN_DROP_BOMB, "span drop");
+    }
+  }
+
+  /// The error payload, whose `Drop` is the *other* caller destructor a rollback runs: popping a
+  /// diagnostic off its group destroys the value the caller handed in.
+  ///
+  /// Each record carries a distinct value, so the observable distinguishes *which* payload sits
+  /// in a slot — a rollback that moves values out rather than destroying them has to move the
+  /// right ones.
+  struct BombErr(u32);
+
+  impl core::fmt::Debug for BombErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+      write!(f, "BombErr({})", self.0)
+    }
+  }
+
+  impl Drop for BombErr {
+    fn drop(&mut self) {
+      tick(&PAYLOAD_DROPS, &PAYLOAD_DROP_BOMB, "payload drop");
+    }
+  }
+
   impl Clone for BombSpan {
     fn clone(&self) -> Self {
-      let n = CLONES.with(|c| {
-        let v = c.get() + 1;
-        c.set(v);
-        v
-      });
-      assert!(
-        n != CLONE_BOMB.with(Cell::get),
-        "BombSpan: the armed clone (#{n}) panics"
-      );
+      tick(&CLONES, &CLONE_BOMB, "span clone");
       Self(self.0)
     }
   }
@@ -477,16 +711,49 @@ mod atomicity_tests {
 
   impl Ord for BombSpan {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-      let n = CMPS.with(|c| {
-        let v = c.get() + 1;
-        c.set(v);
-        v
-      });
-      assert!(
-        n != CMP_BOMB.with(Cell::get),
-        "BombSpan: the armed comparison (#{n}) panics"
-      );
+      tick(&CMPS, &CMP_BOMB, "span comparison");
       self.0.cmp(&other.0)
+    }
+  }
+
+  /// The four kinds of caller code a store call can run, as a sweepable axis: which counter to
+  /// reset and arm, and which one to read back when calibrating.
+  #[derive(Clone, Copy)]
+  enum Axis {
+    Clone,
+    Cmp,
+    SpanDrop,
+    PayloadDrop,
+  }
+
+  impl Axis {
+    /// Resets this axis' counter and arms call `at`; `0` resets without arming, which is how a
+    /// calibration run measures a path without tripping it.
+    fn arm(self, at: usize) {
+      match self {
+        Axis::Clone => arm_clone(at),
+        Axis::Cmp => arm_cmp(at),
+        Axis::SpanDrop => arm_span_drop(at),
+        Axis::PayloadDrop => arm_payload_drop(at),
+      }
+    }
+
+    fn count(self) -> usize {
+      match self {
+        Axis::Clone => CLONES.with(Cell::get),
+        Axis::Cmp => CMPS.with(Cell::get),
+        Axis::SpanDrop => SPAN_DROPS.with(Cell::get),
+        Axis::PayloadDrop => PAYLOAD_DROPS.with(Cell::get),
+      }
+    }
+
+    const fn name(self) -> &'static str {
+      match self {
+        Axis::Clone => "S::Clone",
+        Axis::Cmp => "S::Ord",
+        Axis::SpanDrop => "S::Drop",
+        Axis::PayloadDrop => "Error::Drop",
+      }
     }
   }
 
@@ -499,16 +766,16 @@ mod atomicity_tests {
   }
 
   impl Channel {
-    fn write(self, store: &mut Store<u32, BombSpan>, span: BombSpan) {
+    fn write(self, store: &mut Store<BombErr, BombSpan>, span: BombSpan, payload: u32) {
       match self {
-        Channel::Error => store.record(span, 1u32),
-        Channel::Warning => store.record_warning(span, 1u32),
-        Channel::Hole => store.record_hole(span, 1usize),
+        Channel::Error => store.record(span, BombErr(payload)),
+        Channel::Warning => store.record_warning(span, BombErr(payload)),
+        Channel::Hole => store.record_hole(span, payload as usize),
       }
     }
 
     /// The payload map's entry count — the observable a torn record corrupts.
-    fn payload_len(self, store: &Store<u32, BombSpan>) -> usize {
+    fn payload_len(self, store: &Store<BombErr, BombSpan>) -> usize {
       match self {
         Channel::Error => store.errors().len(),
         Channel::Warning => store.warnings().len(),
@@ -523,118 +790,366 @@ mod atomicity_tests {
         Channel::Hole => "record_hole",
       }
     }
+
+    /// Everything a caller can see of this channel: the payload map, the **label map beside
+    /// it**, the mark, and the replay. The label map is in here deliberately — the record
+    /// orphan is invisible to any check that reads only the payload side of a representation
+    /// documented as parallel, which is exactly how it survived the previous matrix.
+    fn observable(self, store: &Store<BombErr, BombSpan>) -> String {
+      let (payload, labels) = match self {
+        Channel::Error => (
+          format!("{:?}", store.errors()),
+          format!("{:?}", store.labels()),
+        ),
+        Channel::Warning => (
+          format!("{:?}", store.warnings()),
+          format!("{:?}", store.warning_labels()),
+        ),
+        Channel::Hole => (
+          format!("{:?}", store.skipped_regions()),
+          format!("{:?}", store.skipped_region_labels()),
+        ),
+      };
+      let replay: Vec<String> = store
+        .diagnostics()
+        .map(|d| format!("{:?}@{:?}{:?}", d.kind(), d.span(), d.labels()))
+        .collect();
+      format!(
+        "mark={} payload={payload} labels={labels} replay={replay:?}",
+        store.mark()
+      )
+    }
   }
 
-  /// Records at span `1` on `channel` with the second `S::Clone` armed, catches, rewinds to a
-  /// mark taken before the record, and returns the surviving payload-entry count.
-  fn torn_by_clone(channel: Channel) -> usize {
-    let mut store = Store::<u32, BombSpan>::new();
-    let mark = store.mark();
+  /// A store with one `channel` record at each span in `spans`, in order.
+  fn seeded(channel: Channel, spans: &[usize]) -> Store<BombErr, BombSpan> {
+    let mut store = Store::<BombErr, BombSpan>::new();
+    for (seq, &span) in spans.iter().enumerate() {
+      channel.write(&mut store, BombSpan(span), seq as u32);
+    }
+    store
+  }
 
-    arm_clone(2);
-    let caught = catch_unwind(AssertUnwindSafe(|| channel.write(&mut store, BombSpan(1))));
+  /// How many `axis` calls one record at `at_span` makes into a store seeded at `seed`, with
+  /// none of them armed. Both the sweeps and the zero-pin below start here, so "how many" is one
+  /// measurement rather than two that can drift apart.
+  fn record_calls(channel: Channel, axis: Axis, seed: &[usize], at_span: usize) -> usize {
+    let mut cal = seeded(channel, seed);
+    axis.arm(0);
+    channel.write(&mut cal, BombSpan(at_span), 99);
+    let calls = axis.count();
     disarm();
-    assert!(caught.is_err(), "the armed clone must have panicked");
-
-    store.rewind_to(mark);
-    channel.payload_len(&store)
+    calls
   }
 
-  /// The `S::Ord` twin. A first record at span `0` gives both maps one entry, so each descent
-  /// costs the same number of comparisons; a calibration record measures the whole record's
-  /// comparison count, and the armed run panics on the **last** one — the second map descent,
-  /// whichever map that is.
-  fn torn_by_cmp(channel: Channel) -> usize {
-    // Calibrate on a throwaway store of the same shape.
-    let per_record = {
-      let mut cal = Store::<u32, BombSpan>::new();
-      channel.write(&mut cal, BombSpan(0));
-      arm_cmp(0); // resets the counter without arming
-      channel.write(&mut cal, BombSpan(1));
-      CMPS.with(Cell::get)
-    };
+  /// How many `axis` calls `rewind_to(keep)` makes over a store seeded at `spans`, none armed.
+  fn rewind_calls(channel: Channel, axis: Axis, spans: &[usize], keep: usize) -> usize {
+    let mut cal = seeded(channel, spans);
+    axis.arm(0);
+    cal.rewind_to(keep as u64);
+    let calls = axis.count();
+    disarm();
+    calls
+  }
+
+  /// Arms every call of `axis` that one record at `at_span` makes into a store seeded at
+  /// `seed`, and asserts each one leaves the channel byte-for-byte as it was.
+  fn record_sweep(channel: Channel, axis: Axis, seed: &[usize], at_span: usize) {
+    let calls = record_calls(channel, axis, seed, at_span);
     assert!(
-      per_record >= 2,
-      "a record descends two maps, so it compares at least twice (got {per_record})"
+      calls > 0,
+      "`{}` runs no {} the sweep can arm, so this cell measures nothing",
+      channel.name(),
+      axis.name()
     );
 
-    let mut store = Store::<u32, BombSpan>::new();
-    channel.write(&mut store, BombSpan(0));
-    let mark = store.mark();
-
-    arm_cmp(per_record);
-    let caught = catch_unwind(AssertUnwindSafe(|| channel.write(&mut store, BombSpan(1))));
-    disarm();
-    assert!(caught.is_err(), "the armed comparison must have panicked");
-
-    store.rewind_to(mark);
-    channel.payload_len(&store)
+    for at in 1..=calls {
+      let mut store = seeded(channel, seed);
+      let before = channel.observable(&store);
+      axis.arm(at);
+      let caught = catch_unwind(AssertUnwindSafe(|| {
+        channel.write(&mut store, BombSpan(at_span), 99)
+      }));
+      disarm();
+      assert!(
+        caught.is_err(),
+        "{} call #{at} of {calls} in `{}` did not panic when armed",
+        axis.name(),
+        channel.name()
+      );
+      assert_eq!(
+        channel.observable(&store),
+        before,
+        "a panicking {} at call #{at} of {calls} left `{}` half-written: the record is not \
+         panic-atomic",
+        axis.name(),
+        channel.name()
+      );
+    }
   }
+
+  /// Arms every call of `axis` that `rewind_to(keep)` makes over a store seeded at `spans`.
+  ///
+  /// Two assertions per armed call. The state after the caught unwind must equal the state a
+  /// clean rewind to the mark it actually reached would produce — the per-entry rollback either
+  /// happened or did not, and no group is left out of step with the log. And a retried rewind
+  /// must still land on the clean result: a rollback whose only ordering authority has already
+  /// been popped cannot be resumed, which is the shape of the defect this pins.
+  fn rewind_sweep(channel: Channel, axis: Axis, spans: &[usize], keep: usize) {
+    let clean = |to: u64| {
+      let mut twin = seeded(channel, spans);
+      twin.rewind_to(to);
+      channel.observable(&twin)
+    };
+    let target = clean(keep as u64);
+    let calls = rewind_calls(channel, axis, spans, keep);
+    assert!(
+      calls > 0,
+      "`rewind_to` over the {} channel runs no {} the sweep can arm, so this cell measures \
+       nothing",
+      channel.name(),
+      axis.name()
+    );
+
+    for at in 1..=calls {
+      let mut store = seeded(channel, spans);
+      axis.arm(at);
+      let caught = catch_unwind(AssertUnwindSafe(|| store.rewind_to(keep as u64)));
+      disarm();
+      assert!(
+        caught.is_err(),
+        "{} call #{at} of {calls} in `rewind_to` did not panic when armed",
+        axis.name()
+      );
+      assert_eq!(
+        channel.observable(&store),
+        clean(store.mark()),
+        "a panicking {} at call #{at} of {calls} sheared the {} channel: the mark moved to {} \
+         but the maps do not match a rewind to it",
+        axis.name(),
+        channel.name(),
+        store.mark()
+      );
+      store.rewind_to(keep as u64);
+      assert_eq!(
+        channel.observable(&store),
+        target,
+        "after a panicking {} at call #{at} of {calls}, a retried rewind no longer reaches the \
+         clean result",
+        axis.name()
+      );
+    }
+  }
+
+  /// The two record shapes, by what the span key does to each map descent: a **fresh** span
+  /// makes both descents vacant (the pair of insertions the orphan came from), an **existing**
+  /// one makes both occupied. The seed is four spans deep so a descent costs more than the one
+  /// comparison a single-key map would.
+  const SEED: &[usize] = &[10, 20, 30, 40];
+  const FRESH: usize = 25;
+  const EXISTING: usize = 30;
 
   #[test]
   fn record_is_atomic_under_a_panicking_span_clone() {
-    assert_eq!(
-      torn_by_clone(Channel::Error),
-      0,
-      "a panicking `S::Clone` inside `record` left an orphan payload that the rewind cannot \
-       remove — the record is not panic-atomic"
-    );
+    record_sweep(Channel::Error, Axis::Clone, SEED, FRESH);
+    record_sweep(Channel::Error, Axis::Clone, SEED, EXISTING);
   }
 
   #[test]
   fn record_warning_is_atomic_under_a_panicking_span_clone() {
-    assert_eq!(
-      torn_by_clone(Channel::Warning),
-      0,
-      "a panicking `S::Clone` inside `record_warning` left an orphan payload"
-    );
+    record_sweep(Channel::Warning, Axis::Clone, SEED, FRESH);
+    record_sweep(Channel::Warning, Axis::Clone, SEED, EXISTING);
   }
 
   #[test]
   fn record_hole_is_atomic_under_a_panicking_span_clone() {
-    assert_eq!(
-      torn_by_clone(Channel::Hole),
-      0,
-      "a panicking `S::Clone` inside `record_hole` left an orphan payload"
-    );
+    record_sweep(Channel::Hole, Axis::Clone, SEED, FRESH);
+    record_sweep(Channel::Hole, Axis::Clone, SEED, EXISTING);
   }
 
   #[test]
   fn record_is_atomic_under_a_panicking_ord() {
-    assert_eq!(
-      torn_by_cmp(Channel::Error),
-      1,
-      "a panicking `S::Ord` on the second map descent inside `record` left an orphan payload \
-       (only the pre-existing span may survive)"
-    );
+    record_sweep(Channel::Error, Axis::Cmp, SEED, FRESH);
+    record_sweep(Channel::Error, Axis::Cmp, SEED, EXISTING);
   }
 
   #[test]
   fn record_warning_is_atomic_under_a_panicking_ord() {
-    assert_eq!(
-      torn_by_cmp(Channel::Warning),
-      1,
-      "a panicking `S::Ord` on the second map descent inside `record_warning` left an orphan \
-       payload"
-    );
+    record_sweep(Channel::Warning, Axis::Cmp, SEED, FRESH);
+    record_sweep(Channel::Warning, Axis::Cmp, SEED, EXISTING);
   }
 
   #[test]
   fn record_hole_is_atomic_under_a_panicking_ord() {
-    assert_eq!(
-      torn_by_cmp(Channel::Hole),
-      1,
-      "a panicking `S::Ord` on the second map descent inside `record_hole` left an orphan \
-       payload"
-    );
+    record_sweep(Channel::Hole, Axis::Cmp, SEED, FRESH);
+    record_sweep(Channel::Hole, Axis::Cmp, SEED, EXISTING);
+  }
+
+  /// The three rollback shapes, by what the unwound entry does to its group: **`LAST_ONLY`**
+  /// empties it (the removal path), **`LAST_OF_TWO`** merely shortens it (the pop-only path),
+  /// and **`SUFFIX`** unwinds several entries so a panic can land after earlier ones have
+  /// already committed.
+  const LAST_ONLY: (&[usize], usize) = (&[10, 20, 30, 40], 3);
+  const LAST_OF_TWO: (&[usize], usize) = (&[10, 20, 30, 30], 3);
+  const SUFFIX: (&[usize], usize) = (&[10, 20, 30, 30, 40, 20], 1);
+
+  fn rewind_shapes(channel: Channel, axis: Axis) {
+    for (spans, keep) in [LAST_ONLY, LAST_OF_TWO, SUFFIX] {
+      rewind_sweep(channel, axis, spans, keep);
+    }
+  }
+
+  #[test]
+  fn rewind_is_atomic_under_a_panicking_ord() {
+    rewind_shapes(Channel::Error, Axis::Cmp);
+  }
+
+  #[test]
+  fn rewind_warning_is_atomic_under_a_panicking_ord() {
+    rewind_shapes(Channel::Warning, Axis::Cmp);
+  }
+
+  #[test]
+  fn rewind_hole_is_atomic_under_a_panicking_ord() {
+    rewind_shapes(Channel::Hole, Axis::Cmp);
+  }
+
+  /// The rollback path resolves its groups through owned keys, so `S::Clone` is caller code it
+  /// runs too and gets the same sweep as `S::Ord` — the axis a matrix written against the
+  /// comparison defect alone would have left unpinned.
+  #[test]
+  fn rewind_is_atomic_under_a_panicking_span_clone() {
+    rewind_shapes(Channel::Error, Axis::Clone);
+    rewind_shapes(Channel::Warning, Axis::Clone);
+    rewind_shapes(Channel::Hole, Axis::Clone);
+  }
+
+  /// The rollback **destroys** caller values as well as comparing and cloning them: a group that
+  /// empties gives its span key back to be dropped, and so does the log entry that named it.
+  /// This is the axis a census of "`S::Clone` ×2, `S::Ord` (2 descents)" leaves out, and it is
+  /// the one that reached every shape and every channel — including the payload-less
+  /// skipped-region channel, whose maps are still keyed by `S`.
+  #[test]
+  fn rewind_is_atomic_under_a_panicking_span_drop() {
+    rewind_shapes(Channel::Error, Axis::SpanDrop);
+    rewind_shapes(Channel::Warning, Axis::SpanDrop);
+    rewind_shapes(Channel::Hole, Axis::SpanDrop);
+  }
+
+  /// Unwinding a diagnostic destroys the **payload** the caller handed in, which is a second
+  /// caller destructor and lands between the payload group's pop and its label group's — the
+  /// narrowest window in the whole rollback, and enough to leave `Diagnostics` indexing a slot
+  /// the group no longer has.
+  #[test]
+  fn rewind_is_atomic_under_a_panicking_payload_drop() {
+    rewind_shapes(Channel::Error, Axis::PayloadDrop);
+    rewind_shapes(Channel::Warning, Axis::PayloadDrop);
+  }
+
+  /// A record over a span the channel already has destroys two span keys —
+  /// [`BTreeMap::entry`] drops the key it was handed whenever the descent finds one — so the
+  /// destructor axis reaches the write path too.
+  #[test]
+  fn record_is_atomic_under_a_panicking_span_drop() {
+    record_sweep(Channel::Error, Axis::SpanDrop, SEED, EXISTING);
+    record_sweep(Channel::Warning, Axis::SpanDrop, SEED, EXISTING);
+    record_sweep(Channel::Hole, Axis::SpanDrop, SEED, EXISTING);
+  }
+
+  /// A panic escaping mid-suffix must not drag a caller destructor out with it.
+  ///
+  /// Where the detached values are released is a decision, not a detail, and the state oracle
+  /// above cannot see it: holding every entry's payload until the whole loop finished would
+  /// satisfy every assertion in [`rewind_sweep`] — the maps and the log still agree at each catch
+  /// point — while moving all of those destructors *into* the unwind, which is the one place a
+  /// panic is a second panic and aborts the process instead of being catchable. Fusing the loop
+  /// into a single interval would also need an allocation to hold the suffix.
+  ///
+  /// So the property is about *timing*, and a `SUFFIX` unwind is where it bites: by the time
+  /// entry *k+1*'s descent runs, entry *k*'s payload must already be destroyed. Arming each
+  /// comparison in turn, the payload-destructor count sampled at the instant the panic is raised
+  /// must already equal the count once it is caught — an unwind out of `rewind_to` destroys no
+  /// payload on its way. Under a fused loop the two diverge by exactly the number of entries the
+  /// suffix had already unwound.
+  #[test]
+  fn an_escaping_panic_destroys_no_payload_on_the_way_out() {
+    let (spans, keep) = SUFFIX;
+    for channel in [Channel::Error, Channel::Warning] {
+      let calls = rewind_calls(channel, Axis::Cmp, spans, keep);
+      assert!(
+        calls > 0,
+        "no comparison to arm: this cell measures nothing"
+      );
+      for at in 1..=calls {
+        let mut store = seeded(channel, spans);
+        arm_payload_drop(0);
+        PAYLOAD_DROPS_AT_PANIC.with(|c| c.set(usize::MAX));
+        arm_cmp(at);
+        let caught = catch_unwind(AssertUnwindSafe(|| store.rewind_to(keep as u64)));
+        disarm();
+        assert!(
+          caught.is_err(),
+          "S::Ord call #{at} of {calls} in `rewind_to` did not panic when armed"
+        );
+        assert_eq!(
+          PAYLOAD_DROPS_AT_PANIC.with(Cell::get),
+          PAYLOAD_DROPS.with(Cell::get),
+          "a panicking comparison at call #{at} of {calls} over the {} channel unwound through \
+           a payload the rollback was still holding: entry k's detached values must be released \
+           before entry k+1 begins, or the whole suffix is one interval and the destructors run \
+           mid-unwind",
+          channel.name()
+        );
+      }
+    }
+  }
+
+  /// The cells where an axis has **nothing to arm**, pinned at zero instead of left out.
+  ///
+  /// "Measures nothing" and "measures a property" must not look alike from the outside: the
+  /// destructor axis was missing from the previous matrix precisely because nobody had asked how
+  /// many destructors these paths run, and a cell quietly finding no calls is how that question
+  /// stays unasked. Each row below is a claim about the code, and a change that makes one of
+  /// them destroy something reds here rather than going unswept:
+  ///
+  /// - a record **moves** every caller value it touches — the payload into the group, the span
+  ///   into two handles and a log entry — so over a *fresh* span it destroys nothing at all;
+  /// - a record never destroys its payload on any shape, fresh or existing;
+  /// - the skipped-region channel stores a `usize` count rather than an `Error`, so no rollback
+  ///   on it can run a payload destructor, on any of the three rollback shapes.
+  #[test]
+  fn the_cells_with_no_caller_destructor_have_none() {
+    for channel in [Channel::Error, Channel::Warning, Channel::Hole] {
+      assert_eq!(
+        record_calls(channel, Axis::SpanDrop, SEED, FRESH),
+        0,
+        "`{}` over a fresh span destroys a span key: it is meant to move every one of them",
+        channel.name()
+      );
+      for at_span in [FRESH, EXISTING] {
+        assert_eq!(
+          record_calls(channel, Axis::PayloadDrop, SEED, at_span),
+          0,
+          "`{}` destroys its payload: it is meant to move it into the group",
+          channel.name()
+        );
+      }
+    }
+    for (spans, keep) in [LAST_ONLY, LAST_OF_TWO, SUFFIX] {
+      assert_eq!(
+        rewind_calls(Channel::Hole, Axis::PayloadDrop, spans, keep),
+        0,
+        "the skipped-region channel ran an `Error` destructor, but it stores no `Error`"
+      );
+    }
   }
 
   /// The keep-green control: with nothing armed, all three channels record normally.
   #[test]
   fn unarmed_records_are_unaffected() {
     for channel in [Channel::Error, Channel::Warning, Channel::Hole] {
-      let mut store = Store::<u32, BombSpan>::new();
-      channel.write(&mut store, BombSpan(1));
+      let mut store = Store::<BombErr, BombSpan>::new();
+      channel.write(&mut store, BombSpan(1), 1);
       assert_eq!(
         channel.payload_len(&store),
         1,

--- a/tokora/src/emitter/mod.rs
+++ b/tokora/src/emitter/mod.rs
@@ -463,9 +463,26 @@ pub trait Emitter<'a, L, Lang: ?Sized = ()> {
   /// in flight — including for a [`Commit`](crate::Commit)-policy guard, which takes the
   /// rollback arm on the unwind edge. A panic raised here mid-unwind is a double panic and
   /// aborts the process. The clause [`release`](Self::release) already carries applies in full:
-  /// stay observably total on the restore path. The built-in emitters are structurally
-  /// non-panicking there (truncations and pops); the crate's rollback-on-drop guarantee is
-  /// conditional on yours being too.
+  /// stay observably total on the restore path. The crate's rollback-on-drop guarantee is
+  /// conditional on yours being so.
+  ///
+  /// Most of the built-in emitters are structurally non-panicking there because their rollback
+  /// is *empty*: `Fatal`, `Silent` and `Ignored` keep nothing to unwind. `Verbose` is the
+  /// exception, and it is a generic one rather than an oversight. Its rollback resolves
+  /// span-keyed groups, so it runs the caller's `S: Ord` and, to take the group handles it
+  /// mutates through, the caller's `S: Clone`; and undoing an emission ends by *destroying* what
+  /// it removed, so it runs the caller's `S::drop` and the error payload's `Drop` as well. A
+  /// generic parameter is the caller's type in every position it appears, destruction included,
+  /// and none of those four can be suppressed from inside the rollback.
+  /// What it does guarantee is **atomicity**: a caught panic leaves it either exactly as it was
+  /// or with the entry completely unwound, never with a group out of step with the log or a mark
+  /// out of step with either. Atomicity is not totality, and it is totality that this clause
+  /// needs, so a span type whose `Ord`, `Clone` or `Drop` can panic — or an error type whose
+  /// `Drop` can panic — forfeits the rollback-on-drop guarantee for `Verbose`. A rollback that
+  /// runs no caller code at all would have to address its groups by an identifier the log
+  /// carries and hand the values it removes back to someone who can outlive the unwind, which is
+  /// not what a `BTreeMap` keyed by the span and a `rewind` that returns `()` offer. Span and
+  /// error types that cannot panic (every one this crate ships) are unaffected.
   ///
   /// The property that actually has to hold is **"never abort the process"**, and it binds
   /// only while an unwind is in progress. An implementation that can *detect* a settle
@@ -476,8 +493,9 @@ pub trait Emitter<'a, L, Lang: ?Sized = ()> {
   /// double-panic abort would be worse than either. The recording CST `Sink` is the one
   /// in-crate implementation that takes this door (the `rowan` feature), and its
   /// `rewind`'s `# Panics` section states exactly which condition and why. An emitter with
-  /// nothing to detect — every built-in one — simply inherits the stricter "never panics"
-  /// reading, unchanged.
+  /// nothing to detect — every built-in one — is simply held to the stricter "never panics"
+  /// reading, unchanged; whether it can *meet* that reading is the separate question the
+  /// paragraph above answers for `Verbose`, which detects nothing and still runs caller code.
   ///
   /// Two riders come with that door, and neither is optional.
   ///


### PR DESCRIPTION
Closes #249. Refs #254 — see *What is not closed* below.

`Verbose` keeps each diagnostic channel as two parallel `BTreeMap`s — payloads and label snapshots — that must agree key for key. Both write paths fused a map's descent with its mutation, so the first map was already changed while the second descent was still running the caller's `S: Ord`. A span type whose comparison unwinds tore the pair apart.

**`BTreeMap::entry` searches without touching the map, and that search is the only part that runs `S::Ord`; `or_default` then fills the returned handle without comparing again.** Splitting them is the whole repair, and it is the same repair in both places — #249 and #254 are one mistake made twice, not two defects that happen to share a file.

- **#249, `record`:** left an empty label group under a span key `errors()` does not have. `Verbose::labels` publishes it and no log entry names it, so no `rewind` can reach it — while the method's own docs promised *"no payload, no label entry and no log entry"* two lines above conceding the residue *"is publicly visible"*.
- **#254, `rewind_to`:** popped the log entry first, then ran two to four more descents, so a panicking comparison left the mark moved with the maps untouched, or one channel's group removed and its twin kept. Both permanent — the only ordering authority naming the entry was already gone.

## Two things that were measured rather than reasoned

**Popping the log last is not the fix, and on its own it is worse than the bug.** It leaves the log naming a slot the payload group no longer has, and `Diagnostics::next` indexes by that slot. Built and armed: **12 of 16 armed comparisons in one shape and 3 of 6 in another made `Verbose::diagnostics()` — a `&self` read method — panic.** At base that probe never panics, because popping the log first is precisely what keeps the log a prefix of the maps.

**The commit half ran caller code too, which the first version of this fix missed.** External review found it and a sweep confirmed the whole extent before anything was repaired. Across 3 channels × 3 rollback shapes + 3 channels × 2 record shapes, arming one caller-controlled call at a time:

| axis | armed | corrupt |
|---|---|---|
| `S::Ord` | 162 | **0** |
| `S::Clone` | 54 | **0** |
| `S::drop` | 93 | **24** |
| `Error::drop` | 14 | **14** |

**323 armed positions, 38 corrupt, every one of them on a destructor axis.** A discarded `Vec::pop()` runs `Error::drop`, and `OccupiedEntry::remove()` drops the stored key — both between the first mutation and the last. Every corruption surfaces as `Diagnostics::next` panicking, the same signature as above.

After the repair: **323 armed, 0 corrupt, with identical per-cell call counts** — so nothing was deferred out of the call or skipped.

## What shipped

Both write paths take every entry handle first, then commit. `pop_group` returns the popped value and the removed key-and-group (`remove_entry`, not `remove`) instead of discarding them; `unwind_one` holds both bundles and the popped `LogEntry` past the log pop, then releases them. **The interval now runs no caller-controlled code at all** — no comparison, no clone, no destructor. `pop_group` taking a resolved `Entry` rather than a map and a key is what makes the discipline unspellable-otherwise at the call site.

The `Entry::Vacant` arm also owns a key, so it hands it back through `into_key()`. That one was not in the review finding; it turned up while implementing.

`Store::rewind_to` gains `S: Clone`, already required by the `Emitter for Verbose` impl — **no public API moved, no accessor changed type, no public bound moved.** `rewind_to` collapsed to a three-arm dispatch and the two duplicated channel bodies are gone.

## Unreachable positions, stated rather than quietly fixed

`record` over a fresh span runs zero `S::drop`; `record` runs zero `Error::drop` on any shape; the skipped-region channel runs zero `Error::drop` on any rollback shape. `record` over an existing span runs two `S::drop` and both are above the commit point and clean. These are pinned at zero by a cell rather than omitted.

**Debug and release are now byte-identical.** Round one removed the two `debug_assert` lookups from the rollback path, so no caller code is profile-dependent any more — the profile split that round one measured no longer exists.

## The suffix loop, and why the state oracle could not see it

The held values are released per entry, immediately after the log pop, not accumulated across the loop. To check that, the fused alternative was planted — and it **reds one test while leaving all 15 state cells green.** The maps and the log agree at every catch point, so a state oracle is blind to it in principle. It is pinned instead by a timing property: the payload-destructor count sampled when a panic is raised must already equal the count when it is caught. That cell reds on the fused shape and on nothing else.

Four plants in total. A restores the pre-fix behaviour and reds both new destructor cells while every `Ord`/`Clone` cell stays green. B and C destroy one half each and red exactly one cell apiece — so the two destructor axes pin disjoint positions rather than one masking the other.

## What is not closed

**#254's mid-unwind half stands, and it is not closable by ordering.** `Emitter::rewind` may run from a guard's `Drop` during an existing unwind — reachable for `Verbose` through `ScanScope::drop` → `on_incomplete` → `restore_entry` — where any panic is a second panic and aborts. Atomicity is not totality: no ordering removes caller code from a rollback that descends a map keyed by a caller-supplied type.

Three routes were considered and rejected with reasons: a `std::thread::panicking()` skip-path is unavailable under `alloc`-without-`std` where `Verbose` compiles, and silently skipping the rollback is the invisible degradation the trait's own rider forbids; a drop guard would `remove`, which compares, which mid-unwind is the abort; and `BTreeMap` cursors would give infallible removal with the comparisons up front, but **`btree_cursors` is still unstable** (verified by compiling, against a recollection that it had stabilised) and the MSRV is stable 1.95.

Only #254's own stable-group-id redesign closes it, and it costs `errors()` its `&BTreeMap` return and adds a permanently-growing span→id index. Recommended against, and priced in the branch's notes rather than deferred silently. **Left to the owner to decide whether #254 closes here.**

**A third over-scoped claim was found and fixed on the way:** `Emitter::rewind`'s contract asserted that every built-in emitter is structurally non-panicking there. True of `Fatal`, `Silent` and `Ignored`, whose rollbacks are empty; never true of `Verbose`. It was the crate-wide clause the rollback-on-drop guarantee rests on.

Follow-ups priced but not taken: labels indexed parallel to the log (better than the alternative structural option, by the design's own stated priority — it keeps `errors()` returning exactly `&BTreeMap<S, Vec<Error>>`; costs three accessors, ~19 call sites and a live doctest, and is a perf change that wants a benchmark) and one group struct per channel (moves all six accessors and buys nothing the first does not).

## Verification

Both columns measured on this machine, base `ca7ae72` → head.

| leg | base | head |
|---|---|---|
| `fmt --all --check` | 0 | 0 |
| `clippy --all-features --all-targets -D warnings` | 0 | 0 |
| `test -p tokora --all-features --lib --tests` | 113 suites, **6240** | 113 suites, **6249** |
| `--no-default-features` | 855 | 855 |
| `--no-default-features --features alloc` | 1313 | 1313 |
| both rustdoc legs, `-D warnings` | 0 | 0 |
| `ci/changelog_structure.sh` | 0 | 0 |
| atomicity matrix, debug | **7 cells** | **16 cells** |
| atomicity matrix, release | **7 cells** | **16 cells** |

+9 tests, all of them matrix cells (6249 − 6240 = 16 − 7). Each filtered run's selected-cell count is asserted rather than inferred, and the base was measured from a `git archive` export with its own target directory so nothing shared artifacts with head.

**Two coverage facts, because the leg names overstate what they cover:** `--no-default-features` runs **zero** `Verbose` tests — `Verbose` is `cfg(any(std, alloc))` and compiles out entirely, so that leg is a build check. `--features alloc` runs 20 of the 31, because the atomicity module needs `catch_unwind` and is `cfg(feature = "std")`. Only the `--all-features` and clippy legs exercise the new cells. Pre-existing, not introduced here.

Failing-at-base evidence: the cells spliced onto `ca7ae72` go **7 of 11 red** — 3 record-`ord`, 3 rewind-`ord`, 1 rewind-`clone`. One caveat recorded honestly: `rewind_is_atomic_under_a_panicking_span_clone` reds at base for the *weaker* reason that the base rollback makes no clones the sweep can arm, so that cell is a forward pin on caller code this PR introduces, not base-defect evidence.

External adversarial review: **APPROVE** — *"the amended rollback performs no caller-controlled clone, comparison, or destruction between its first map mutation and the log pop; detached values are released after consistency is restored and before the next suffix entry begins."*

`semver-checks (advisory)` will be red, as it is on every PR until `0.10.0` ships: it fires on breaks already merged to `main` (`logos_0_14` / `logos_0_15` removed, `Emitter::checkpoint` taking `&mut Self`) measured against the published `0.9.1` baseline.

Not run and not claimed: the full feature matrix, Miri, the release-profile legs, the `thumbv6m` targets.
