### PR TITLE
fix(recursion)!: measure the door the parse budget is enforced on, and price both arms at the debug cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,15 +281,15 @@ and will red until they do.
 
 ### Changed (breaking)
 
-- **`RecursionLimiter::PARSE_DEFAULT_DEPTH` is 32 in a debug build and 256 in a release one, was 16
-  in both** (#297). Every unconfigured parse gets a deeper budget, and for the first time the two
-  profile arms hold different numbers.
+- **`RecursionLimiter::PARSE_DEFAULT_DEPTH` is 32, in every build, and was 16** (#297). Every
+  unconfigured parse gets twice the depth. The profile arms hold the same number, deliberately, and
+  what a release build actually supports is published separately as the new
+  **`RecursionLimiter::OPTIMIZED_PARSE_DEPTH`** — 256, installed by nothing.
 
   **Why 16 was wrong is measured, not argued.** It came from applying `MIN_HEADROOM` to a consumer
   grammar's abort depth of 51 — a reading of that consumer's *syntactic* door, which takes no
   `InputRef::descend` and therefore spends none of this budget. The door that does spend it aborts
-  at 667 descents. The entry under **Fixed** has the sweep, the axes and the survive/abort pairs;
-  this entry is what was done with them.
+  at 667. The entry under **Fixed** has the sweep, the axes and the survive/abort pairs.
 
   **The criterion is two-tier, and the asymmetry is the decision rather than a convenience.** This
   cell is *shared*: `InputContext::new` seeds it for tokora's two Pratt engines (~16.4 KiB a frame),
@@ -303,47 +303,37 @@ and will red until they do.
 
   **Applying the multiplier to the modelled row as well gives 16; applying only the fit to the
   spending rows gives 128. 32 is exactly the width of that distinction**, and it ships documented as
-  a criterion rather than as a number, because a reader who collapses the two tiers will move the
-  default without noticing.
+  a criterion rather than as a number. 128 is refused by a measurement: it is *above* tokora's own
+  125, so an unconfigured Pratt parse in a debug build would reach the native stack before the
+  limiter — `128 x 16 112 B` measured is 98.3% of a 2 MiB thread.
 
-  **128 was refused, and by a measurement.** It is what the old single-tier formula gives when
-  simply repointed at the right row — and it is *above* tokora's own 125, so an unconfigured Pratt
-  parse in a debug build would reach the native stack before the limiter: `128 x 16 112 B` measured
-  on the same host is 98.3% of a 2 MiB thread. That is the abort the 500 -> 64 -> 16 sequence exists
-  to delete, restated with a bigger number.
+  **The two profile arms hold one number, and the reason is not a missing measurement.** The release
+  sweep exists and says 256. What is missing is any way for this crate to know whether the condition
+  256 rests on holds. `debug_assertions` is not `opt-level`, so `debug-assertions = false` at
+  `opt-level = 0` selects the release arm at unoptimised frame prices; and it is **per crate**,
+  while the frames this budget bounds are the **caller's** — so a build script reading cargo's
+  `OPT_LEVEL` would close the first gap and not the second, and a debug consumer against a release
+  tokora reinstates the mismatch with every signal available here reading "release". **A number
+  only safe when a fact holds, selected by a flag that cannot observe that fact, is not a default.**
+  A `const` assertion now prices *both* arms at the debug cost, which is the guard that held before
+  this campaign and the one whose loss made an intermediate revision unsafe.
 
-  **The release arm, 256, is a derivation and no longer a floor.** The sweep this file has recorded
-  as owed since the arm was written now exists, so the provisional `==` holding it equal to the
-  debug cell is deleted. Same rule over the release rows: the headroom tier would allow 1024, and
-  the fit refuses 512 at ~4.3 KiB a modelled level. So each tier is the binding one in one profile —
-  debug is fixed by headroom, release by the fit — and neither is decoration. 1024 would also have
-  collided exactly with `SEGMENTED_PRATT_RELEASE`, making `stacker` buy zero extra depth in a
-  release build; a `const` assertion catches that and did.
+  **`OPTIMIZED_PARSE_DEPTH` (new, `pub`) is 256** — the same two-tier derivation over the release
+  rows: `256 x 3 = 768 < 3282`, and `256 x 4 452 B = 1.09 MiB < 2 MiB` where `512` needs 2.17 MiB
+  and is refused. **No new API is owed to use it**: `RecursionLimiter::with_limitation`,
+  `InputContext::with_recursion_limiter`, `ParserContext::with_recursion_limiter` and
+  `cst::parse_lossless_with_context` all predate this change. The constant exists because a
+  measurement nobody can reach is not an opt-in — without it a consumer would have to re-run the
+  bisection to arrive at a figure this crate already knows. **The precondition is the caller's to
+  check**: every frame the budget bounds, theirs included, compiled at `opt-level = 3`.
 
-  **The residue, stated because nothing can check it.** With the arms diverged, `debug_assertions`
-  is observable for the first time — and it is a proxy for the profile, not for `opt-level`. **A
-  build with `debug-assertions = false` at `opt-level = 0` takes the 256 arm while paying debug
-  frame prices, and nothing refuses it**: there is no `cfg(opt_level)` for a constant to read,
-  `native_stack`'s red zone is `stacker`-only and sits on the two Pratt prologues rather than on
-  this cell, and `ci/stack_probe.sh` asserts no threshold by design. While both arms held one number
-  this combination was refused at *compile time* by the assertion that priced the release arm at the
-  debug cost; **that refusal is what divergence spends, and it is a downgrade from "refused" to
-  "documented"** rather than a hazard that was already there. It is confined — an ordinary debug and
-  an ordinary release build are each safe at their own price, and a `const` assertion says so — and
-  the same caveat covers a per-package profile override compiling tokora differently from the
-  consumer. The closure exists and has deliberately **not** been taken: cargo passes `OPT_LEVEL` to
-  build scripts and this crate already has one that emits cfgs, so selecting on that instead would
-  make the proxy exact.
+  **What a caller does.** Nothing, unless they relied on 16 as an upper bound — a parse that refused
+  at 17 levels now accepts up to 32. A release deployment that wants the depth its profile supports
+  passes `OPTIMIZED_PARSE_DEPTH` explicitly. Nothing about a *configured* parse changes.
 
-  **What a caller does.** Nothing, unless they were relying on 16 as an upper bound — a parse that
-  refused at 17 levels now accepts up to 32, or 256 in release. A grammar that needs a *different*
-  budget still says so explicitly through `InputContext::with_recursion_limiter`,
-  `ParserContext::with_recursion_limiter` or `cst::parse_lossless_with_context`, and an explicit
-  budget makes the profile question moot. Nothing about a *configured* parse changes.
-
-  `SEGMENTED_PRATT_DEPTH` is unchanged at 1024 in both profiles. A release per-level figure to
-  derive it from now exists and would give 8192; it stays a floor because that is a decision about
-  how much segment *memory* an unconfigured parse may reach, not one the stack sweep licensed.
+  `SEGMENTED_PRATT_DEPTH` is unchanged at 1024. A release per-level figure to derive it from now
+  exists and would give 8192; it stays a floor because that is a decision about how much segment
+  *memory* an unconfigured parse may reach, not one the stack sweep licensed.
 
 - **`TokenBudget` is the ceiling; `input::TokenBudgetTally` is what one `Input` spent against it.**
   `TokenBudget::{spent, is_exhausted, refused_an_item}` are gone from that type and live on the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,70 @@ and will red until they do.
 
 ### Changed (breaking)
 
+- **`RecursionLimiter::PARSE_DEFAULT_DEPTH` is 32 in a debug build and 256 in a release one, was 16
+  in both** (#297). Every unconfigured parse gets a deeper budget, and for the first time the two
+  profile arms hold different numbers.
+
+  **Why 16 was wrong is measured, not argued.** It came from applying `MIN_HEADROOM` to a consumer
+  grammar's abort depth of 51 — a reading of that consumer's *syntactic* door, which takes no
+  `InputRef::descend` and therefore spends none of this budget. The door that does spend it aborts
+  at 667 descents. The entry under **Fixed** has the sweep, the axes and the survive/abort pairs;
+  this entry is what was done with them.
+
+  **The criterion is two-tier, and the asymmetry is the decision rather than a convenience.** This
+  cell is *shared*: `InputContext::new` seeds it for tokora's two Pratt engines (~16.4 KiB a frame),
+  for a caller's own hand-written `descending` (modelled at the measured heaviest, ~41 KiB), and for
+  a lossless consumer's descent (~3.1 KiB) — a 68x span, and no single row bounds it. So:
+
+  - **full `MIN_HEADROOM` against every population that actually *spends* the cell** — tokora's own
+    125 and the consumer's 667, minimum 125; `32 x 3 = 96 < 125`, and `64 x 3 = 192` is not;
+  - **a bare fit, no multiplier, at the heaviest population that is only *modelled*** —
+    `32 x 41 120 B = 1.31 MiB < 2 MiB`, and `64 x 41 120 B = 2.51 MiB` is not.
+
+  **Applying the multiplier to the modelled row as well gives 16; applying only the fit to the
+  spending rows gives 128. 32 is exactly the width of that distinction**, and it ships documented as
+  a criterion rather than as a number, because a reader who collapses the two tiers will move the
+  default without noticing.
+
+  **128 was refused, and by a measurement.** It is what the old single-tier formula gives when
+  simply repointed at the right row — and it is *above* tokora's own 125, so an unconfigured Pratt
+  parse in a debug build would reach the native stack before the limiter: `128 x 16 112 B` measured
+  on the same host is 98.3% of a 2 MiB thread. That is the abort the 500 -> 64 -> 16 sequence exists
+  to delete, restated with a bigger number.
+
+  **The release arm, 256, is a derivation and no longer a floor.** The sweep this file has recorded
+  as owed since the arm was written now exists, so the provisional `==` holding it equal to the
+  debug cell is deleted. Same rule over the release rows: the headroom tier would allow 1024, and
+  the fit refuses 512 at ~4.3 KiB a modelled level. So each tier is the binding one in one profile —
+  debug is fixed by headroom, release by the fit — and neither is decoration. 1024 would also have
+  collided exactly with `SEGMENTED_PRATT_RELEASE`, making `stacker` buy zero extra depth in a
+  release build; a `const` assertion catches that and did.
+
+  **The residue, stated because nothing can check it.** With the arms diverged, `debug_assertions`
+  is observable for the first time — and it is a proxy for the profile, not for `opt-level`. **A
+  build with `debug-assertions = false` at `opt-level = 0` takes the 256 arm while paying debug
+  frame prices, and nothing refuses it**: there is no `cfg(opt_level)` for a constant to read,
+  `native_stack`'s red zone is `stacker`-only and sits on the two Pratt prologues rather than on
+  this cell, and `ci/stack_probe.sh` asserts no threshold by design. While both arms held one number
+  this combination was refused at *compile time* by the assertion that priced the release arm at the
+  debug cost; **that refusal is what divergence spends, and it is a downgrade from "refused" to
+  "documented"** rather than a hazard that was already there. It is confined — an ordinary debug and
+  an ordinary release build are each safe at their own price, and a `const` assertion says so — and
+  the same caveat covers a per-package profile override compiling tokora differently from the
+  consumer. The closure exists and has deliberately **not** been taken: cargo passes `OPT_LEVEL` to
+  build scripts and this crate already has one that emits cfgs, so selecting on that instead would
+  make the proxy exact.
+
+  **What a caller does.** Nothing, unless they were relying on 16 as an upper bound — a parse that
+  refused at 17 levels now accepts up to 32, or 256 in release. A grammar that needs a *different*
+  budget still says so explicitly through `InputContext::with_recursion_limiter`,
+  `ParserContext::with_recursion_limiter` or `cst::parse_lossless_with_context`, and an explicit
+  budget makes the profile question moot. Nothing about a *configured* parse changes.
+
+  `SEGMENTED_PRATT_DEPTH` is unchanged at 1024 in both profiles. A release per-level figure to
+  derive it from now exists and would give 8192; it stays a floor because that is a decision about
+  how much segment *memory* an unconfigured parse may reach, not one the stack sweep licensed.
+
 - **`TokenBudget` is the ceiling; `input::TokenBudgetTally` is what one `Input` spent against it.**
   `TokenBudget::{spent, is_exhausted, refused_an_item}` are gone from that type and live on the new
   one, and `InputRef::token_budget` now returns `&TokenBudgetTally`. Every existing *read* — `inp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -734,6 +734,70 @@ and will red until they do.
 
 ### Fixed
 
+- **`PARSE_DEFAULT_DEPTH` is derived from a five-axis measurement of a door that spends none of it,
+  and the door it *is* enforced on has now been measured** (#297). `measured::CONSUMER_ABORTS_AT`
+  was documented as "a real consumer grammar's debug build aborts at this depth […] on the tightest
+  of its five measured axes". Those five axes vary architecture, dialect, shape and source backing
+  — and hold fixed, without saying so, that every reading is of that consumer's **syntactic** door,
+  which takes no `InputRef::descend` and therefore spends no level of this budget at all.
+
+  Cross-checked three ways and then at runtime. A sweep of the consumer's syntactic tree finds no
+  `descend`/`descending` call; `RecursionLimitReached` has exactly **one** construction site in this
+  crate (`InputRef::descend`); that site's only in-crate callers are the two Pratt engines
+  (`InputRef::pratt`, `parser::pratt::expr`), which the consumer does not use. Directly: under the
+  shipped budget of 16, with the consumer's own lexer tally lifted, its syntactic door parses 64
+  nested braces clean while its lossless door refuses at exactly 16.
+
+  **The re-measurement.** Same method as the original — one parse per *process*, on an explicitly
+  sized 2 MiB thread, greatest depth that returns before the next aborts — pointed at the lossless
+  door, with the boundary converted into *descents* (the unit `RecursionLimiter::limitation` is
+  compared against) by an in-process oracle: the smallest ceiling under which the same document
+  parses clean. `aarch64-apple-darwin`, rustc 1.99.0-nightly (771916f90). Debug, last descent count
+  that returns: GraphQL inline fragments **717**, GraphQLx inline fragments **715**, GraphQLx
+  generic angle brackets **843**, GraphQL recovery bypass **669**, GraphQLx recovery bypass with
+  `)` and with `>` alike **667**, object-value cycle **875**, list-value cycle **1294**; x86_64
+  moves the first cell to 805, so aarch64 stays the binding architecture. The syntactic row's fifth
+  axis — a `bytes::Bytes` source backing — has **no lossless counterpart**: all twelve of that
+  consumer's lossless entry points take `&str`.
+
+  **The release table, which had never been taken, is the same instrument run twice.** Release,
+  aarch64: 4238 / 3861 / **3282** / 5472 / 4863 / 3455 / 3455 in the same order. Optimisation
+  reorders which shape binds — the generic angle brackets are the loosest debug cell and the
+  tightest release one — so a release figure extrapolated from debug's ratio would have named the
+  wrong shape as well as the wrong number.
+
+  **What the shipped formula makes of it**, unchanged, with `MIN_HEADROOM` and `MIN_MARGIN_TENTHS`
+  untouched: **128** debug (`128 × 3 = 384 < 667`, `256 × 3 = 768` is not) and **1024** release.
+  Both are published as `policy::PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW` and its release twin,
+  derived from the measured rows, pinned by the same two-halved assertion the shipped cells get and
+  by a literal from outside the derivation — **and read by nothing.**
+
+  **`PARSE_DEFAULT_DEPTH` is unchanged at 16, deliberately.** The mis-pointing errs in the
+  recoverable direction — the wrong row is the tighter one, so the cost is depth rather than an
+  abort — and repointing is one decision that moves four other things: an 8× loosening of a shipped
+  safety default and a behaviour break; `TOKORA_ABORTS_AT > CONSUMER_…_ABORTS_AT`, whose intent
+  ("the consumer row is the binding one") is an artefact of the syntactic door and inverts
+  legitimately on the lossless one; the release arm, which can then be derived rather than floored,
+  making the two arms diverge and the `debug_assertions`-as-profile-proxy caveat live for the first
+  time; and the provisional release assertion, which prices the release budget at the *debug*
+  per-level cost and must be re-priced or a 1024-level release budget "fits" a 2 MiB thread it does
+  not fit. Each of those is now a compiled relation rather than a paragraph.
+
+  What it costs today is measured rather than argued: over 472 shipped fixtures, that consumer's
+  deepest spends **11** descents, an ordinary filter query reaches 10 or 11, and
+  `f(where: {a: {b: [1]}})` spends **5** for what reads as three-deep because an argument list's
+  `(` is a one-off toll. So 16 leaves 1.45× over documents that already exist, under the 2× floor
+  that same consumer enforces on its own nesting ceiling at compile time — which it escapes only
+  because the binding number is tokora's.
+
+  No public API moved. `measured::CONSUMER_ABORTS_AT` and `CONSUMER_BYTES_PER_LEVEL` are
+  `pub(crate)` and are renamed `CONSUMER_SYNTACTIC_ABORTS_AT` / `CONSUMER_SYNTACTIC_BYTES_PER_LEVEL`
+  — a bare "consumer" figure is exactly the name that got read as describing the door the budget is
+  enforced on. The syntactic row keeps the two jobs it is still the right row for: pricing
+  `native_stack::RED_ZONE` and `SEGMENTED_PRATT_DEPTH`, both of which are about the *heaviest* frame
+  and would silently drop by 13× and rise by 16× respectively if the repoint had been done by
+  moving one constant.
+
 - **An at-limit refusal on a *second* entry could be decided and then not recorded, and the
   analysis that was supposed to have found it looked at the wrong set of sites.** Once the one-shot
   probe is spent, the input carries a **recorded** decision that it already refused an item — a

--- a/tokora/src/input/input_ref/descent_tests.rs
+++ b/tokora/src/input/input_ref/descent_tests.rs
@@ -481,7 +481,8 @@ const MEASUREMENT_STACK: usize = 2 * 1024 * 1024;
 /// This is what makes the cell below a statement about a *stack* rather than about a counter. A
 /// frame of a handful of bytes would let any budget whatever fit in 2 MiB, and the cell would pass
 /// for a build in which the shared default was 1024.
-const HEAVY_LEVEL: usize = crate::state::recursion_tracker::measured::CONSUMER_BYTES_PER_LEVEL;
+const HEAVY_LEVEL: usize =
+  crate::state::recursion_tracker::measured::CONSUMER_SYNTACTIC_BYTES_PER_LEVEL;
 
 /// How deep [`heavy`] is willing to go before giving up and returning `Ok`.
 ///

--- a/tokora/src/input/input_ref/descent_tests.rs
+++ b/tokora/src/input/input_ref/descent_tests.rs
@@ -476,24 +476,21 @@ fn a_leaked_guard_holds_its_level_for_the_rest_of_the_parse() {
 const MEASUREMENT_STACK: usize = 2 * 1024 * 1024;
 
 /// Bytes of native stack each level of [`heavy`] spends, set to the heaviest per-level cost
-/// anybody has measured — **in this build's profile**: ~41 KiB debug, ~4.3 KiB release.
+/// anybody has measured: the consumer's syntactic row, ~41 KiB.
 ///
 /// This is what makes the cell below a statement about a *stack* rather than about a counter. A
 /// frame of a handful of bytes would let any budget whatever fit in 2 MiB, and the cell would pass
 /// for a build in which the shared default was 1024.
 ///
-/// **It is keyed on `debug_assertions` because the budget it is measured against is.** For every
-/// revision before the two arms diverged this was one constant, and it could be: both arms held one
-/// number, so pricing either at the debug cost was the conservative reading. With the release arm
-/// at 256, a fixed debug price would model 10 MiB of frames against a 2 MiB thread and this cell
-/// would red in every release test run — reporting a defect that is an artefact of measuring one
-/// profile's frames against the other profile's budget, which is the very confusion
-/// `state::recursion_tracker` exists to keep out.
-const HEAVY_LEVEL: usize = if cfg!(debug_assertions) {
-  crate::state::recursion_tracker::measured::CONSUMER_SYNTACTIC_BYTES_PER_LEVEL
-} else {
-  crate::state::recursion_tracker::measured::CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL
-};
+/// **It is the DEBUG price in every profile, and that is now the correct model rather than the
+/// conservative one.** It was briefly keyed on `debug_assertions`, for the revision in which the
+/// shipped default was keyed on it too. The default holds one number in both arms again — chosen
+/// precisely so that it survives the debug frame price whichever arm a build selects, because that
+/// flag observes neither `opt-level` nor the consumer's compilation — so pricing this cell at the
+/// debug cost in both profiles is what the guarantee actually is. Keying it would make the cell
+/// weaker than the claim it exists to witness.
+const HEAVY_LEVEL: usize =
+  crate::state::recursion_tracker::measured::CONSUMER_SYNTACTIC_BYTES_PER_LEVEL;
 
 /// How deep [`heavy`] is willing to go before giving up and returning `Ok`.
 ///

--- a/tokora/src/input/input_ref/descent_tests.rs
+++ b/tokora/src/input/input_ref/descent_tests.rs
@@ -476,22 +476,53 @@ fn a_leaked_guard_holds_its_level_for_the_rest_of_the_parse() {
 const MEASUREMENT_STACK: usize = 2 * 1024 * 1024;
 
 /// Bytes of native stack each level of [`heavy`] spends, set to the heaviest per-level cost
-/// anybody has measured: the consumer row, ~41 KiB.
+/// anybody has measured — **in this build's profile**: ~41 KiB debug, ~4.3 KiB release.
 ///
 /// This is what makes the cell below a statement about a *stack* rather than about a counter. A
 /// frame of a handful of bytes would let any budget whatever fit in 2 MiB, and the cell would pass
 /// for a build in which the shared default was 1024.
-const HEAVY_LEVEL: usize =
-  crate::state::recursion_tracker::measured::CONSUMER_SYNTACTIC_BYTES_PER_LEVEL;
+///
+/// **It is keyed on `debug_assertions` because the budget it is measured against is.** For every
+/// revision before the two arms diverged this was one constant, and it could be: both arms held one
+/// number, so pricing either at the debug cost was the conservative reading. With the release arm
+/// at 256, a fixed debug price would model 10 MiB of frames against a 2 MiB thread and this cell
+/// would red in every release test run — reporting a defect that is an artefact of measuring one
+/// profile's frames against the other profile's budget, which is the very confusion
+/// `state::recursion_tracker` exists to keep out.
+const HEAVY_LEVEL: usize = if cfg!(debug_assertions) {
+  crate::state::recursion_tracker::measured::CONSUMER_SYNTACTIC_BYTES_PER_LEVEL
+} else {
+  crate::state::recursion_tracker::measured::CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL
+};
 
 /// How deep [`heavy`] is willing to go before giving up and returning `Ok`.
 ///
 /// **It exists so that a defect reds this cell instead of killing the process.** The budget is
 /// what should stop the recursion; if it does not, something has to, and an assertion failure is a
-/// test result while `fatal runtime error: stack overflow` is not. 24 levels at ~41 KiB is ≈0.94
-/// MiB — comfortably inside the 2 MiB thread — and it is above the shipped default, which is the
-/// other half of what it has to be or the cell would never reach the budget at all.
-const HEAVY_CAP: usize = 24;
+/// test result while `fatal runtime error: stack overflow` is not.
+///
+/// **Four levels past the shipped default, derived rather than written down.** A literal has to be
+/// re-chosen every time the default moves, and choosing it wrong is not symmetrical: too low makes
+/// the pin below vacuous — the recursion gives up before the budget is reached, and a budget that
+/// refuses nothing passes — while too high walks a 41 KiB frame into the guard page and kills the
+/// harness. Deriving it removes both. It is a safety stop and not an expectation; what this cell
+/// *expects* is that the budget refuses first, and that is asserted against the default itself.
+const HEAVY_CAP: usize = RecursionLimiter::PARSE_DEFAULT_DEPTH + 4;
+
+/// **The other side of the cap**, which the derived form makes checkable rather than assumed: the
+/// recursion [`heavy`] is about to run must itself fit the thread.
+///
+/// Without it, a default that grew past what 2 MiB holds would take the harness down *inside* the
+/// cell written to stop exactly that, instead of reporting. It is a `const` assertion and not a
+/// line in the test for the reason `state::recursion_tracker`'s own block gives: every operand is a
+/// constant, so a build is the stronger place to settle it than a run — and clippy refuses the
+/// weaker one.
+const _: () = assert!(
+  HEAVY_CAP * HEAVY_LEVEL < MEASUREMENT_STACK,
+  "the probe in `the_shared_budget_refuses_unsegmented_descent_within_a_2mib_thread` would recurse \
+   past the 2 MiB thread it is stated on. Its cap is the shipped default plus four, so this means \
+   the default itself no longer leaves room for the probe that checks it."
+);
 
 /// A **non-Pratt** recursive production with an ordinary, expensive native frame.
 ///

--- a/tokora/src/native_stack.rs
+++ b/tokora/src/native_stack.rs
@@ -208,15 +208,15 @@ pub(crate) fn maybe_grow<R>(frame: impl FnOnce() -> R) -> R {
 /// no arguments, so the messages name what to read instead of printing what they compared.
 #[cfg(feature = "stacker")]
 const _: () = {
-  use crate::state::recursion_tracker::measured::{CONSUMER_BYTES_PER_LEVEL, STACK};
+  use crate::state::recursion_tracker::measured::{CONSUMER_SYNTACTIC_BYTES_PER_LEVEL, STACK};
 
   // `RED_ZONE` is a prediction about how much stack one level spends between two consecutive
   // checks. A red zone below the heaviest level actually measured is not a prediction, it is a
   // known-wrong one: the frame overruns the segment into a guard page, which is a SIGSEGV and not
   // a diagnostic.
   assert!(
-    RED_ZONE >= CONSUMER_BYTES_PER_LEVEL * 4,
-    "RED_ZONE is under 4x CONSUMER_BYTES_PER_LEVEL, the heaviest measured per-level cost"
+    RED_ZONE >= CONSUMER_SYNTACTIC_BYTES_PER_LEVEL * 4,
+    "RED_ZONE is under 4x CONSUMER_SYNTACTIC_BYTES_PER_LEVEL, the heaviest measured per-level cost"
   );
   // A segment at or barely above the red zone re-enters it immediately, so every frame would
   // allocate.
@@ -227,7 +227,7 @@ const _: () = {
   // The claim in `SEGMENT`'s derivation is ~43 levels of the heaviest measured grammar; this is
   // the floor under it, and therefore under the allocation-frequency figure.
   assert!(
-    (SEGMENT - RED_ZONE) / CONSUMER_BYTES_PER_LEVEL >= 32,
+    (SEGMENT - RED_ZONE) / CONSUMER_SYNTACTIC_BYTES_PER_LEVEL >= 32,
     "a segment holds too few levels of the heaviest measured grammar for the allocation \
      frequency SEGMENT's derivation claims"
   );

--- a/tokora/src/state/recursion_tracker/mod.rs
+++ b/tokora/src/state/recursion_tracker/mod.rs
@@ -426,6 +426,18 @@ pub(crate) mod measured {
   /// being the looser of the two is what a cheaper frame means rather than evidence of an edit.
   pub(crate) const TOKORA_ABORTS_AT: usize = 125;
 
+  /// The tightest cell of **tokora's own release table** — the typed driver, 3 871 frames at
+  /// ~0.53 KiB against the token driver's 4 247 at ~0.48 KiB.
+  ///
+  /// A constant rather than only a row in [`RecursionLimiter`]'s own doc table, because a release
+  /// derivation has to read it and a figure that exists only in prose is the thing this module
+  /// stopped doing. The two now cannot drift.
+  ///
+  /// **Note which driver binds, and that it is the other one.** Debug's tightest cell is the
+  /// *token* driver at 125; release's is the *typed* driver at 3 871. Optimisation reorders them,
+  /// which is the same lesson [`CONSUMER_LOSSLESS_RELEASE_ABORTS_AT`] records about shapes.
+  pub(crate) const TOKORA_RELEASE_ABORTS_AT: usize = 3871;
+
   /// The thread every figure is stated on, and the one `std::thread::spawn` hands out.
   pub(crate) const STACK: usize = 2 * 1024 * 1024;
 
@@ -439,6 +451,43 @@ pub(crate) mod measured {
   /// [`SEGMENTED_PRATT_DEBUG`](super::policy::SEGMENTED_PRATT_DEBUG) by 16 as a side effect of
   /// fixing an unrelated default.
   pub(crate) const CONSUMER_SYNTACTIC_BYTES_PER_LEVEL: usize = STACK / CONSUMER_SYNTACTIC_ABORTS_AT;
+
+  /// **The release sweep of the syntactic row**, which this module recorded as owed for four
+  /// revisions and which never existed until now — the binding cell of four of its five axes.
+  ///
+  /// Same instrument, same 2 MiB thread, same one-parse-per-process bisection;
+  /// `opt-level = 3`, `debug-assertions = false`, `overflow-checks = false`. Last depth that
+  /// returns / first that aborts:
+  ///
+  /// | cell (syntactic door, 2 MiB, release) | returns | aborts |
+  /// |---|---|---|
+  /// | GraphQL, inline fragments, `str`, aarch64 | 504 | 505 |
+  /// | GraphQLx, inline fragments, `str`, aarch64 | **471** | 472 |
+  /// | GraphQLx, generic angle brackets, `str`, aarch64 | 567 | 568 |
+  /// | GraphQL, inline fragments, `str`, x86_64 | 513 | 514 |
+  /// | GraphQLx, inline fragments, `str`, x86_64 | 490 | 491 |
+  ///
+  /// The fifth axis — a `bytes::Bytes` source backing — is **not** measured here. On the debug
+  /// table that backing cost 0.89x and was the binding cell; the same discount over 471 would be
+  /// about 419. That is an extrapolation and is deliberately not this constant.
+  ///
+  /// **What the missing axis can and cannot change.** This row is read only to price a *fit*, and
+  /// the fit is what fixes [`PARSE_DEFAULT_RELEASE`](super::policy::PARSE_DEFAULT_RELEASE) at 256:
+  /// the next power of two up needs this cell above 512, and the loosest axis measured is 505. So
+  /// the missing axis cannot raise the answer, and to lower it the true binding cell would have to
+  /// fall below 256 — a 1.8x miss, twice the spread the whole debug table showed. The answer is
+  /// robust to the axis that is absent, which is the only reason recording four is honest.
+  pub(crate) const CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT: usize = 471;
+
+  /// Bytes of native stack one level of the heaviest measured syntactic grammar spends in a
+  /// **release** build — derived from [`CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT`]. ~4.3 KiB, against
+  /// ~41 KiB debug, so a release level of the heavy population is 9.2x cheaper.
+  ///
+  /// It prices the release half of the *fit* tier. It deliberately does **not** reprice
+  /// [`SEGMENTED_PRATT_RELEASE`](super::policy::SEGMENTED_PRATT_RELEASE), which is a memory policy
+  /// over segments rather than a thread-stack bound and whose value is its own decision.
+  pub(crate) const CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL: usize =
+    STACK / CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT;
 
   /// Bytes of native stack one **descent** of that consumer's lossless door spends, debug —
   /// derived from [`CONSUMER_LOSSLESS_ABORTS_AT`] the same way. ~3.1 KiB.
@@ -876,7 +925,9 @@ const _: () = {
   use measured::{
     CONSUMER_DEEPEST_SHIPPED_DOCUMENT, CONSUMER_LOSSLESS_ABORTS_AT,
     CONSUMER_LOSSLESS_BYTES_PER_LEVEL, CONSUMER_LOSSLESS_RELEASE_ABORTS_AT,
-    CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL, STACK, TOKORA_ABORTS_AT,
+    CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL, CONSUMER_SYNTACTIC_ABORTS_AT,
+    CONSUMER_SYNTACTIC_BYTES_PER_LEVEL, CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT,
+    CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL, STACK, TOKORA_ABORTS_AT, TOKORA_RELEASE_ABORTS_AT,
   };
   use policy::{
     MIN_HEADROOM, MIN_MARGIN_TENTHS, PARSE_DEFAULT_DEBUG, PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW,
@@ -911,7 +962,7 @@ const _: () = {
   // converge, the argument for two rows has gone with them and this file needs re-reading rather
   // than a wider constant.
   assert!(
-    CONSUMER_LOSSLESS_ABORTS_AT > measured::CONSUMER_SYNTACTIC_ABORTS_AT * 4,
+    CONSUMER_LOSSLESS_ABORTS_AT > CONSUMER_SYNTACTIC_ABORTS_AT * 4,
     "the syntactic and lossless consumer rows have converged. They are readings of two different \
      doors whose per-level costs differ by roughly an order of magnitude, so convergence means a \
      row was edited rather than re-measured — see `measured`'s header for what each door spends."
@@ -926,11 +977,24 @@ const _: () = {
      lossless descent had become as expensive as a Pratt frame"
   );
   // A release descent is cheaper than a debug one, so more of them fit the same thread. The same
-  // standing order the shipped pair carries, on the row that now has both halves measured.
+  // standing order the shipped pair carries, stated once per row now that all three have both
+  // halves measured — tokora's own, the syntactic consumer's, and the lossless consumer's.
   assert!(
     CONSUMER_LOSSLESS_RELEASE_ABORTS_AT > CONSUMER_LOSSLESS_ABORTS_AT,
     "the release lossless row is at or below the debug one, which inverts the only thing known \
      about the two profiles"
+  );
+  assert!(
+    TOKORA_RELEASE_ABORTS_AT > TOKORA_ABORTS_AT,
+    "tokora's own release row is at or below its debug one, which inverts the only thing known \
+     about the two profiles"
+  );
+  assert!(
+    CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT > CONSUMER_SYNTACTIC_ABORTS_AT
+      && CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL < CONSUMER_SYNTACTIC_BYTES_PER_LEVEL,
+    "the release syntactic row is at or below the debug one, or its derived per-level cost is not \
+     the cheaper of the two — the second cannot disagree with the first unless one was written \
+     down rather than derived"
   );
 
   // **THE DIRECTION OF THE DEFECT.** The shipped default is derived from the wrong door, and this

--- a/tokora/src/state/recursion_tracker/mod.rs
+++ b/tokora/src/state/recursion_tracker/mod.rs
@@ -112,6 +112,12 @@ impl RecursionLimitExceeded {
 /// them; that is what `PARSE_DEFAULT_DEPTH` records, and it is why the shipped figure is derived
 /// from a consumer measurement of **51** rather than from the 125 here.
 ///
+/// **And the 51 is a reading of that consumer's *syntactic* door, which spends no level of this
+/// counter at all** — the door the budget is enforced on has since been measured separately and is
+/// roughly an order of magnitude cheaper per level. That does not make the choice above unsafe, it
+/// makes it tight; [`PARSE_DEFAULT_DEPTH`](Self::PARSE_DEFAULT_DEPTH) carries the correction and
+/// this module's private `measured` carries both rows.
+///
 /// The two failure modes are not symmetric, and that is what settles the direction to err in. A
 /// limit that is too *low* returns a clean, catchable, documented
 /// [`RecursionLimitReached`](crate::error::RecursionLimitReached) telling the caller to raise it.
@@ -305,25 +311,164 @@ impl Default for RecursionLimiter {
 /// alternative source representation. A derivation reading it would be exactly the
 /// derived-not-measured figure this module's assertions exist to refuse. `policy` therefore ships
 /// the release cells as *floors* equal to the debug cells until that sweep is run.
+///
+/// # EVERY FIGURE IS ALSO OF ONE **DOOR**, AND THE NAMES NOW SAY WHICH
+///
+/// The consumer's five axes were varied over architecture, dialect, shape and source backing —
+/// and held one thing fixed that nobody wrote down: they are all readings of that consumer's
+/// **syntactic** door, which spends **no** [`RecursionLimiter`] level at all. Its cost per level
+/// is a native frame the budget never sees. The budget is spent on the consumer's **lossless**
+/// door, one [`InputRef::descend`](crate::InputRef::descend) per nesting delimiter, and a level
+/// there is roughly an order of magnitude cheaper. So a default derived from the syntactic row
+/// bounds one population with another's frame cost, which is the same
+/// derived-over-the-wrong-population defect that made 64 wrong one layer further in.
+///
+/// Both rows are therefore named for their door, and neither name is `CONSUMER_ABORTS_AT` any
+/// more: a bare "consumer" figure is the thing that got read as though it described the door the
+/// budget is enforced on.
 pub(crate) mod measured {
-  /// The binding cell: a real **consumer** grammar's debug build aborts at this depth on an
-  /// explicitly sized 2 MiB thread, on the tightest of its five measured axes (the others are 52,
-  /// 53, 57 and 60).
-  pub(crate) const CONSUMER_ABORTS_AT: usize = 51;
+  /// A real **consumer** grammar's debug build aborts at this depth on an explicitly sized 2 MiB
+  /// thread, on the tightest of its five measured axes (the others are 52, 53, 57 and 60) — at
+  /// its **syntactic** door.
+  ///
+  /// **That door spends no recursion level.** Its cost is a native frame per level of nesting and
+  /// nothing the budget can count, cross-checked three ways: a sweep of that consumer's syntactic
+  /// tree finds no `descend`/`descending` call; [`RecursionLimitReached`] has exactly one
+  /// construction site in this crate ([`InputRef::descend`](crate::InputRef::descend)); and that
+  /// site's only in-crate callers are the two Pratt engines, which the consumer does not use.
+  /// Confirmed at runtime: under the shipped budget of 16 with the consumer's own lexer tally
+  /// lifted, its syntactic door parses 64 nested braces clean while its lossless door refuses at
+  /// exactly 16.
+  ///
+  /// So this figure is **not** the one [`PARSE_DEFAULT_DEBUG`](super::policy::PARSE_DEFAULT_DEBUG)
+  /// should be derived from, and today it is. See
+  /// [`CONSUMER_LOSSLESS_ABORTS_AT`] for the row that is, and
+  /// [`PARSE_DEFAULT_DEBUG`](super::policy::PARSE_DEFAULT_DEBUG) for why the repoint is a decision
+  /// rather than an edit.
+  ///
+  /// What it *is* still the right row for is a **memory** policy over heavy frames — see
+  /// [`CONSUMER_SYNTACTIC_BYTES_PER_LEVEL`].
+  pub(crate) const CONSUMER_SYNTACTIC_ABORTS_AT: usize = 51;
+
+  /// **The same consumer, the same five axes, pointed at the door the budget is actually spent
+  /// on** — one [`InputRef::descend`](crate::InputRef::descend) per nesting delimiter — and the
+  /// figure is in *descents*, which is the unit
+  /// [`RecursionLimiter::limitation`](super::RecursionLimiter::limitation) is compared against.
+  ///
+  /// # The bisection
+  ///
+  /// One parse per **process**, on an explicitly sized 2 MiB thread, greatest descent count that
+  /// returns before the next one aborts with `fatal runtime error: stack overflow`. The document
+  /// depth a boundary is found at is converted to descents by an in-process oracle: the smallest
+  /// ceiling under which that same document parses without a diagnostic, which is exactly how many
+  /// levels it spends. Measured `aarch64-apple-darwin`, `opt-level = 0` with `debug-assertions`
+  /// and `overflow-checks` on, rustc 1.99.0-nightly (771916f90 2026-08-08):
+  ///
+  /// | cell (lossless door, 2 MiB, debug) | last descent count that returns | first that aborts |
+  /// |---|---|---|
+  /// | GraphQL, inline fragments, `str`, aarch64 | 717 | 718 |
+  /// | GraphQL, inline fragments, `str`, x86_64 | 805 | 806 |
+  /// | GraphQLx, inline fragments, `str`, aarch64 | 715 | 716 |
+  /// | GraphQLx, generic angle brackets, `str`, aarch64 | 843 | 844 |
+  /// | GraphQL, the recovery bypass `{ ) f {`, `str`, aarch64 | 669 | 670 |
+  /// | GraphQLx, the same with `)` and with `>` alike, `str`, aarch64 | **667** | 668 |
+  /// | GraphQL, the object-value cycle, `str`, aarch64 | 875 | 876 |
+  /// | GraphQL, the list-value cycle, `str`, aarch64 | 1294 | 1295 |
+  ///
+  /// **The fifth axis has no cell, and that is a fact about the consumer rather than an omission.**
+  /// The syntactic row's tightest cell was a `bytes::Bytes` source backing; every one of that
+  /// consumer's twelve shipped lossless entry points takes `&str`, so there is no lossless door to
+  /// point the backing axis at. If the syntactic row's 0.89x for that backing carried across, the
+  /// binding cell would extrapolate to about 593 — which is an extrapolation, is **not** what this
+  /// constant records, and is exactly the shape this module refuses.
+  ///
+  /// **The binding cell is a shape the syntactic five never had.** The recovery bypass costs two
+  /// native frames per level (`field` and `selection_set`) while spending one descent, so it is
+  /// the tightest cell in the budget's own unit even though it is not the tightest in document
+  /// depth. It is the shape that walked past the consumer's first nesting fix, and the consumer's
+  /// suite pins it.
+  ///
+  /// The figures are one host's, and the control says how far one host moves them. Re-running the
+  /// same instrument against the *syntactic* door here reproduces that row's recorded 57 / 53 / 52
+  /// / 60 at 64 / 60 / 60 / 68 — 12-15% looser, on a newer toolchain and a newer branch of the
+  /// consumer, with the same architecture relation (x86_64 the looser of the two) and the same
+  /// ordering up to a tie between the two GraphQLx cells. It also reproduces that row's recorded
+  /// release reading, "500 levels of the syntactic door need about 1.95 MiB of the 2 MiB
+  /// available", at 505. **So each figure here is an expectation to re-check on another host
+  /// rather than a constant**, which is what the headroom policy is there to absorb.
+  pub(crate) const CONSUMER_LOSSLESS_ABORTS_AT: usize = 667;
+
+  /// The same bisection, the same door, the same host, **release**: `opt-level = 3`,
+  /// `debug-assertions = false`, `overflow-checks = false`.
+  ///
+  /// | cell (lossless door, 2 MiB, release, aarch64) | last that returns | first that aborts |
+  /// |---|---|---|
+  /// | GraphQL, inline fragments, `str` | 4238 | 4239 |
+  /// | GraphQLx, inline fragments, `str` | 3861 | 3862 |
+  /// | GraphQLx, generic angle brackets, `str` | **3282** | 3283 |
+  /// | GraphQL, the recovery bypass `{ ) f {`, `str` | 5472 | 5473 |
+  /// | GraphQLx, the same with `)` and with `>` alike, `str` | 4863 | 4864 |
+  /// | GraphQL, the object-value cycle, `str` | 3455 | 3456 |
+  /// | GraphQL, the list-value cycle, `str` | 3455 | 3456 |
+  ///
+  /// **The binding cell is not the debug row's.** Optimisation reorders which shape is tightest:
+  /// the generic angle brackets are the *loosest* debug cell and the *tightest* release one. A
+  /// release figure extrapolated from debug's ratio would have named the wrong shape as well as
+  /// the wrong number, which is the whole reason
+  /// [`PARSE_DEFAULT_RELEASE`](super::policy::PARSE_DEFAULT_RELEASE) refused to be raised from one.
+  pub(crate) const CONSUMER_LOSSLESS_RELEASE_ABORTS_AT: usize = 3282;
 
   /// The tightest cell of **tokora's own** table — the debug token driver on the same thread.
   ///
-  /// Kept beside the consumer figure precisely because it is the one the old default was sized
-  /// against. Every guard below that names `CONSUMER_ABORTS_AT` is a place where using this
-  /// number instead is the defect.
+  /// Kept beside the consumer figures precisely because it is the one the old default was sized
+  /// against. Note that it is no longer comparable with the row the budget is enforced on: 125 is
+  /// a *Pratt frame* figure at ~16.4 KiB, and a lossless descent is ~3.1 KiB, so tokora's own row
+  /// being the looser of the two is what a cheaper frame means rather than evidence of an edit.
   pub(crate) const TOKORA_ABORTS_AT: usize = 125;
 
   /// The thread every figure is stated on, and the one `std::thread::spawn` hands out.
   pub(crate) const STACK: usize = 2 * 1024 * 1024;
 
-  /// Bytes of native stack one level of the heaviest measured grammar spends — **derived** from
-  /// the bisection rather than written down separately, so the two cannot disagree.
-  pub(crate) const CONSUMER_BYTES_PER_LEVEL: usize = STACK / CONSUMER_ABORTS_AT;
+  /// Bytes of native stack one level of the heaviest measured **syntactic** grammar spends —
+  /// **derived** from that bisection rather than written down separately, so the two cannot
+  /// disagree. ~41 KiB.
+  ///
+  /// This is the row a **memory** policy over segmented Pratt frames must be priced at, and that
+  /// is why the repoint below does not touch it: a Pratt frame is the heavy kind, and pricing a
+  /// segment budget at the cheap lossless descent would multiply
+  /// [`SEGMENTED_PRATT_DEBUG`](super::policy::SEGMENTED_PRATT_DEBUG) by 16 as a side effect of
+  /// fixing an unrelated default.
+  pub(crate) const CONSUMER_SYNTACTIC_BYTES_PER_LEVEL: usize = STACK / CONSUMER_SYNTACTIC_ABORTS_AT;
+
+  /// Bytes of native stack one **descent** of that consumer's lossless door spends, debug —
+  /// derived from [`CONSUMER_LOSSLESS_ABORTS_AT`] the same way. ~3.1 KiB.
+  pub(crate) const CONSUMER_LOSSLESS_BYTES_PER_LEVEL: usize = STACK / CONSUMER_LOSSLESS_ABORTS_AT;
+
+  /// The same, release — derived from [`CONSUMER_LOSSLESS_RELEASE_ABORTS_AT`]. ~0.6 KiB.
+  ///
+  /// **This is the figure that unblocks the release arm.** The provisional assertion that keeps
+  /// [`PARSE_DEFAULT_RELEASE`](super::policy::PARSE_DEFAULT_RELEASE) at a floor prices the release
+  /// budget at the *debug* per-level cost, because until now that was the only cost there was; a
+  /// release budget large enough to be worth having does not fit a 2 MiB thread at a debug price
+  /// and never could.
+  pub(crate) const CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL: usize =
+    STACK / CONSUMER_LOSSLESS_RELEASE_ABORTS_AT;
+
+  /// The descents the **deepest document that consumer actually ships** spends at the door the
+  /// budget is enforced on, over the 472 fixtures in its tree.
+  ///
+  /// Every other figure here is about where a stack dies. This one is about what a real document
+  /// needs, and it is the half no arithmetic over the rows above can reach: it is what decides
+  /// whether a derived ceiling is comfortable or tight. Measured with the same in-process oracle
+  /// the descent conversion uses — the smallest ceiling under which that fixture parses clean —
+  /// and it comes out equal to its bracket count, which is what one-descent-per-nesting-delimiter
+  /// predicts.
+  ///
+  /// For scale beside it, and deliberately not constants because they are illustrations rather
+  /// than bounds: an ordinary filter query reaches 10 or 11, and `f(where: {a: {b: [1]}})` spends
+  /// 5 for what reads as three-deep, because an argument list's `(` is a one-off toll on top of
+  /// the object nesting.
+  pub(crate) const CONSUMER_DEEPEST_SHIPPED_DOCUMENT: usize = 11;
 }
 
 /// **What this crate CHOSE**, given what [`measured`] records — kept apart from it because the two
@@ -348,9 +493,34 @@ pub(crate) mod measured {
 ///
 /// Every cell is named and pinned by an `==` of its own. The two release cells are **floors set
 /// equal to their debug siblings, and are not derivations**: [`measured`] contains no release
-/// bisection to derive them from, and inventing one from debug's ratio is the defect. What the
-/// split buys today is that filling them in later is a value change and not a refactor — and that
-/// no assertion in this file claims a release derivation nobody performed.
+/// bisection *of the population they describe* to derive them from, and inventing one from debug's
+/// ratio is the defect. What the split buys today is that filling them in later is a value change
+/// and not a refactor — and that no assertion in this file claims a release derivation nobody
+/// performed.
+///
+/// # There is a fifth cell here, and it is not shipped
+///
+/// [`PARSE_DEFAULT_DEBUG`] and [`PARSE_DEFAULT_RELEASE`] are both derived from
+/// [`measured::CONSUMER_SYNTACTIC_ABORTS_AT`], which is a reading of a door that spends **no**
+/// recursion level. The row the budget is enforced on has now been measured
+/// ([`measured::CONSUMER_LOSSLESS_ABORTS_AT`]), and what the *same formula and the same guards*
+/// produce from it is published here as [`PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW`] and
+/// [`PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW`] — derived, asserted, and read by nothing.
+///
+/// **Repointing is one decision and it moves four other things**, which is why it is not taken
+/// here as a side effect of taking the measurement:
+///
+/// 1. the shipped [`RecursionLimiter::PARSE_DEFAULT_DEPTH`](super::RecursionLimiter::PARSE_DEFAULT_DEPTH)
+///    goes 16 → 128, an 8× loosening of a safety default and a behaviour break;
+/// 2. `TOKORA_ABORTS_AT > CONSUMER_…_ABORTS_AT` stops holding, and its intent — *the consumer row
+///    is the binding one* — has to be re-derived rather than flipped, because on the lossless door
+///    the consumer row is legitimately the looser of the two;
+/// 3. the release arm can finally be derived rather than floored, which makes the two arms
+///    diverge, which makes the `debug_assertions`-as-profile-proxy caveat on [`PARSE_DEFAULT`]
+///    live for the first time;
+/// 4. and the provisional release assertion has to be re-priced at
+///    [`measured::CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL`], because a 1024-level release budget
+///    priced at a debug per-level cost does not fit the 2 MiB thread the derivation is stated on.
 pub(crate) mod policy {
   use super::measured;
 
@@ -374,7 +544,7 @@ pub(crate) mod policy {
   pub(crate) const MIN_MARGIN_TENTHS: usize = 19;
 
   /// **The parse-side default in a debug build, derived**: the deepest power of two that still
-  /// fits [`MIN_HEADROOM`] times under [`measured::CONSUMER_ABORTS_AT`].
+  /// fits [`MIN_HEADROOM`] times under [`measured::CONSUMER_SYNTACTIC_ABORTS_AT`].
   ///
   /// 16, from 51 and 3 — `16 × 3 = 48 < 51`, and `32 × 3 = 96` is not. A power of two because
   /// every default this crate has shipped has been one and a reader expects it, and the *deepest*
@@ -383,9 +553,65 @@ pub(crate) mod policy {
   /// This exists so the published constant can be asserted **equal** to something. A bare
   /// inequality against the measurement admits every smaller value including 1, which is what the
   /// guards in this file used to do.
+  ///
+  /// # **It is derived from the wrong door, and that is measured rather than suspected**
+  ///
+  /// 51 is a *syntactic*-door reading and this budget is spent on a *lossless* one; a level there
+  /// costs about eleven times less. Repointing the same formula at
+  /// [`measured::CONSUMER_LOSSLESS_ABORTS_AT`] gives
+  /// [`PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW`] — 128 — and the direction is the recoverable one:
+  /// 16 is *below* what the right row supports, so what the mis-pointing costs is depth a real
+  /// document can use, not safety. The consumer's deepest shipped fixture spends 11 descents and
+  /// an ordinary filter query reaches 10 or 11, so 16 leaves 1.45× over documents that already
+  /// exist, against a floor of 2× that the same consumer enforces on its own ceiling at compile
+  /// time.
+  ///
+  /// The repoint is deliberately not taken as part of recording the measurement — see the module
+  /// header for the four things it moves with it.
   pub(crate) const PARSE_DEFAULT_DEBUG: usize = {
     let mut depth = 1;
-    while depth * 2 * MIN_HEADROOM < measured::CONSUMER_ABORTS_AT {
+    while depth * 2 * MIN_HEADROOM < measured::CONSUMER_SYNTACTIC_ABORTS_AT {
+      depth *= 2;
+    }
+    depth
+  };
+
+  /// **What [`PARSE_DEFAULT_DEBUG`] becomes when its derivation is pointed at the door the budget
+  /// is enforced on** — the same loop, the same [`MIN_HEADROOM`], over
+  /// [`measured::CONSUMER_LOSSLESS_ABORTS_AT`] instead.
+  ///
+  /// 128, from 667 and 3 — `128 × 3 = 384 < 667`, and `256 × 3 = 768` is not.
+  ///
+  /// **Nothing reads it, and that is the point of it existing.** The measurement it rests on is
+  /// answerable to a bisection; a paragraph saying "and the answer would be 128" is answerable to
+  /// nobody, and would be the third figure in this file's history to go stale while reading as
+  /// current. Deriving it here means the number moves when the row does, the shipped guards can
+  /// state their relation to it, and taking the decision is deleting these two constants rather
+  /// than re-doing the arithmetic.
+  ///
+  /// It also settles a discrepancy worth recording: the issue that found the mis-pointing inferred
+  /// a ~13× ratio, arrived at ~663 — within 1% of the measured 667 — and then read the loop's
+  /// *guard* (`d × 2 × 3 < C`) as its criterion instead of its exit state (`d × 3 < C`), landing on
+  /// 64. On its own figure this derivation gives 128.
+  pub(crate) const PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW: usize = {
+    let mut depth = 1;
+    while depth * 2 * MIN_HEADROOM < measured::CONSUMER_LOSSLESS_ABORTS_AT {
+      depth *= 2;
+    }
+    depth
+  };
+
+  /// The release twin of [`PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW`], from
+  /// [`measured::CONSUMER_LOSSLESS_RELEASE_ABORTS_AT`].
+  ///
+  /// 1024, from 3282 and 3 — `1024 × 3 = 3072 < 3282`, and `2048 × 3 = 6144` is not. Read by
+  /// nothing, for the reason its debug twin gives.
+  ///
+  /// **This is a derivation and not a floor**, which is what the release bisection buys: it is the
+  /// first release figure in this file that does not stand in for a measurement nobody took.
+  pub(crate) const PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW: usize = {
+    let mut depth = 1;
+    while depth * 2 * MIN_HEADROOM < measured::CONSUMER_LOSSLESS_RELEASE_ABORTS_AT {
       depth *= 2;
     }
     depth
@@ -400,13 +626,21 @@ pub(crate) mod policy {
   /// [`RecursionLimitReached`](crate::error::RecursionLimitReached) naming the knob, rather than an
   /// abort.
   ///
-  /// **What would raise it:** the same five-axis bisection [`measured::CONSUMER_ABORTS_AT`]
-  /// records, run against a release build — architecture, the primary dialect, a second dialect,
-  /// that dialect's generic brackets, and the alternative source representation. Until all five
-  /// exist, a release `CONSUMER_ABORTS_AT` would be one reading standing in for a table, which is
-  /// the shape this whole file refuses. When they exist, add them to [`measured`], derive this the
-  /// way [`PARSE_DEFAULT_DEBUG`] is derived, and delete the *provisional* equality assertion that
-  /// names this constant.
+  /// **What would raise it:** the same five-axis bisection
+  /// [`measured::CONSUMER_SYNTACTIC_ABORTS_AT`] records, run against a release build —
+  /// architecture, the primary dialect, a second dialect, that dialect's generic brackets, and the
+  /// alternative source representation. Until all five exist, a release figure would be one
+  /// reading standing in for a table, which is the shape this whole file refuses. When they exist,
+  /// add them to [`measured`], derive this the way [`PARSE_DEFAULT_DEBUG`] is derived, and delete
+  /// the *provisional* equality assertion that names this constant.
+  ///
+  /// **That sweep has now been run — against the lossless door, not this one.**
+  /// [`measured::CONSUMER_LOSSLESS_RELEASE_ABORTS_AT`] is a release table over seven cells of the
+  /// door the budget is enforced on, and [`PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW`] is what
+  /// this constant's own formula makes of it. So the release arm is no longer blocked on a missing
+  /// measurement; it is blocked on the same decision the debug arm is, because deriving one arm
+  /// from the lossless row and flooring the other against the syntactic row would ship a pair whose
+  /// two halves describe two different populations.
   pub(crate) const PARSE_DEFAULT_RELEASE: usize = PARSE_DEFAULT_DEBUG;
 
   /// The cell this build selects, and the value
@@ -449,7 +683,7 @@ pub(crate) mod policy {
   #[cfg(feature = "stacker")]
   pub(crate) const SEGMENTED_PRATT_DEBUG: usize = {
     let mut depth = 1;
-    while depth * 2 * measured::CONSUMER_BYTES_PER_LEVEL <= SEGMENT_MEMORY_CEILING {
+    while depth * 2 * measured::CONSUMER_SYNTACTIC_BYTES_PER_LEVEL <= SEGMENT_MEMORY_CEILING {
       depth *= 2;
     }
     depth
@@ -516,7 +750,9 @@ pub(crate) mod policy {
 /// The cost is the message: `panic!` in a const context takes a string literal and no arguments, so
 /// these cannot print the numbers they compared. They name what to go and read instead.
 const _: () = {
-  use measured::{CONSUMER_ABORTS_AT, CONSUMER_BYTES_PER_LEVEL, STACK, TOKORA_ABORTS_AT};
+  use measured::{
+    CONSUMER_SYNTACTIC_ABORTS_AT, CONSUMER_SYNTACTIC_BYTES_PER_LEVEL, STACK, TOKORA_ABORTS_AT,
+  };
   use policy::{
     MIN_HEADROOM, MIN_MARGIN_TENTHS, PARSE_DEFAULT, PARSE_DEFAULT_DEBUG, PARSE_DEFAULT_RELEASE,
   };
@@ -524,12 +760,12 @@ const _: () = {
   // THE NUMBER, PINNED. Not "inside a band the derivation would tolerate" — the value the
   // derivation produces, and no other. 64 fails this, and so do 1, 32 and 1024.
   assert!(
-    PARSE_DEFAULT_DEBUG * MIN_HEADROOM < CONSUMER_ABORTS_AT
-      && PARSE_DEFAULT_DEBUG * 2 * MIN_HEADROOM >= CONSUMER_ABORTS_AT,
+    PARSE_DEFAULT_DEBUG * MIN_HEADROOM < CONSUMER_SYNTACTIC_ABORTS_AT
+      && PARSE_DEFAULT_DEBUG * 2 * MIN_HEADROOM >= CONSUMER_SYNTACTIC_ABORTS_AT,
     "PARSE_DEFAULT_DEBUG is not the number its own derivation produces — the DEEPEST power of two \
-     that fits MIN_HEADROOM times under CONSUMER_ABORTS_AT. Both halves matter: the first is the \
-     safety requirement, the second is what makes it a derivation rather than a bound satisfied \
-     by 1."
+     that fits MIN_HEADROOM times under CONSUMER_SYNTACTIC_ABORTS_AT. Both halves matter: the \
+     first is the safety requirement, the second is what makes it a derivation rather than a \
+     bound satisfied by 1."
   );
   // THE STANDING ORDER between the two profiles, and the one that survives the release sweep. A
   // release frame is cheaper than a debug one, so a release budget may be larger and may never be
@@ -542,6 +778,11 @@ const _: () = {
   // THE PROVISIONAL LINE. **Delete this when, and only when, the release bisection exists** —
   // see PARSE_DEFAULT_RELEASE for the five axes it owes. Until then, a release value above the
   // debug one is a number nobody measured, and this is what stops it being written.
+  //
+  // A release bisection now exists, and it is of the OTHER DOOR: `CONSUMER_LOSSLESS_RELEASE_*`.
+  // That does not license deleting this line, because this pair is derived from the syntactic row
+  // and lifting one arm of a pair onto a different population is the defect one layer up. The
+  // line goes when both arms move together; see `policy`'s module header.
   assert!(
     PARSE_DEFAULT_RELEASE == PARSE_DEFAULT_DEBUG,
     "the release parse default has been raised above the debug one without a release measurement \
@@ -567,14 +808,14 @@ const _: () = {
   );
 
   // THE WHOLE ORIGINAL DEFECT, AS ONE INEQUALITY, now stated over the derived value.
-  // `PARSE_DEFAULT_DEPTH` was 64 and `CONSUMER_ABORTS_AT` is 51, so a derivation producing 64
-  // fails here: the native stack got there before the limiter could, and the refusal the budget
-  // exists to produce was unreachable.
+  // `PARSE_DEFAULT_DEPTH` was 64 and `CONSUMER_SYNTACTIC_ABORTS_AT` is 51, so a derivation
+  // producing 64 fails here: the native stack got there before the limiter could, and the refusal
+  // the budget exists to produce was unreachable.
   assert!(
-    PARSE_DEFAULT_DEBUG * MIN_MARGIN_TENTHS <= CONSUMER_ABORTS_AT * 10,
-    "the derived debug default does not clear CONSUMER_ABORTS_AT — the depth at which a measured \
-     consumer grammar aborts on a 2 MiB thread — by MIN_MARGIN_TENTHS, the margin this crate \
-     already requires of such a number. See PARSE_DEFAULT_DEPTH's derivation."
+    PARSE_DEFAULT_DEBUG * MIN_MARGIN_TENTHS <= CONSUMER_SYNTACTIC_ABORTS_AT * 10,
+    "the derived debug default does not clear CONSUMER_SYNTACTIC_ABORTS_AT — the depth at which a \
+     measured consumer grammar aborts on a 2 MiB thread — by MIN_MARGIN_TENTHS, the margin this \
+     crate already requires of such a number. See PARSE_DEFAULT_DEPTH's derivation."
   );
   assert!(
     MIN_HEADROOM * 10 > MIN_MARGIN_TENTHS,
@@ -583,8 +824,17 @@ const _: () = {
   );
   // A guard against the derivation being 'repaired' by re-reading the wrong row: sizing against
   // tokora's own 125 admits 64, which is exactly the number that was wrong.
+  //
+  // **THIS ONE IS DOOR-SPECIFIC AND DOES NOT CARRY OVER.** What it actually says is "the consumer
+  // row is the tighter of the two", and that was true only because the consumer row was read at a
+  // door whose levels are heavier than tokora's own Pratt frames. On the door the budget is
+  // enforced on the relation legitimately inverts — a lossless descent is ~3.1 KiB against
+  // tokora's ~16.4 KiB — so repointing the derivation makes this line fail for a correct reason.
+  // It has to be re-derived rather than flipped: the property worth keeping is that the row a
+  // default is derived from is the row that *binds* it, which is a statement about which door, not
+  // about which number is larger.
   assert!(
-    TOKORA_ABORTS_AT > CONSUMER_ABORTS_AT,
+    TOKORA_ABORTS_AT > CONSUMER_SYNTACTIC_ABORTS_AT,
     "the two measured rows have stopped disagreeing, which means one was edited to match the \
      other rather than re-measured"
   );
@@ -596,16 +846,16 @@ const _: () = {
   // tokora compiled for itself: re-introducing a `cfg!(feature = "stacker")` arm here fails this
   // line, because 1024 levels of the heaviest measured grammar is ≈41 MiB and the thread is 2.
   //
-  // The debug cell is what it is priced against, because `CONSUMER_BYTES_PER_LEVEL` is a debug
-  // figure and pricing a release budget with a debug cost is the conservative direction.
+  // The debug cell is what it is priced against, because `CONSUMER_SYNTACTIC_BYTES_PER_LEVEL` is
+  // a debug figure and pricing a release budget with a debug cost is the conservative direction.
   assert!(
-    PARSE_DEFAULT_DEBUG * CONSUMER_BYTES_PER_LEVEL < STACK,
+    PARSE_DEFAULT_DEBUG * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL < STACK,
     "an unconfigured parse can reach more native stack than the 2 MiB the derivation is stated \
      on. A budget that only a segmented path could survive does not belong on the cell every \
      unsegmented `descend` reads; see RecursionLimiter::SEGMENTED_PRATT_DEPTH."
   );
   assert!(
-    PARSE_DEFAULT_RELEASE * CONSUMER_BYTES_PER_LEVEL < STACK,
+    PARSE_DEFAULT_RELEASE * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL < STACK,
     "the release parse default, priced at the DEBUG per-level cost, no longer fits the 2 MiB \
      thread. Once `measured` carries a release per-level figure this assertion should be priced \
      at that one instead — until then the debug cost is the only one there is, and it is the \
@@ -613,11 +863,131 @@ const _: () = {
   );
 };
 
+/// **The door the budget is enforced on, and the derivation this crate does not yet ship.**
+///
+/// Nothing in the block above reads a lossless figure, so without this one the re-measurement
+/// would be four `pub(crate)` constants and a paragraph — which is the shape every stale number in
+/// this file's history had. What these assertions buy is that the *relations* the decision rests on
+/// are compiled: that the two doors are far enough apart to be two populations, that the shipped
+/// default is below rather than above what the right row supports, that the repointed pair fits the
+/// 2 MiB thread the whole derivation is stated on, and that the release arm cannot be lifted
+/// without re-pricing the guard that currently floors it.
+const _: () = {
+  use measured::{
+    CONSUMER_DEEPEST_SHIPPED_DOCUMENT, CONSUMER_LOSSLESS_ABORTS_AT,
+    CONSUMER_LOSSLESS_BYTES_PER_LEVEL, CONSUMER_LOSSLESS_RELEASE_ABORTS_AT,
+    CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL, STACK, TOKORA_ABORTS_AT,
+  };
+  use policy::{
+    MIN_HEADROOM, MIN_MARGIN_TENTHS, PARSE_DEFAULT_DEBUG, PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW,
+    PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW,
+  };
+
+  // The repointed pair, pinned by the same two-halved shape the shipped pair gets: within the
+  // safety requirement, and the DEEPEST power of two that is.
+  assert!(
+    PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW * MIN_HEADROOM < CONSUMER_LOSSLESS_ABORTS_AT
+      && PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW * 2 * MIN_HEADROOM >= CONSUMER_LOSSLESS_ABORTS_AT,
+    "PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW is not the number the shipped derivation produces \
+     from the lossless row, so it has stopped being what it claims to be — the answer to 'what \
+     would this crate ship if the derivation were pointed at the door the budget is spent on'."
+  );
+  assert!(
+    PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW * MIN_HEADROOM < CONSUMER_LOSSLESS_RELEASE_ABORTS_AT
+      && PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW * 2 * MIN_HEADROOM
+        >= CONSUMER_LOSSLESS_RELEASE_ABORTS_AT,
+    "PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW is not what the shipped derivation produces from \
+     the release lossless row"
+  );
+  assert!(
+    PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW * MIN_MARGIN_TENTHS <= CONSUMER_LOSSLESS_ABORTS_AT * 10,
+    "the repointed debug default would not clear its own binding cell by MIN_MARGIN_TENTHS, the \
+     margin this crate already requires of such a number"
+  );
+
+  // THE DOOR MISMATCH, AS A COMPILED FACT. Measured at ~13x per level; four is a floor loose
+  // enough to survive another platform's codegen and tight enough that the two rows converging
+  // means one of them was edited to match the other rather than re-measured. If they ever do
+  // converge, the argument for two rows has gone with them and this file needs re-reading rather
+  // than a wider constant.
+  assert!(
+    CONSUMER_LOSSLESS_ABORTS_AT > measured::CONSUMER_SYNTACTIC_ABORTS_AT * 4,
+    "the syntactic and lossless consumer rows have converged. They are readings of two different \
+     doors whose per-level costs differ by roughly an order of magnitude, so convergence means a \
+     row was edited rather than re-measured — see `measured`'s header for what each door spends."
+  );
+  // And the relation that makes the *tokora* row incomparable with the lossless one, stated so a
+  // reader who finds `TOKORA_ABORTS_AT > CONSUMER_SYNTACTIC_ABORTS_AT` above does not conclude the
+  // same ordering must hold here. A Pratt frame is the heavier kind; the lossless row is looser
+  // BECAUSE its levels are cheaper, which is the opposite of evidence that something was edited.
+  assert!(
+    CONSUMER_LOSSLESS_ABORTS_AT > TOKORA_ABORTS_AT,
+    "the lossless consumer row has fallen to tokora's own Pratt-frame row, which would mean a \
+     lossless descent had become as expensive as a Pratt frame"
+  );
+  // A release descent is cheaper than a debug one, so more of them fit the same thread. The same
+  // standing order the shipped pair carries, on the row that now has both halves measured.
+  assert!(
+    CONSUMER_LOSSLESS_RELEASE_ABORTS_AT > CONSUMER_LOSSLESS_ABORTS_AT,
+    "the release lossless row is at or below the debug one, which inverts the only thing known \
+     about the two profiles"
+  );
+
+  // **THE DIRECTION OF THE DEFECT.** The shipped default is derived from the wrong door, and this
+  // is the line that says which way that cuts: below what the right row supports, so the cost is
+  // depth a real document could have used rather than an abort. If this ever inverts, the
+  // mis-pointing has stopped being conservative and the repoint stops being a decision.
+  assert!(
+    PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW > PARSE_DEFAULT_DEBUG,
+    "the shipped debug default now EXCEEDS what the door it is enforced on supports. It was \
+     derived from a syntactic-door reading, which was safe only while that door's levels were the \
+     more expensive ones; see `measured::CONSUMER_LOSSLESS_ABORTS_AT`."
+  );
+  // **AND WHAT THAT DIRECTION COSTS**, which is the half no arithmetic over the two rows can
+  // reach. The shipped default does not clear the deepest document the measured consumer already
+  // ships by the 2x that same consumer requires of its own nesting ceiling — a floor it escapes
+  // only because the number that binds its lossless door is this one rather than its own. If this
+  // line ever fails, the consumer-side half of the case for repointing has been retired and the
+  // remaining half is that the row is still the wrong door's; re-read `policy`'s header rather
+  // than deleting it.
+  assert!(
+    PARSE_DEFAULT_DEBUG < CONSUMER_DEEPEST_SHIPPED_DOCUMENT * 2,
+    "the shipped default now clears the deepest document the measured consumer ships by 2x. That \
+     retires half the case for repointing the derivation; see `policy`'s module header for the \
+     half it does not."
+  );
+
+  // Both repointed arms against the 2 MiB thread, each at ITS OWN per-level cost — which is what
+  // the shipped release assertion cannot do, since `measured` had no release price until now.
+  assert!(
+    PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW * CONSUMER_LOSSLESS_BYTES_PER_LEVEL < STACK,
+    "the repointed debug default does not fit the 2 MiB thread at the lossless per-level cost"
+  );
+  assert!(
+    PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW * CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL < STACK,
+    "the repointed release default does not fit the 2 MiB thread at the RELEASE lossless \
+     per-level cost"
+  );
+  // And the fourth consequence of repointing, as a fact rather than a sentence: the repointed
+  // release arm does NOT fit at the debug price, so the provisional guard above — which prices the
+  // release budget at the debug cost because that was the only cost there was — has to be
+  // re-priced at the release row in the same commit that lifts the arm. Deleting the provisional
+  // `==` without doing so trades a floor for an abort.
+  assert!(
+    PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW * CONSUMER_LOSSLESS_BYTES_PER_LEVEL >= STACK,
+    "the repointed release arm now fits the 2 MiB thread even at the DEBUG per-level cost, which \
+     retires the reason the shipped release assertion has to be re-priced before that arm is \
+     lifted. Re-read that assertion rather than deleting this line."
+  );
+};
+
 /// The derivation of [`RecursionLimiter::SEGMENTED_PRATT_DEPTH`], on the same terms as the block
 /// above: every cell of the profile matrix pinned by name, arithmetic second.
 #[cfg(feature = "stacker")]
 const _: () = {
-  use measured::{CONSUMER_ABORTS_AT, CONSUMER_BYTES_PER_LEVEL, TOKORA_ABORTS_AT};
+  use measured::{
+    CONSUMER_SYNTACTIC_ABORTS_AT, CONSUMER_SYNTACTIC_BYTES_PER_LEVEL, TOKORA_ABORTS_AT,
+  };
   use policy::{
     SEGMENT_MEMORY_CEILING, SEGMENTED_PRATT, SEGMENTED_PRATT_DEBUG, SEGMENTED_PRATT_RELEASE,
   };
@@ -625,8 +995,8 @@ const _: () = {
   // 512 fails this, and so did every other value in the 501..=1632 band the inequality-only
   // guards accepted. Both halves again: within the ceiling, and the deepest such power of two.
   assert!(
-    SEGMENTED_PRATT_DEBUG * CONSUMER_BYTES_PER_LEVEL <= SEGMENT_MEMORY_CEILING
-      && SEGMENTED_PRATT_DEBUG * 2 * CONSUMER_BYTES_PER_LEVEL > SEGMENT_MEMORY_CEILING,
+    SEGMENTED_PRATT_DEBUG * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL <= SEGMENT_MEMORY_CEILING
+      && SEGMENTED_PRATT_DEBUG * 2 * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL > SEGMENT_MEMORY_CEILING,
     "SEGMENTED_PRATT_DEBUG is not the number its own derivation produces — the DEEPEST power of \
      two whose segments fit inside SEGMENT_MEMORY_CEILING at the binding per-level cost. Move the \
      memory policy, not the published depth."
@@ -663,7 +1033,7 @@ const _: () = {
   // memory: the budget must buy a depth the thread stack could not have — otherwise the feature is
   // paying for a ceiling it did not raise.
   assert!(
-    SEGMENTED_PRATT_DEBUG > CONSUMER_ABORTS_AT * 4,
+    SEGMENTED_PRATT_DEBUG > CONSUMER_SYNTACTIC_ABORTS_AT * 4,
     "SEGMENTED_PRATT_DEPTH is not meaningfully past what a 2 MiB thread already gave that \
      grammar, so the feature raised no ceiling"
   );
@@ -736,6 +1106,27 @@ impl RecursionLimiter {
   /// 16 is the largest power of two leaving more than 3× under the binding cell of 51 — the next
   /// one up, 32, leaves 1.59×, which is *below* the 1.9× that made 64 look safe and well inside
   /// the range a different platform's codegen moves. It clears tokora's own tightest cell by 7.8×.
+  ///
+  /// # **The 51 is a measurement of a door this budget is never spent at**
+  ///
+  /// Those five axes were varied over architecture, dialect, shape and source backing, and held
+  /// one thing fixed that was not written down: they are all readings of that consumer's
+  /// **syntactic** door, which takes no [`descend`](crate::InputRef::descend) and therefore spends
+  /// none of this budget. What spends it is that consumer's **lossless** door — one level per
+  /// nesting delimiter — where a level costs about eleven times less. Re-running the same
+  /// bisection there gives a binding cell of **667** descents rather than 51 levels, and the same
+  /// formula over it gives **128**; the release table, which had never been taken, gives 3282 and
+  /// **1024**. The figures, the axes and the survive/abort pairs are on
+  /// this module's private `measured`, and what taking the decision moves with it is on the
+  /// header of its `policy` sibling.
+  ///
+  /// **The direction is the recoverable one**, which is why the value is still 16: the wrong row is
+  /// the *tighter* one, so what the mis-pointing costs is depth rather than safety. What it costs
+  /// is real, though — the measured consumer's deepest shipped fixture spends 11 of these levels
+  /// and an ordinary filter query 10 or 11 (an argument list's `(` is a one-off toll, so
+  /// `f(where: {a: {b: [1]}})` spends 5 for what reads as three-deep), so 16 leaves 1.45× over
+  /// documents that already exist, against the 2× floor that consumer enforces on its *own* nesting
+  /// ceiling at compile time. It escapes that floor only because the binding number is this one.
   ///
   /// **This is a reduction, and a grammar that legitimately nests deeper must now say so** — with
   /// [`with_limitation`](Self::with_limitation) through

--- a/tokora/src/state/recursion_tracker/mod.rs
+++ b/tokora/src/state/recursion_tracker/mod.rs
@@ -88,9 +88,9 @@ impl RecursionLimitExceeded {
 /// never builds its recursion budget through it — so its constructors inherit this same
 /// general-purpose 500 rather than requesting the parser's own.
 ///
-/// That constant is **32** in a debug build and **256** in a release one, under every feature, and
-/// the whole derivation — including why it was 16, why 16 was measured at the wrong door, why 64
-/// was wrong before that, and why no feature is allowed to move it — is on
+/// That constant is **32**, in every build and under every feature, and the whole derivation —
+/// including why it was 16, why 16 was measured at the wrong door, why 64 was wrong before that,
+/// why no feature is allowed to move it, and why the profile is not allowed to either — is on
 /// [`PARSE_DEFAULT_DEPTH`](Self::PARSE_DEFAULT_DEPTH) rather than repeated here. What belongs here
 /// is the measurement table it is *not* derived from, because that table is this type's own and
 /// keeps being mistaken for the answer:
@@ -492,19 +492,16 @@ pub(crate) mod measured {
   pub(crate) const CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL: usize =
     STACK / CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT;
 
-  /// Bytes of native stack one **descent** of that consumer's lossless door spends, debug —
-  /// derived from [`CONSUMER_LOSSLESS_ABORTS_AT`] the same way. ~3.1 KiB.
-  pub(crate) const CONSUMER_LOSSLESS_BYTES_PER_LEVEL: usize = STACK / CONSUMER_LOSSLESS_ABORTS_AT;
-
-  /// The same, release — derived from [`CONSUMER_LOSSLESS_RELEASE_ABORTS_AT`]. ~0.6 KiB.
-  ///
-  /// **This is the figure that unblocks the release arm.** The provisional assertion that keeps
-  /// [`PARSE_DEFAULT_RELEASE`](super::policy::PARSE_DEFAULT_RELEASE) at a floor prices the release
-  /// budget at the *debug* per-level cost, because until now that was the only cost there was; a
-  /// release budget large enough to be worth having does not fit a 2 MiB thread at a debug price
-  /// and never could.
-  pub(crate) const CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL: usize =
-    STACK / CONSUMER_LOSSLESS_RELEASE_ABORTS_AT;
+  // **THE TWO LOSSLESS PER-LEVEL CONSTANTS ARE DELETED**, and not because the figures stopped
+  // being true. They were `STACK / CONSUMER_LOSSLESS_ABORTS_AT` and its release twin, ~3.1 KiB and
+  // ~0.6 KiB, and they existed to price assertions about a shipped default derived from the
+  // lossless row. The shipped default is priced against the heaviest MODELLED row instead — the
+  // lossless level being the cheapest population that spends the cell, a budget that fits at the
+  // heavy price cannot fail to fit at this one — so both constants lost their only readers.
+  //
+  // Keeping a `pub(crate)` constant alive by inventing a relation for it to appear in is how a
+  // file acquires guards that cannot fail. Both figures remain derivable in one division from
+  // `STACK` and the abort rows above, which is where they are cited.
 
   /// The descents the **deepest document that consumer actually ships** spends at the door the
   /// budget is enforced on, over the 472 fixtures in its tree.
@@ -665,34 +662,67 @@ pub(crate) mod policy {
     measured::CONSUMER_SYNTACTIC_BYTES_PER_LEVEL,
   );
 
-  /// **The parse-side default in a release build — now a DERIVATION, not a floor.**
+  /// **The parse-side default in a release build — equal to the debug one, and NOT because no
+  /// release measurement exists.**
   ///
-  /// **256**, by the same [`two_tier`] rule over [`SPENDING_MIN_RELEASE`] and
-  /// [`measured::CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL`]. Tier one: `256 × 3 = 768 < 3282`
-  /// — and so is `512 × 3 = 1536`, so **tier one does not refuse the next doubling**. Tier two
-  /// does: `256 × 4 452 B = 1.09 MiB < 2 MiB`, `512 × 4 452 B = 2.17 MiB` is not.
+  /// One does: [`measured::CONSUMER_LOSSLESS_RELEASE_ABORTS_AT`] and
+  /// [`measured::CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT`], and what this constant's own rule makes of
+  /// them is [`OPTIMIZED_PARSE`] — 256. That figure is real, defensible and **published for a
+  /// consumer to pass**. It is not shipped as this default, and the reason is the whole of what
+  /// this constant now records.
   ///
-  /// So the release arm is fixed by the fit and the debug arm by the headroom, and each tier is
-  /// the binding one somewhere. Deleting either changes a shipped number.
+  /// # `debug_assertions` cannot express the fact that sets the frame price, and nothing can
   ///
-  /// It is a floor no longer because the sweep it owed exists: see
-  /// [`measured::CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT`] and
-  /// [`measured::CONSUMER_LOSSLESS_RELEASE_ABORTS_AT`]. The provisional `==` assertion that held it
-  /// equal to the debug cell is deleted with it.
+  /// The arms diverged for one revision, and that revision shipped a process-level abort:
   ///
-  /// **1024 was refused, and by a guard rather than by an argument.** The single-tier derivation
-  /// over the release lossless row gives 1024, which collides exactly with
-  #[cfg_attr(
-    feature = "stacker",
-    doc = "[`SEGMENTED_PRATT_RELEASE`] — so `stacker` would have bought zero extra depth in a"
-  )]
-  #[cfg_attr(
-    not(feature = "stacker"),
-    doc = "`SEGMENTED_PRATT_RELEASE` (`stacker` only) — so that feature would have bought zero \
-           extra depth in a"
-  )]
-  /// release build, which is the one thing the segmented constant exists to be.
-  pub(crate) const PARSE_DEFAULT_RELEASE: usize = two_tier(
+  /// - `debug_assertions` is **not** `opt-level`. A build with `debug-assertions = false` at
+  ///   `opt-level = 0` selects the release arm and pays debug frame prices. At 256 against the
+  ///   heaviest modelled debug level that is `256 × 41 120 B ≈ 10 MiB` on a 2 MiB thread — an
+  ///   abort with no diagnostic, which is exactly the failure this whole file exists to delete.
+  /// - It is also **per crate**, and the frames being paid are the **consumer's**. A build script
+  ///   reading cargo's `OPT_LEVEL` would fix the first bullet and not the second: it observes
+  ///   *tokora's* optimisation, while the recursion is spent in the caller's productions. A
+  ///   per-package profile override, or simply a consumer compiled differently from its
+  ///   dependency, reinstates the mismatch with every signal available to this crate reading
+  ///   "release".
+  ///
+  /// So there is no proxy — not one this crate has, and not one it could add — for the quantity
+  /// the release figure is conditioned on. **A number that is only safe when a fact holds, chosen
+  /// by a signal that cannot observe that fact, is not a default.** It is an argument the caller
+  /// has to make, and [`OPTIMIZED_PARSE`] is what they make it with.
+  ///
+  /// # What a future round has to establish before diverging
+  ///
+  /// Not "a better profile proxy". **A way to know the per-level cost of the frames this budget
+  /// will actually bound**, which is a fact about the caller's compilation and not about tokora's.
+  /// Until that exists the two arms hold one number, and the assertion below is stated over the
+  /// *debug* price for both of them precisely because either arm may be selected by a build paying
+  /// it.
+  pub(crate) const PARSE_DEFAULT_RELEASE: usize = PARSE_DEFAULT_DEBUG;
+
+  /// **What a release build actually supports, published so a consumer can opt into it** — 256,
+  /// and nothing installs it.
+  ///
+  /// Derived by [`two_tier`] over the release rows exactly as [`PARSE_DEFAULT_DEBUG`] is derived
+  /// over the debug ones: `256 × 3 = 768 < 3282` for the headroom tier, and
+  /// `256 × 4 452 B = 1.09 MiB < 2 MiB` for the fit — with `512 × 4 452 B = 2.17 MiB` refused by
+  /// the fit where the headroom tier alone would have allowed 1024.
+  ///
+  /// It exists because a measurement nobody can reach is not an opt-in. The release sweep is what
+  /// makes 256 defensible; without a constant a consumer would have to re-run the bisection to
+  /// arrive at a number this crate already knows.
+  ///
+  /// # The precondition, stated as narrowly as it actually is
+  ///
+  /// **Every frame the budget bounds must be an optimised one** — tokora's *and* the caller's
+  /// productions, which is where the recursion is actually spent. That is a fact about the
+  /// caller's build, and it is the fact [`PARSE_DEFAULT_RELEASE`] records that no signal available
+  /// to this crate can read. Only the caller knows it, which is why this is opt-in and why the
+  /// shape is the same one [`SEGMENTED_PRATT`](self::SEGMENTED_PRATT) already uses: a published
+  /// figure to hand to
+  /// [`with_recursion_limiter`](crate::input::InputContext::with_recursion_limiter), not a default
+  /// anybody inherits.
+  pub(crate) const OPTIMIZED_PARSE: usize = two_tier(
     SPENDING_MIN_RELEASE,
     measured::CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL,
   );
@@ -821,8 +851,8 @@ const _: () = {
     TOKORA_ABORTS_AT, TOKORA_RELEASE_ABORTS_AT,
   };
   use policy::{
-    MIN_HEADROOM, MIN_MARGIN_TENTHS, PARSE_DEFAULT, PARSE_DEFAULT_DEBUG, PARSE_DEFAULT_RELEASE,
-    SPENDING_MIN_DEBUG, SPENDING_MIN_RELEASE,
+    MIN_HEADROOM, MIN_MARGIN_TENTHS, OPTIMIZED_PARSE, PARSE_DEFAULT, PARSE_DEFAULT_DEBUG,
+    PARSE_DEFAULT_RELEASE, SPENDING_MIN_DEBUG, SPENDING_MIN_RELEASE,
   };
 
   // THE NUMBER, PINNED — both arms, and by BOTH tiers. Not "inside a band the derivation would
@@ -840,29 +870,65 @@ const _: () = {
      per-level price, and the deepest power of two meeting both. See `policy::two_tier`: the two \
      tiers are not interchangeable and collapsing them moves this number."
   );
+  // THE OPT-IN FIGURE, pinned by the same two-halved shape — because it is a derivation, and the
+  // shipped release arm is no longer one. 512 fails the fit clause, 1024 fails it harder, and 128
+  // fails the third: this is the deepest power of two the release rows support.
   assert!(
-    PARSE_DEFAULT_RELEASE * MIN_HEADROOM < SPENDING_MIN_RELEASE
-      && PARSE_DEFAULT_RELEASE * CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL < STACK
-      && (PARSE_DEFAULT_RELEASE * 2 * MIN_HEADROOM >= SPENDING_MIN_RELEASE
-        || PARSE_DEFAULT_RELEASE * 2 * CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL >= STACK),
-    "PARSE_DEFAULT_RELEASE is not the number the same two-tier derivation produces over the \
-     release rows. It is a derivation now rather than a floor, so it has the same obligation the \
-     debug arm has."
+    OPTIMIZED_PARSE * MIN_HEADROOM < SPENDING_MIN_RELEASE
+      && OPTIMIZED_PARSE * CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL < STACK
+      && (OPTIMIZED_PARSE * 2 * MIN_HEADROOM >= SPENDING_MIN_RELEASE
+        || OPTIMIZED_PARSE * 2 * CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL >= STACK),
+    "OPTIMIZED_PARSE is not the number the two-tier derivation produces over the release rows. It \
+     is the figure this crate publishes for a consumer to opt into, so it carries the same \
+     obligation a shipped default does."
+  );
+  // AND THE REASON IT IS NOT THE DEFAULT, as a compiled fact rather than a paragraph: it does NOT
+  // survive the debug frame price. That is the whole distinction between a figure a caller may
+  // choose and a figure this crate may install, and if it ever stopped holding — if 256 became
+  // safe at debug prices too — the argument for opt-in would have gone with it and this constant
+  // should be re-read rather than kept.
+  assert!(
+    OPTIMIZED_PARSE * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL >= STACK,
+    "OPTIMIZED_PARSE now fits the 2 MiB thread at the DEBUG per-level cost, which retires the \
+     reason it is opt-in rather than the shipped release default. See PARSE_DEFAULT_RELEASE."
+  );
+  // An opt-in that buys nothing is not an opt-in. This is the falsifiable form of what the old
+  // `PARSE_DEFAULT_RELEASE >= PARSE_DEFAULT_DEBUG` was for: the release rows support MORE than the
+  // shipped default, and the two are derived from different inputs, so it can fail.
+  assert!(
+    OPTIMIZED_PARSE > PARSE_DEFAULT,
+    "OPTIMIZED_PARSE is not above the shipped default, so opting into it buys no depth and the \
+     constant has collapsed into the one it exists to be an alternative to"
   );
 
-  // THE STANDING ORDER between the two profiles, and the one that survives the release sweep. A
-  // release frame is cheaper than a debug one, so a release budget may be larger and may never be
-  // smaller; getting this backwards ships debug-sized frames against a release-sized budget.
+  // **A2 AND A3 ARE BOTH GONE, and deleting them is the point rather than a tidy-up.**
+  //
+  // A2 was `PARSE_DEFAULT_RELEASE >= PARSE_DEFAULT_DEBUG` and A3 was `== `. With the release arm
+  // DEFINED as the debug one, neither can fail for any value the constants can legally take —
+  // they are the same expression compared with itself. A guard that cannot fail is decoration, and
+  // this file's own rule is that a range-shaped guard which reads like a derivation is worse than
+  // no guard at all. A2's intent survives above as `OPTIMIZED_PARSE > PARSE_DEFAULT`, which is
+  // stated over two constants derived from different rows and therefore has content.
+  //
+  // What replaces A3 is not an equality. **It is the invariant the equality was standing in for**,
+  // and it is the guard that held at the last revision where this file was correct: whichever arm
+  // `debug_assertions` selects, the result must survive the DEBUG frame price. That is what makes
+  // the proxy's inaccuracy harmless instead of fatal — an `opt-level = 0, debug-assertions = false`
+  // build selects the release arm and pays debug prices, and a consumer compiled differently from
+  // tokora does the same with every signal this crate can read saying "release".
+  //
+  // **A future round that wants to diverge the arms must falsify this line, and to do that it needs
+  // a way to know the per-level cost of the CALLER's frames** — not a better profile proxy, which
+  // is a fact about tokora's compilation and not about the frames the budget bounds.
   assert!(
-    PARSE_DEFAULT_RELEASE >= PARSE_DEFAULT_DEBUG,
-    "the release parse default is below the debug one, which inverts the only thing known about \
-     the two profiles: a release frame is cheaper, so its budget can only be the larger"
+    PARSE_DEFAULT_DEBUG * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL < STACK
+      && PARSE_DEFAULT_RELEASE * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL < STACK,
+    "a shipped parse default does not survive the DEBUG per-level cost. Both arms are priced at it \
+     because `debug_assertions` does not observe `opt-level`, and because it is tokora's flag \
+     while the frames are the consumer's — so either arm can be selected by a build paying debug \
+     prices. Raising one arm needs a signal for the caller's frame cost, not a better profile \
+     proxy; the figure a caller can opt into meanwhile is RecursionLimiter::OPTIMIZED_PARSE_DEPTH."
   );
-  // THE PROVISIONAL LINE IS GONE. It held the release arm equal to the debug one and said so:
-  // "raising it means running the five-axis bisection, not extrapolating from debug's ratio."
-  // The bisection was run — `measured::CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT` and its lossless
-  // sibling — so the arm is a derivation and the two now differ. What survives is the standing
-  // `>=` above, which is the half that was never provisional.
 
   // And the selection, so that the published constant is the arm this build's flag names rather
   // than whichever one somebody typed.
@@ -876,6 +942,11 @@ const _: () = {
     "PARSE_DEFAULT does not select the cell `debug_assertions` names"
   );
   assert!(
+    RecursionLimiter::OPTIMIZED_PARSE_DEPTH == OPTIMIZED_PARSE,
+    "OPTIMIZED_PARSE_DEPTH is not the value `policy` derives for it. It is published for a caller \
+     to pass, so editing the published constant alone is the same defect it is on the default."
+  );
+  assert!(
     RecursionLimiter::PARSE_DEFAULT_DEPTH == PARSE_DEFAULT,
     "PARSE_DEFAULT_DEPTH is not the value `policy` derives for this build. If the shipped default \
      should move, move the measurement or the policy it is derived from; editing the published \
@@ -887,12 +958,21 @@ const _: () = {
   // so the native stack got there before the limiter could and the refusal the budget exists to
   // produce was unreachable. Stated on SPENDING_MIN rather than on a fixed row, because which
   // population is tightest is a per-profile fact.
+  //
+  // Stated over the DEBUG row only, and the release half is deliberately not a second clause: both
+  // arms hold one number and SPENDING_MIN_RELEASE is the looser row, so `REL * 19 <= REL_ROW * 10`
+  // is implied by the line below and could not fail on its own. OPTIMIZED_PARSE carries the
+  // release margin, against the row it is actually derived from.
   assert!(
-    PARSE_DEFAULT_DEBUG * MIN_MARGIN_TENTHS <= SPENDING_MIN_DEBUG * 10
-      && PARSE_DEFAULT_RELEASE * MIN_MARGIN_TENTHS <= SPENDING_MIN_RELEASE * 10,
-    "a derived default does not clear the tightest population that spends the cell by \
+    PARSE_DEFAULT * MIN_MARGIN_TENTHS <= SPENDING_MIN_DEBUG * 10,
+    "the shipped default does not clear the tightest population that spends the cell by \
      MIN_MARGIN_TENTHS, the margin this crate already requires of such a number. See \
      PARSE_DEFAULT_DEPTH's derivation."
+  );
+  assert!(
+    OPTIMIZED_PARSE * MIN_MARGIN_TENTHS <= SPENDING_MIN_RELEASE * 10,
+    "the published opt-in figure does not clear the tightest population that spends the cell in a \
+     release build by MIN_MARGIN_TENTHS"
   );
   assert!(
     MIN_HEADROOM * 10 > MIN_MARGIN_TENTHS,
@@ -952,35 +1032,25 @@ const _: () = {
      on. A budget that only a segmented path could survive does not belong on the cell every \
      unsegmented `descend` reads; see RecursionLimiter::SEGMENTED_PRATT_DEPTH."
   );
-  // The release arm, priced at the RELEASE heaviest-modelled cost — which is the re-pricing this
-  // assertion's own text asked for and which `measured::CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT` now
-  // supplies. It is the tier that fixes the release number: 512 fails it where tier one would
-  // have allowed 1024.
-  assert!(
-    PARSE_DEFAULT_RELEASE * CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL < STACK,
-    "the release parse default, priced at the heaviest modelled RELEASE per-level cost, no longer \
-     fits the 2 MiB thread the derivation is stated on."
-  );
-  // **AND THE RESIDUE, NAMED BECAUSE NOTHING CAN CHECK IT.** The two arms now differ, so
-  // `debug_assertions` is observable for the first time — and it is a proxy for the profile, not
-  // for `opt-level`. A build with `debug-assertions = false` at `opt-level = 0` takes the release
-  // arm while paying debug frame prices: 256 levels of the heaviest modelled DEBUG level is 10 MiB
-  // against a 2 MiB thread. Nothing refuses that. There is no `cfg(opt_level)`; `native_stack`'s
-  // red zone is `stacker`-only and sits on the two Pratt prologues, not on the cell this bounds;
-  // and `ci/stack_probe.sh` asserts no threshold by design. The available closure is a `build.rs`
-  // cfg off cargo's `OPT_LEVEL`, which this crate's build script is already shaped to emit — it is
-  // a decision, not an oversight, and this comment is where it is recorded rather than lost.
+  // **THE RESIDUE PARAGRAPH IS GONE, AND ITS INVERSION IS THE POINT OF THIS REVISION.**
   //
-  // This line states the part that IS checkable: the debug arm remains safe at the debug price,
-  // so the residue is confined to the profile combination above and does not reach an ordinary
-  // debug or an ordinary release build.
-  assert!(
-    PARSE_DEFAULT_DEBUG * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL < STACK
-      && PARSE_DEFAULT_RELEASE * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL >= STACK,
-    "either the debug arm has stopped fitting the 2 MiB thread at the debug price, or the release \
-     arm has started fitting it — the second would retire the `debug-assertions = false at \
-     opt-level = 0` residue recorded above, and that is a paragraph to delete rather than a line."
-  );
+  // It used to record that with the arms diverged, an `opt-level = 0, debug-assertions = false`
+  // build took the 256 arm at debug frame prices and nothing refused it — a downgrade from
+  // refused-at-compile-time to documented. That was not residue. It was a process-level abort
+  // reachable from an ordinary cargo profile, and calling it documented did not make it survivable.
+  //
+  // The default is now chosen so that **no profile combination can abort**: both arms hold the
+  // same number and the line above prices both at the debug cost, which is the most any build can
+  // pay. There is nothing left to document here, and the assertion that used to state the residue
+  // ("the release arm does NOT fit at the debug price") is deleted because it is now false — which
+  // is exactly what fixing it looks like.
+  //
+  // A caller who wants the depth a release build genuinely supports takes it explicitly, and takes
+  // responsibility for its own frame prices with it: RecursionLimiter::OPTIMIZED_PARSE_DEPTH
+  // through `InputContext::with_recursion_limiter`. tokora cannot take that responsibility on the
+  // caller's behalf, and the reason is not squeamishness — `debug_assertions` is per crate, and
+  // the frames the budget bounds are the caller's, so no signal available here observes the fact
+  // the figure is conditioned on.
 };
 
 /// **The measured rows themselves**, and the consumer-side fact no arithmetic over them reaches.
@@ -999,12 +1069,11 @@ const _: () = {
 const _: () = {
   use measured::{
     CONSUMER_DEEPEST_SHIPPED_DOCUMENT, CONSUMER_LOSSLESS_ABORTS_AT,
-    CONSUMER_LOSSLESS_BYTES_PER_LEVEL, CONSUMER_LOSSLESS_RELEASE_ABORTS_AT,
-    CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL, CONSUMER_SYNTACTIC_ABORTS_AT,
+    CONSUMER_LOSSLESS_RELEASE_ABORTS_AT, CONSUMER_SYNTACTIC_ABORTS_AT,
     CONSUMER_SYNTACTIC_BYTES_PER_LEVEL, CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT,
-    CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL, STACK, TOKORA_ABORTS_AT, TOKORA_RELEASE_ABORTS_AT,
+    CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL, TOKORA_ABORTS_AT, TOKORA_RELEASE_ABORTS_AT,
   };
-  use policy::{PARSE_DEFAULT_DEBUG, PARSE_DEFAULT_RELEASE};
+  use policy::PARSE_DEFAULT;
 
   // THE DOOR MISMATCH, AS A COMPILED FACT. Measured at ~13x per level; four is a floor loose
   // enough to survive another platform's codegen and tight enough that the two rows converging
@@ -1052,21 +1121,20 @@ const _: () = {
   // moment the repoint happened. With the repoint taken, the obligation inverts — the shipped
   // default must now stay clear of the corpus by the same 2x that consumer enforces on its own
   // nesting ceiling at compile time. 32 over 11 is 2.9x; the release arm has far more.
+  // One clause, not two: both arms hold one number, so a second over PARSE_DEFAULT_RELEASE would
+  // be the same comparison written twice.
   assert!(
-    PARSE_DEFAULT_DEBUG >= CONSUMER_DEEPEST_SHIPPED_DOCUMENT * 2
-      && PARSE_DEFAULT_RELEASE >= CONSUMER_DEEPEST_SHIPPED_DOCUMENT * 2,
-    "a shipped default no longer clears the deepest document the measured consumer ships by 2x — \
-     the floor that consumer holds its OWN ceiling to. Either the default was lowered or the \
+    PARSE_DEFAULT >= CONSUMER_DEEPEST_SHIPPED_DOCUMENT * 2,
+    "the shipped default no longer clears the deepest document the measured consumer ships by 2x \
+     — the floor that consumer holds its OWN ceiling to. Either the default was lowered or the \
      corpus grew; `measured::CONSUMER_DEEPEST_SHIPPED_DOCUMENT` says which."
   );
-  // And the budget still fits the 2 MiB thread at the price of the door that actually spends it,
-  // in both profiles — the cheap side of the same pair the fit tier states on the heavy side.
-  assert!(
-    PARSE_DEFAULT_DEBUG * CONSUMER_LOSSLESS_BYTES_PER_LEVEL < STACK
-      && PARSE_DEFAULT_RELEASE * CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL < STACK,
-    "a shipped default does not fit the 2 MiB thread even at the lossless per-level cost, which \
-     is the cheapest population that spends it"
-  );
+  // **DELETED: the shipped default against the LOSSLESS per-level cost, in both profiles.** The
+  // lossless level is the cheapest population that spends the cell, so once the default is known
+  // to fit at the heaviest modelled price — which the block above asserts, for both arms — it
+  // cannot fail to fit at the cheapest. It was worth stating while the arms could hold different
+  // and much larger numbers; at one number priced against the heavy row it is arithmetic that
+  // cannot come out the other way, and this file's rule is that such a line is decoration.
 };
 
 /// The derivation of [`RecursionLimiter::SEGMENTED_PRATT_DEPTH`], on the same terms as the block
@@ -1151,17 +1219,29 @@ const _: () = {
   // And the separation itself: the segmented figure has to be strictly the larger of the two, or
   // there was no reason to name it apart from the default. Stated per profile, because the two
   // pairs move independently once the release sweep lands.
+  //
+  // **The per-profile pair is gone and this is one clause, because the release half had become the
+  // debug half.** It was written "stated per profile, because the two pairs move independently
+  // once the release sweep lands" — and the sweep landed, and they do not: both release cells are
+  // equal to their debug siblings, so `SEG_REL > PARSE_REL` was `SEG_DBG > PARSE_DBG` compared with
+  // itself and could not fail for any legal value.
+  //
+  // What the per-profile form was reaching for has a real subject now. The collision it would have
+  // caught is between the segmented budget and the figure derived from the RELEASE rows, and that
+  // figure is OPTIMIZED_PARSE — 1024 against 1024 is exactly what the release parse arm would have
+  // been had it shipped, and it is what a caller opting in must still sit below.
   assert!(
-    SEGMENTED_PRATT_DEBUG > policy::PARSE_DEFAULT_DEBUG
-      && SEGMENTED_PRATT_RELEASE > policy::PARSE_DEFAULT_RELEASE,
-    "SEGMENTED_PRATT_DEPTH is not above PARSE_DEFAULT_DEPTH in one of the two profiles, so the \
-     constants have collapsed into one there and the segmented policy buys nothing"
+    SEGMENTED_PRATT_DEBUG > policy::PARSE_DEFAULT
+      && SEGMENTED_PRATT_RELEASE > policy::OPTIMIZED_PARSE,
+    "SEGMENTED_PRATT_DEPTH is not above the depth a caller can reach without it — either the \
+     shipped default or the published opt-in figure — so the segmented policy buys nothing over \
+     the budget that population already has"
   );
 };
 
 impl RecursionLimiter {
-  /// tokora's own recursion budget for a parse — **32** in a debug build and **256** in a release
-  /// one — requested explicitly by
+  /// tokora's own recursion budget for a parse — **32**, in every build and under every feature —
+  /// requested explicitly by
   /// [`ParserContext`](crate::ParserContext) and the input layer instead of inherited from
   /// [`new`](Self::new).
   ///
@@ -1276,41 +1356,91 @@ impl RecursionLimiter {
     doc = "`SEGMENTED_PRATT_DEPTH`, published only when that feature is on."
   )]
   ///
-  /// # It is keyed on the build profile, and for the first time the two cells differ
+  /// # It is keyed on the build profile, and both cells hold the same number on purpose
   ///
   /// A debug frame and a release frame are not the same size — tokora's own table is ~16.4 KiB
-  /// against ~0.48–0.53 KiB, a 31× spread — so the constant selects on `debug_assertions`: **32**
-  /// in a debug build, **256** in a release one. For every previous revision both arms held the
-  /// same number and the selection could not be observed. It can now, and that has a cost worth
-  /// stating plainly.
+  /// against ~0.48–0.53 KiB, a 31× spread — and the release rows genuinely support **256**. The
+  /// constant still selects on `debug_assertions`, and both arms are **32**.
   ///
-  /// ## The residue: `debug-assertions = false` at `opt-level = 0`
+  /// **That is not caution, and it is not a missing measurement.** The release sweep exists; the
+  /// figure it produces is published as
+  /// [`OPTIMIZED_PARSE_DEPTH`](Self::OPTIMIZED_PARSE_DEPTH) for a caller to pass. What is missing
+  /// is any way for *this crate* to know whether the condition that figure rests on holds:
   ///
-  /// **`debug_assertions` is a proxy for the profile, and it is not `opt-level`.** A build that
-  /// turns debug assertions off while leaving optimisation at zero takes the **release** arm — 256
-  /// — while its frames still cost debug prices. 256 levels of the heaviest modelled debug level is
-  /// ≈10 MiB against a 2 MiB thread. **Nothing refuses that**, and the list of things that were
-  /// checked and cannot is short: there is no `cfg(opt_level)` for a constant to read;
-  /// `native_stack`'s red zone is `stacker`-only and sits on the two Pratt prologues rather than on
-  /// the cell this bounds; and `ci/stack_probe.sh` asserts no threshold by design. While both arms
-  /// held one number this combination was refused at compile time by the assertion that priced the
-  /// release arm at the debug cost; that refusal is what diverging spends.
+  /// - `debug_assertions` is not `opt-level`. A build with `debug-assertions = false` at
+  ///   `opt-level = 0` selects the release arm and pays unoptimised frame prices.
+  /// - It is **per crate**, and the frames this budget bounds are the **caller's**. A build script
+  ///   reading cargo's `OPT_LEVEL` would close the first gap and not the second: it observes
+  ///   tokora's optimisation, while the recursion is spent in the consumer's productions. A
+  ///   per-package profile override, or a debug consumer against a release tokora, reinstates the
+  ///   mismatch with every signal available here reading "release".
   ///
-  /// It is confined: an ordinary debug build and an ordinary release build are both safe at their
-  /// own prices, and a `const` assertion says so. The same caveat also covers a **per-package
-  /// profile override** that compiles tokora differently from the consumer's grammar, which no
-  /// signal available to this crate can see.
+  /// **This crate shipped the divergence for one revision and it was a process-level denial of
+  /// service**: the release arm at 256, selected by an ordinary cargo profile combination, against
+  /// debug frames — ≈10 MiB on a 2 MiB thread, an abort with no diagnostic and nothing on any
+  /// `Result` channel. The default is now chosen so that **no profile combination can abort**, and
+  /// a `const` assertion prices *both* arms at the debug cost to keep it that way.
   ///
-  /// **The closure exists and has not been taken.** Cargo passes `OPT_LEVEL` to build scripts, and
-  /// this crate already has one that emits cfgs; reading it and selecting on that instead of on
-  /// `debug_assertions` would make the proxy exact. That is a decision rather than an oversight,
-  /// and it is recorded here so it does not have to be rediscovered.
-  ///
-  /// **A caller who cannot accept the residue sets the budget rather than inheriting it** — the
-  /// knobs are the ones listed above, and passing an explicit
-  /// [`with_limitation`](Self::with_limitation) makes the profile irrelevant.
+  /// **A caller who wants the depth a release build supports takes it explicitly, and takes
+  /// responsibility for its own frame prices with it.** That is not a burden tokora is pushing
+  /// away: it is the only place the fact lives. See
+  /// [`OPTIMIZED_PARSE_DEPTH`](Self::OPTIMIZED_PARSE_DEPTH) for the figure and the precondition,
+  /// and [`with_limitation`](Self::with_limitation) with
+  /// [`InputContext::with_recursion_limiter`](crate::input::InputContext::with_recursion_limiter)
+  /// for how to pass it — no new API is involved, that path predates this constant.
   ///
   pub const PARSE_DEFAULT_DEPTH: usize = policy::PARSE_DEFAULT;
+
+  /// **The recursion budget a fully optimised parse supports — 256, and nothing installs it.**
+  ///
+  /// [`PARSE_DEFAULT_DEPTH`](Self::PARSE_DEFAULT_DEPTH) is 32 in *every* build, including a release
+  /// one, and this is the figure a release build actually justifies. It is a number to hand to
+  /// [`InputContext::with_recursion_limiter`](crate::input::InputContext::with_recursion_limiter)
+  /// or [`ParserContext::with_recursion_limiter`](crate::ParserContext::with_recursion_limiter) —
+  /// the same shape as
+  #[cfg_attr(
+    feature = "stacker",
+    doc = "[`SEGMENTED_PRATT_DEPTH`](Self::SEGMENTED_PRATT_DEPTH), and for the same reason."
+  )]
+  #[cfg_attr(
+    not(feature = "stacker"),
+    doc = "`SEGMENTED_PRATT_DEPTH` (`stacker` only), and for the same reason."
+  )]
+  ///
+  /// # Why this is not simply the release arm of the default
+  ///
+  /// Because the default is selected by `cfg!(debug_assertions)`, and **that flag cannot express
+  /// the fact 256 is conditioned on.** Two ways it gets it wrong, and the second has no fix
+  /// available to this crate:
+  ///
+  /// - it is not `opt-level`, so a build with `debug-assertions = false` at `opt-level = 0` would
+  ///   select 256 while paying unoptimised frame prices — `256 × 41 KiB ≈ 10 MiB` on a 2 MiB
+  ///   thread, an abort with no diagnostic;
+  /// - it is **per crate**, and the frames this budget bounds are *yours*. Even a build script
+  ///   reading cargo's `OPT_LEVEL` would observe tokora's optimisation, not the optimisation of the
+  ///   productions the recursion is actually spent in.
+  ///
+  /// For one revision this crate shipped the divergence and it was a process-level denial of
+  /// service reachable from an ordinary cargo profile. The default went back to one number in both
+  /// arms, and the release figure became this.
+  ///
+  /// # The precondition, and it is yours to check
+  ///
+  /// **Every frame the budget bounds is compiled at `opt-level = 3`** — tokora's *and* your own
+  /// productions. Pass this when that holds of the build you are shipping; do not pass it because
+  /// a `cargo build --release` happened somewhere in the tree. If your grammar's deep part is
+  /// unoptimised for any reason — a per-package profile override, a debug consumer against a
+  /// release tokora — the number that applies is the default, not this one.
+  ///
+  /// # Why 256
+  ///
+  /// The same two-tier derivation [`PARSE_DEFAULT_DEPTH`](Self::PARSE_DEFAULT_DEPTH) uses, over the
+  /// release halves of the measured rows: `256 × 3 = 768` under the 3 282 at which the measured
+  /// consumer's lossless door aborts optimised, and `256 × 4.3 KiB = 1.09 MiB` inside a 2 MiB
+  /// thread at the heaviest modelled optimised level — where 512 needs 2.17 MiB and is refused.
+  /// It is 8× the shipped default, which is what a release frame being roughly an order of
+  /// magnitude cheaper buys.
+  pub const OPTIMIZED_PARSE_DEPTH: usize = policy::OPTIMIZED_PARSE;
 
   /// The recursion budget that is defensible **when every level of the descent is a segmented
   /// Pratt frame** — 1024, and `stacker`-only because that is the feature that makes the sentence

--- a/tokora/src/state/recursion_tracker/mod.rs
+++ b/tokora/src/state/recursion_tracker/mod.rs
@@ -88,8 +88,9 @@ impl RecursionLimitExceeded {
 /// never builds its recursion budget through it — so its constructors inherit this same
 /// general-purpose 500 rather than requesting the parser's own.
 ///
-/// That constant is **16**, in every build and under every feature, and the whole derivation —
-/// including why it was 64, why 64 was wrong, and why no feature is allowed to move it — is on
+/// That constant is **32** in a debug build and **256** in a release one, under every feature, and
+/// the whole derivation — including why it was 16, why 16 was measured at the wrong door, why 64
+/// was wrong before that, and why no feature is allowed to move it — is on
 /// [`PARSE_DEFAULT_DEPTH`](Self::PARSE_DEFAULT_DEPTH) rather than repeated here. What belongs here
 /// is the measurement table it is *not* derived from, because that table is this type's own and
 /// keeps being mistaken for the answer:
@@ -114,9 +115,11 @@ impl RecursionLimitExceeded {
 ///
 /// **And the 51 is a reading of that consumer's *syntactic* door, which spends no level of this
 /// counter at all** — the door the budget is enforced on has since been measured separately and is
-/// roughly an order of magnitude cheaper per level. That does not make the choice above unsafe, it
-/// makes it tight; [`PARSE_DEFAULT_DEPTH`](Self::PARSE_DEFAULT_DEPTH) carries the correction and
-/// this module's private `measured` carries both rows.
+/// roughly an order of magnitude cheaper per level. The shipped default is no longer derived from
+/// either row alone: it takes headroom against the populations that *spend* the cell and a bare fit
+/// against the heaviest one that is only *modelled*, which is what 51 now prices.
+/// [`PARSE_DEFAULT_DEPTH`](Self::PARSE_DEFAULT_DEPTH) carries the derivation and this module's
+/// private `measured` carries every row.
 ///
 /// The two failure modes are not symmetric, and that is what settles the direction to err in. A
 /// limit that is too *low* returns a clean, catchable, documented
@@ -547,29 +550,20 @@ pub(crate) mod measured {
 /// and not a refactor — and that no assertion in this file claims a release derivation nobody
 /// performed.
 ///
-/// # There is a fifth cell here, and it is not shipped
+/// # The two tiers, and why the file has an asymmetry in it
 ///
-/// [`PARSE_DEFAULT_DEBUG`] and [`PARSE_DEFAULT_RELEASE`] are both derived from
-/// [`measured::CONSUMER_SYNTACTIC_ABORTS_AT`], which is a reading of a door that spends **no**
-/// recursion level. The row the budget is enforced on has now been measured
-/// ([`measured::CONSUMER_LOSSLESS_ABORTS_AT`]), and what the *same formula and the same guards*
-/// produce from it is published here as [`PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW`] and
-/// [`PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW`] — derived, asserted, and read by nothing.
+/// The two `PARSE_DEFAULT_*` cells are derived by [`policy::two_tier`], which applies
+/// [`MIN_HEADROOM`](policy::MIN_HEADROOM) to the tightest population that **spends** a level of the
+/// cell and a bare fit — no multiplier — to the heaviest population that is merely **modelled**.
+/// That asymmetry is a decision and not a convenience: applying the multiplier to the modelled row
+/// as well gives 16, and applying neither tier's opposite gives 128, a value **above** the depth at
+/// which tokora's own Pratt driver aborts on the thread every figure here is stated on. 32 is
+/// precisely the width of that distinction, and 256 is its release twin.
 ///
-/// **Repointing is one decision and it moves four other things**, which is why it is not taken
-/// here as a side effect of taking the measurement:
-///
-/// 1. the shipped [`RecursionLimiter::PARSE_DEFAULT_DEPTH`](super::RecursionLimiter::PARSE_DEFAULT_DEPTH)
-///    goes 16 → 128, an 8× loosening of a safety default and a behaviour break;
-/// 2. `TOKORA_ABORTS_AT > CONSUMER_…_ABORTS_AT` stops holding, and its intent — *the consumer row
-///    is the binding one* — has to be re-derived rather than flipped, because on the lossless door
-///    the consumer row is legitimately the looser of the two;
-/// 3. the release arm can finally be derived rather than floored, which makes the two arms
-///    diverge, which makes the `debug_assertions`-as-profile-proxy caveat on [`PARSE_DEFAULT`]
-///    live for the first time;
-/// 4. and the provisional release assertion has to be re-priced at
-///    [`measured::CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL`], because a 1024-level release budget
-///    priced at a debug per-level cost does not fit the 2 MiB thread the derivation is stated on.
+/// The set each tier ranges over is written out at [`policy::SPENDING_MIN_DEBUG`] and asserted
+/// beside the derivation, so a third population that starts spending the cell has an obvious place
+/// to be added — and so that the syntactic row's exclusion from the headroom tier stays visible
+/// rather than inferable. That row spends zero levels; its productions take `descend` nowhere.
 pub(crate) mod policy {
   use super::measured;
 
@@ -592,105 +586,116 @@ pub(crate) mod policy {
   /// against, so it is what makes "and it still clears the bar 64 was held to" checkable.
   pub(crate) const MIN_MARGIN_TENTHS: usize = 19;
 
-  /// **The parse-side default in a debug build, derived**: the deepest power of two that still
-  /// fits [`MIN_HEADROOM`] times under [`measured::CONSUMER_SYNTACTIC_ABORTS_AT`].
+  /// **The two-tier rule both parse-side defaults are derived by**, and the asymmetry between the
+  /// tiers is the decision rather than a convenience.
   ///
-  /// 16, from 51 and 3 — `16 × 3 = 48 < 51`, and `32 × 3 = 96` is not. A power of two because
-  /// every default this crate has shipped has been one and a reader expects it, and the *deepest*
-  /// one because the asymmetry the constant's docs argue says to err low, not to err small.
+  /// - **Tier one — full [`MIN_HEADROOM`] against every population that actually SPENDS the
+  ///   cell.** `spending_min` is the tightest of those; see [`SPENDING_MIN_DEBUG`] for who is in
+  ///   the set and who is not.
+  /// - **Tier two — a bare fit, with no multiplier, at the heaviest MODELLED per-level price.**
+  ///   Nothing shipped spends the cell at that price today; the syntactic consumer's ~41 KiB level
+  ///   is what a caller's own hand-written [`descending`](crate::InputRef::descending) *could*
+  ///   cost, and `descent_tests.rs` models exactly that. A population that is modelled rather than
+  ///   observed earns a fit, not a margin.
   ///
-  /// This exists so the published constant can be asserted **equal** to something. A bare
-  /// inequality against the measurement admits every smaller value including 1, which is what the
-  /// guards in this file used to do.
-  ///
-  /// # **It is derived from the wrong door, and that is measured rather than suspected**
-  ///
-  /// 51 is a *syntactic*-door reading and this budget is spent on a *lossless* one; a level there
-  /// costs about eleven times less. Repointing the same formula at
-  /// [`measured::CONSUMER_LOSSLESS_ABORTS_AT`] gives
-  /// [`PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW`] — 128 — and the direction is the recoverable one:
-  /// 16 is *below* what the right row supports, so what the mis-pointing costs is depth a real
-  /// document can use, not safety. The consumer's deepest shipped fixture spends 11 descents and
-  /// an ordinary filter query reaches 10 or 11, so 16 leaves 1.45× over documents that already
-  /// exist, against a floor of 2× that the same consumer enforces on its own ceiling at compile
-  /// time.
-  ///
-  /// The repoint is deliberately not taken as part of recording the measurement — see the module
-  /// header for the four things it moves with it.
-  pub(crate) const PARSE_DEFAULT_DEBUG: usize = {
+  /// **Applying `MIN_HEADROOM` to the modelled row instead gives 16, and applying only the fit
+  /// gives what ships. 32 is precisely the width of that distinction.** A future reader who
+  /// collapses the two tiers into one will move the default in one direction or the other without
+  /// noticing, which is how this constant reached the wrong door in the first place.
+  const fn two_tier(spending_min: usize, heaviest_modelled_bytes: usize) -> usize {
     let mut depth = 1;
-    while depth * 2 * MIN_HEADROOM < measured::CONSUMER_SYNTACTIC_ABORTS_AT {
+    while depth * 2 * MIN_HEADROOM < spending_min
+      && depth * 2 * heaviest_modelled_bytes < measured::STACK
+    {
       depth *= 2;
     }
     depth
-  };
+  }
 
-  /// **What [`PARSE_DEFAULT_DEBUG`] becomes when its derivation is pointed at the door the budget
-  /// is enforced on** — the same loop, the same [`MIN_HEADROOM`], over
-  /// [`measured::CONSUMER_LOSSLESS_ABORTS_AT`] instead.
+  /// The tightest population that **spends** a level of this cell in a debug build, named rather
+  /// than minimised so the assertion beside it has something to be wrong about.
   ///
-  /// 128, from 667 and 3 — `128 × 3 = 384 < 667`, and `256 × 3 = 768` is not.
+  /// The set is two rows and the exclusion is the point:
   ///
-  /// **Nothing reads it, and that is the point of it existing.** The measurement it rests on is
-  /// answerable to a bisection; a paragraph saying "and the answer would be 128" is answerable to
-  /// nobody, and would be the third figure in this file's history to go stale while reading as
-  /// current. Deriving it here means the number moves when the row does, the shipped guards can
-  /// state their relation to it, and taking the decision is deleting these two constants rather
-  /// than re-doing the arithmetic.
+  /// - [`measured::TOKORA_ABORTS_AT`] — tokora's own Pratt engines, which take
+  ///   [`descend`](crate::InputRef::descend) at their two prologues;
+  /// - [`measured::CONSUMER_LOSSLESS_ABORTS_AT`] — the measured consumer's lossless door, one
+  ///   level per nesting delimiter;
+  /// - **and NOT [`measured::CONSUMER_SYNTACTIC_ABORTS_AT`]**, because that door spends zero
+  ///   levels. Its productions call `descend` nowhere, which is why 51 sizes the *fit* tier and
+  ///   never the headroom tier.
   ///
-  /// It also settles a discrepancy worth recording: the issue that found the mis-pointing inferred
-  /// a ~13× ratio, arrived at ~663 — within 1% of the measured 667 — and then read the loop's
-  /// *guard* (`d × 2 × 3 < C`) as its criterion instead of its exit state (`d × 3 < C`), landing on
-  /// 64. On its own figure this derivation gives 128.
-  pub(crate) const PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW: usize = {
-    let mut depth = 1;
-    while depth * 2 * MIN_HEADROOM < measured::CONSUMER_LOSSLESS_ABORTS_AT {
-      depth *= 2;
-    }
-    depth
-  };
+  /// tokora's own row is the tighter of the two in debug. It is not in release — see
+  /// [`SPENDING_MIN_RELEASE`], where the lossless row binds instead.
+  pub(crate) const SPENDING_MIN_DEBUG: usize = measured::TOKORA_ABORTS_AT;
 
-  /// The release twin of [`PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW`], from
-  /// [`measured::CONSUMER_LOSSLESS_RELEASE_ABORTS_AT`].
+  /// [`SPENDING_MIN_DEBUG`]'s release twin, over the release halves of the same two rows — and it
+  /// is the **other** row that binds.
   ///
-  /// 1024, from 3282 and 3 — `1024 × 3 = 3072 < 3282`, and `2048 × 3 = 6144` is not. Read by
-  /// nothing, for the reason its debug twin gives.
-  ///
-  /// **This is a derivation and not a floor**, which is what the release bisection buys: it is the
-  /// first release figure in this file that does not stand in for a measurement nobody took.
-  pub(crate) const PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW: usize = {
-    let mut depth = 1;
-    while depth * 2 * MIN_HEADROOM < measured::CONSUMER_LOSSLESS_RELEASE_ABORTS_AT {
-      depth *= 2;
-    }
-    depth
-  };
+  /// tokora's release Pratt row is 3 871 and the consumer's release lossless row is 3 282, so the
+  /// consumer binds here where tokora binds in debug. Which member is the minimum is therefore not
+  /// a fact about the crate, and a guard that assumed it would be reading one profile's accident.
+  pub(crate) const SPENDING_MIN_RELEASE: usize = measured::CONSUMER_LOSSLESS_RELEASE_ABORTS_AT;
 
-  /// **The parse-side default in a release build — a FLOOR, not a derivation.**
+  /// **The parse-side default in a debug build, derived** by [`two_tier`] over
+  /// [`SPENDING_MIN_DEBUG`] and [`measured::CONSUMER_SYNTACTIC_BYTES_PER_LEVEL`].
   ///
-  /// A release frame is far cheaper than a debug one (see [`measured`]'s header: 31× on tokora's
-  /// own table, ~11× on the one consumer release reading), so the honest release figure is
-  /// *larger* than the debug one and this is therefore conservative in the recoverable direction:
-  /// a caller who needs the depth gets a catchable
-  /// [`RecursionLimitReached`](crate::error::RecursionLimitReached) naming the knob, rather than an
-  /// abort.
+  /// **32.** Tier one: `32 × 3 = 96 < 125`, and `64 × 3 = 192` is not. Tier two:
+  /// `32 × 41 120 B = 1.31 MiB < 2 MiB`, and `64 × 41 120 B = 2.51 MiB` is not. **Both tiers refuse
+  /// the next doubling here**, which is why the debug arm is the one where the rule is easy to
+  /// mistake for a single criterion. The release arm is refused by tier two alone.
   ///
-  /// **What would raise it:** the same five-axis bisection
-  /// [`measured::CONSUMER_SYNTACTIC_ABORTS_AT`] records, run against a release build —
-  /// architecture, the primary dialect, a second dialect, that dialect's generic brackets, and the
-  /// alternative source representation. Until all five exist, a release figure would be one
-  /// reading standing in for a table, which is the shape this whole file refuses. When they exist,
-  /// add them to [`measured`], derive this the way [`PARSE_DEFAULT_DEBUG`] is derived, and delete
-  /// the *provisional* equality assertion that names this constant.
+  /// A power of two because every default this crate has shipped has been one and a reader expects
+  /// it, and the *deepest* one because the asymmetry the constant's docs argue says to err low,
+  /// not to err small.
   ///
-  /// **That sweep has now been run — against the lossless door, not this one.**
-  /// [`measured::CONSUMER_LOSSLESS_RELEASE_ABORTS_AT`] is a release table over seven cells of the
-  /// door the budget is enforced on, and [`PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW`] is what
-  /// this constant's own formula makes of it. So the release arm is no longer blocked on a missing
-  /// measurement; it is blocked on the same decision the debug arm is, because deriving one arm
-  /// from the lossless row and flooring the other against the syntactic row would ship a pair whose
-  /// two halves describe two different populations.
-  pub(crate) const PARSE_DEFAULT_RELEASE: usize = PARSE_DEFAULT_DEBUG;
+  /// # Why it is 32 and was 16, and why 128 was refused
+  ///
+  /// 16 came from applying `MIN_HEADROOM` to `CONSUMER_SYNTACTIC_ABORTS_AT`, a reading of a door
+  /// that spends nothing here — the defect #297 recorded. Pointing that same single-tier formula
+  /// at the row the budget *is* spent on gives 128, and 128 is worse than wrong: it is **above
+  /// [`measured::TOKORA_ABORTS_AT`]**, so an unconfigured Pratt parse in a debug build would reach
+  /// the native stack before the limiter — `128 × 16 112 B` measured is 98.3% of a 2 MiB thread —
+  /// which is the abort the 500 → 64 → 16 sequence exists to delete, restated with a bigger number.
+  ///
+  /// What both of those got wrong is the same thing in opposite directions: **this cell is shared,
+  /// and no single row bounds it.** The two tiers are what say so.
+  pub(crate) const PARSE_DEFAULT_DEBUG: usize = two_tier(
+    SPENDING_MIN_DEBUG,
+    measured::CONSUMER_SYNTACTIC_BYTES_PER_LEVEL,
+  );
+
+  /// **The parse-side default in a release build — now a DERIVATION, not a floor.**
+  ///
+  /// **256**, by the same [`two_tier`] rule over [`SPENDING_MIN_RELEASE`] and
+  /// [`measured::CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL`]. Tier one: `256 × 3 = 768 < 3282`
+  /// — and so is `512 × 3 = 1536`, so **tier one does not refuse the next doubling**. Tier two
+  /// does: `256 × 4 452 B = 1.09 MiB < 2 MiB`, `512 × 4 452 B = 2.17 MiB` is not.
+  ///
+  /// So the release arm is fixed by the fit and the debug arm by the headroom, and each tier is
+  /// the binding one somewhere. Deleting either changes a shipped number.
+  ///
+  /// It is a floor no longer because the sweep it owed exists: see
+  /// [`measured::CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT`] and
+  /// [`measured::CONSUMER_LOSSLESS_RELEASE_ABORTS_AT`]. The provisional `==` assertion that held it
+  /// equal to the debug cell is deleted with it.
+  ///
+  /// **1024 was refused, and by a guard rather than by an argument.** The single-tier derivation
+  /// over the release lossless row gives 1024, which collides exactly with
+  #[cfg_attr(
+    feature = "stacker",
+    doc = "[`SEGMENTED_PRATT_RELEASE`] — so `stacker` would have bought zero extra depth in a"
+  )]
+  #[cfg_attr(
+    not(feature = "stacker"),
+    doc = "`SEGMENTED_PRATT_RELEASE` (`stacker` only) — so that feature would have bought zero \
+           extra depth in a"
+  )]
+  /// release build, which is the one thing the segmented constant exists to be.
+  pub(crate) const PARSE_DEFAULT_RELEASE: usize = two_tier(
+    SPENDING_MIN_RELEASE,
+    measured::CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL,
+  );
 
   /// The cell this build selects, and the value
   /// [`RecursionLimiter::PARSE_DEFAULT_DEPTH`](super::RecursionLimiter::PARSE_DEFAULT_DEPTH) is
@@ -738,13 +743,24 @@ pub(crate) mod policy {
     depth
   };
 
-  /// **The segmented-Pratt budget in a release build — a FLOOR, on the same terms as
-  /// [`PARSE_DEFAULT_RELEASE`].**
+  /// **The segmented-Pratt budget in a release build — still a FLOOR, and no longer for the reason
+  /// [`PARSE_DEFAULT_RELEASE`] used to give.**
   ///
-  /// This one is a memory policy rather than a stack one, so what a release measurement buys here
-  /// is different: the same 64 MiB ceiling holds *more* levels when a level is cheaper, so the
-  /// derived release figure would again be larger. It needs the same missing per-level table, so
-  /// it waits for the same sweep.
+  /// That one was a floor because the sweep it needed had never been run. It has been, so that arm
+  /// is a derivation now and this one is the last floor in the file — but not because a figure is
+  /// missing. [`measured::CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL`] exists, and deriving this
+  /// cell from it gives **8192**.
+  ///
+  /// It stays a floor because that would be a different decision from the one the release
+  /// measurement licensed. This budget is a **memory** policy over heap segments, not a
+  /// thread-stack bound: a cheaper release level does not buy headroom under a wall, it buys more
+  /// segment memory reached before the refusal. 8192 levels at the release per-level cost is a
+  /// parse allowed to touch roughly half a gigabyte of segments, and
+  /// [`SEGMENT_MEMORY_CEILING`] — 64 MiB, stated in bytes precisely because bytes are what this
+  /// policy is about — is the number that would have to move for that to be intended.
+  ///
+  /// So the derivation is one line and it is deliberately not written. The `const` assertion below
+  /// says the same thing where a reader who skips docs will meet it.
   #[cfg(feature = "stacker")]
   pub(crate) const SEGMENTED_PRATT_RELEASE: usize = SEGMENTED_PRATT_DEBUG;
 
@@ -800,22 +816,40 @@ pub(crate) mod policy {
 /// these cannot print the numbers they compared. They name what to go and read instead.
 const _: () = {
   use measured::{
-    CONSUMER_SYNTACTIC_ABORTS_AT, CONSUMER_SYNTACTIC_BYTES_PER_LEVEL, STACK, TOKORA_ABORTS_AT,
+    CONSUMER_LOSSLESS_ABORTS_AT, CONSUMER_LOSSLESS_RELEASE_ABORTS_AT,
+    CONSUMER_SYNTACTIC_BYTES_PER_LEVEL, CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL, STACK,
+    TOKORA_ABORTS_AT, TOKORA_RELEASE_ABORTS_AT,
   };
   use policy::{
     MIN_HEADROOM, MIN_MARGIN_TENTHS, PARSE_DEFAULT, PARSE_DEFAULT_DEBUG, PARSE_DEFAULT_RELEASE,
+    SPENDING_MIN_DEBUG, SPENDING_MIN_RELEASE,
   };
 
-  // THE NUMBER, PINNED. Not "inside a band the derivation would tolerate" — the value the
-  // derivation produces, and no other. 64 fails this, and so do 1, 32 and 1024.
+  // THE NUMBER, PINNED — both arms, and by BOTH tiers. Not "inside a band the derivation would
+  // tolerate": within each tier, and blocked from the next doubling by at least one of them. The
+  // third clause is what makes it a derivation rather than a bound satisfied by 1, and it is a
+  // disjunction because which tier refuses the doubling differs by profile: tier one for debug,
+  // tier two for release. 16, 64 and 128 all fail the debug line; 1024 fails the release one.
   assert!(
-    PARSE_DEFAULT_DEBUG * MIN_HEADROOM < CONSUMER_SYNTACTIC_ABORTS_AT
-      && PARSE_DEFAULT_DEBUG * 2 * MIN_HEADROOM >= CONSUMER_SYNTACTIC_ABORTS_AT,
-    "PARSE_DEFAULT_DEBUG is not the number its own derivation produces — the DEEPEST power of two \
-     that fits MIN_HEADROOM times under CONSUMER_SYNTACTIC_ABORTS_AT. Both halves matter: the \
-     first is the safety requirement, the second is what makes it a derivation rather than a \
-     bound satisfied by 1."
+    PARSE_DEFAULT_DEBUG * MIN_HEADROOM < SPENDING_MIN_DEBUG
+      && PARSE_DEFAULT_DEBUG * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL < STACK
+      && (PARSE_DEFAULT_DEBUG * 2 * MIN_HEADROOM >= SPENDING_MIN_DEBUG
+        || PARSE_DEFAULT_DEBUG * 2 * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL >= STACK),
+    "PARSE_DEFAULT_DEBUG is not the number its own two-tier derivation produces — MIN_HEADROOM \
+     under the tightest population that SPENDS the cell, a bare fit at the heaviest MODELLED \
+     per-level price, and the deepest power of two meeting both. See `policy::two_tier`: the two \
+     tiers are not interchangeable and collapsing them moves this number."
   );
+  assert!(
+    PARSE_DEFAULT_RELEASE * MIN_HEADROOM < SPENDING_MIN_RELEASE
+      && PARSE_DEFAULT_RELEASE * CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL < STACK
+      && (PARSE_DEFAULT_RELEASE * 2 * MIN_HEADROOM >= SPENDING_MIN_RELEASE
+        || PARSE_DEFAULT_RELEASE * 2 * CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL >= STACK),
+    "PARSE_DEFAULT_RELEASE is not the number the same two-tier derivation produces over the \
+     release rows. It is a derivation now rather than a floor, so it has the same obligation the \
+     debug arm has."
+  );
+
   // THE STANDING ORDER between the two profiles, and the one that survives the release sweep. A
   // release frame is cheaper than a debug one, so a release budget may be larger and may never be
   // smaller; getting this backwards ships debug-sized frames against a release-sized budget.
@@ -824,20 +858,12 @@ const _: () = {
     "the release parse default is below the debug one, which inverts the only thing known about \
      the two profiles: a release frame is cheaper, so its budget can only be the larger"
   );
-  // THE PROVISIONAL LINE. **Delete this when, and only when, the release bisection exists** —
-  // see PARSE_DEFAULT_RELEASE for the five axes it owes. Until then, a release value above the
-  // debug one is a number nobody measured, and this is what stops it being written.
-  //
-  // A release bisection now exists, and it is of the OTHER DOOR: `CONSUMER_LOSSLESS_RELEASE_*`.
-  // That does not license deleting this line, because this pair is derived from the syntactic row
-  // and lifting one arm of a pair onto a different population is the defect one layer up. The
-  // line goes when both arms move together; see `policy`'s module header.
-  assert!(
-    PARSE_DEFAULT_RELEASE == PARSE_DEFAULT_DEBUG,
-    "the release parse default has been raised above the debug one without a release measurement \
-     in `measured` to derive it from. See PARSE_DEFAULT_RELEASE: it is a floor, and raising it \
-     means running the five-axis bisection, not extrapolating from debug's ratio."
-  );
+  // THE PROVISIONAL LINE IS GONE. It held the release arm equal to the debug one and said so:
+  // "raising it means running the five-axis bisection, not extrapolating from debug's ratio."
+  // The bisection was run — `measured::CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT` and its lossless
+  // sibling — so the arm is a derivation and the two now differ. What survives is the standing
+  // `>=` above, which is the half that was never provisional.
+
   // And the selection, so that the published constant is the arm this build's flag names rather
   // than whichever one somebody typed.
   assert!(
@@ -856,36 +882,59 @@ const _: () = {
      constant alone is the defect this assertion exists for."
   );
 
-  // THE WHOLE ORIGINAL DEFECT, AS ONE INEQUALITY, now stated over the derived value.
-  // `PARSE_DEFAULT_DEPTH` was 64 and `CONSUMER_SYNTACTIC_ABORTS_AT` is 51, so a derivation
-  // producing 64 fails here: the native stack got there before the limiter could, and the refusal
-  // the budget exists to produce was unreachable.
+  // THE WHOLE ORIGINAL DEFECT, AS ONE INEQUALITY, now stated over the derived value and over the
+  // row each arm is actually held to. `PARSE_DEFAULT_DEPTH` was 64 against a binding cell of 51,
+  // so the native stack got there before the limiter could and the refusal the budget exists to
+  // produce was unreachable. Stated on SPENDING_MIN rather than on a fixed row, because which
+  // population is tightest is a per-profile fact.
   assert!(
-    PARSE_DEFAULT_DEBUG * MIN_MARGIN_TENTHS <= CONSUMER_SYNTACTIC_ABORTS_AT * 10,
-    "the derived debug default does not clear CONSUMER_SYNTACTIC_ABORTS_AT — the depth at which a \
-     measured consumer grammar aborts on a 2 MiB thread — by MIN_MARGIN_TENTHS, the margin this \
-     crate already requires of such a number. See PARSE_DEFAULT_DEPTH's derivation."
+    PARSE_DEFAULT_DEBUG * MIN_MARGIN_TENTHS <= SPENDING_MIN_DEBUG * 10
+      && PARSE_DEFAULT_RELEASE * MIN_MARGIN_TENTHS <= SPENDING_MIN_RELEASE * 10,
+    "a derived default does not clear the tightest population that spends the cell by \
+     MIN_MARGIN_TENTHS, the margin this crate already requires of such a number. See \
+     PARSE_DEFAULT_DEPTH's derivation."
   );
   assert!(
     MIN_HEADROOM * 10 > MIN_MARGIN_TENTHS,
     "MIN_HEADROOM has been loosened below MIN_MARGIN_TENTHS, the margin the rejected default was \
      already held to — which would let this crate ship a default it had itself refused"
   );
-  // A guard against the derivation being 'repaired' by re-reading the wrong row: sizing against
-  // tokora's own 125 admits 64, which is exactly the number that was wrong.
+  // A8, RE-DERIVED RATHER THAN FLIPPED.
   //
-  // **THIS ONE IS DOOR-SPECIFIC AND DOES NOT CARRY OVER.** What it actually says is "the consumer
-  // row is the tighter of the two", and that was true only because the consumer row was read at a
-  // door whose levels are heavier than tokora's own Pratt frames. On the door the budget is
-  // enforced on the relation legitimately inverts — a lossless descent is ~3.1 KiB against
-  // tokora's ~16.4 KiB — so repointing the derivation makes this line fail for a correct reason.
-  // It has to be re-derived rather than flipped: the property worth keeping is that the row a
-  // default is derived from is the row that *binds* it, which is a statement about which door, not
-  // about which number is larger.
+  // The old form asserted `TOKORA_ABORTS_AT > CONSUMER_ABORTS_AT` — "the consumer row is the
+  // tighter of the two" — and that was never the property worth keeping. It held only because the
+  // consumer row was read at a door whose levels are heavier than tokora's own Pratt frames; on
+  // the door the budget is actually spent at, the relation inverts for a correct reason (a
+  // lossless descent is ~3.1 KiB against tokora's ~16.4 KiB). An assertion kept by flipping its
+  // comparison would have been a gate that had stopped gating.
+  //
+  // What it was protecting is that the headroom tier is taken against the population that BINDS
+  // the cell. So: SPENDING_MIN must be a member of the spending set, and no member may be below
+  // it. False in both directions — too high fails the first pair of clauses, and a value that is
+  // no row at all fails the second.
+  //
+  // **The syntactic row is deliberately not in this set**, and that is the whole content of #297:
+  // that door spends ZERO levels, its productions call `descend` nowhere, so it can price the fit
+  // tier and must never price this one. **A third spender goes here**, as another `<=` clause and
+  // another disjunct — which is the obvious place precisely because the set is written out.
   assert!(
-    TOKORA_ABORTS_AT > CONSUMER_SYNTACTIC_ABORTS_AT,
-    "the two measured rows have stopped disagreeing, which means one was edited to match the \
-     other rather than re-measured"
+    SPENDING_MIN_DEBUG <= TOKORA_ABORTS_AT
+      && SPENDING_MIN_DEBUG <= CONSUMER_LOSSLESS_ABORTS_AT
+      && (SPENDING_MIN_DEBUG == TOKORA_ABORTS_AT
+        || SPENDING_MIN_DEBUG == CONSUMER_LOSSLESS_ABORTS_AT),
+    "SPENDING_MIN_DEBUG is not the minimum of the populations that spend a level of this cell. \
+     The set is tokora's own Pratt engines and the measured consumer's lossless door, and it \
+     excludes the syntactic row because that door takes no `descend` at all. Adding a spender \
+     means adding a clause here, not widening the constant."
+  );
+  assert!(
+    SPENDING_MIN_RELEASE <= TOKORA_RELEASE_ABORTS_AT
+      && SPENDING_MIN_RELEASE <= CONSUMER_LOSSLESS_RELEASE_ABORTS_AT
+      && (SPENDING_MIN_RELEASE == TOKORA_RELEASE_ABORTS_AT
+        || SPENDING_MIN_RELEASE == CONSUMER_LOSSLESS_RELEASE_ABORTS_AT),
+    "SPENDING_MIN_RELEASE is not the minimum of the release halves of the same two rows. Note it \
+     is the OTHER member than in debug: a guard that hardcoded which one binds would be reading \
+     one profile's accident."
   );
 
   // **NO `stacker` ARM, and that is the point of this round.** This constant seeds every
@@ -903,24 +952,50 @@ const _: () = {
      on. A budget that only a segmented path could survive does not belong on the cell every \
      unsegmented `descend` reads; see RecursionLimiter::SEGMENTED_PRATT_DEPTH."
   );
+  // The release arm, priced at the RELEASE heaviest-modelled cost — which is the re-pricing this
+  // assertion's own text asked for and which `measured::CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT` now
+  // supplies. It is the tier that fixes the release number: 512 fails it where tier one would
+  // have allowed 1024.
   assert!(
-    PARSE_DEFAULT_RELEASE * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL < STACK,
-    "the release parse default, priced at the DEBUG per-level cost, no longer fits the 2 MiB \
-     thread. Once `measured` carries a release per-level figure this assertion should be priced \
-     at that one instead — until then the debug cost is the only one there is, and it is the \
-     conservative direction."
+    PARSE_DEFAULT_RELEASE * CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL < STACK,
+    "the release parse default, priced at the heaviest modelled RELEASE per-level cost, no longer \
+     fits the 2 MiB thread the derivation is stated on."
+  );
+  // **AND THE RESIDUE, NAMED BECAUSE NOTHING CAN CHECK IT.** The two arms now differ, so
+  // `debug_assertions` is observable for the first time — and it is a proxy for the profile, not
+  // for `opt-level`. A build with `debug-assertions = false` at `opt-level = 0` takes the release
+  // arm while paying debug frame prices: 256 levels of the heaviest modelled DEBUG level is 10 MiB
+  // against a 2 MiB thread. Nothing refuses that. There is no `cfg(opt_level)`; `native_stack`'s
+  // red zone is `stacker`-only and sits on the two Pratt prologues, not on the cell this bounds;
+  // and `ci/stack_probe.sh` asserts no threshold by design. The available closure is a `build.rs`
+  // cfg off cargo's `OPT_LEVEL`, which this crate's build script is already shaped to emit — it is
+  // a decision, not an oversight, and this comment is where it is recorded rather than lost.
+  //
+  // This line states the part that IS checkable: the debug arm remains safe at the debug price,
+  // so the residue is confined to the profile combination above and does not reach an ordinary
+  // debug or an ordinary release build.
+  assert!(
+    PARSE_DEFAULT_DEBUG * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL < STACK
+      && PARSE_DEFAULT_RELEASE * CONSUMER_SYNTACTIC_BYTES_PER_LEVEL >= STACK,
+    "either the debug arm has stopped fitting the 2 MiB thread at the debug price, or the release \
+     arm has started fitting it — the second would retire the `debug-assertions = false at \
+     opt-level = 0` residue recorded above, and that is a paragraph to delete rather than a line."
   );
 };
 
-/// **The door the budget is enforced on, and the derivation this crate does not yet ship.**
+/// **The measured rows themselves**, and the consumer-side fact no arithmetic over them reaches.
 ///
-/// Nothing in the block above reads a lossless figure, so without this one the re-measurement
-/// would be four `pub(crate)` constants and a paragraph — which is the shape every stale number in
-/// this file's history had. What these assertions buy is that the *relations* the decision rests on
-/// are compiled: that the two doors are far enough apart to be two populations, that the shipped
-/// default is below rather than above what the right row supports, that the repointed pair fits the
-/// 2 MiB thread the whole derivation is stated on, and that the release arm cannot be lifted
-/// without re-pricing the guard that currently floors it.
+/// The block above pins what this crate *chose*. These pin what it is choosing *between*: that the
+/// two doors are far enough apart to be two populations rather than one row edited twice, that
+/// tokora's own row is not comparable with the lossless one, and that the shipped default still
+/// clears a document the measured consumer actually ships.
+///
+/// The two `PARSE_DEFAULT_*_ON_THE_LOSSLESS_ROW` constants that used to live here are **gone**.
+/// They existed to publish what the derivation would give if repointed, while the shipped cells
+/// were still derived from the syntactic row. The shipped cells now take their headroom tier from
+/// the spending set — which the lossless row is a member of — so a separate "on the lossless row"
+/// derivation would be a second derivation of a number this file already derives, and one that no
+/// longer describes what ships. Two derivations of one number is how they drift.
 const _: () = {
   use measured::{
     CONSUMER_DEEPEST_SHIPPED_DOCUMENT, CONSUMER_LOSSLESS_ABORTS_AT,
@@ -929,32 +1004,7 @@ const _: () = {
     CONSUMER_SYNTACTIC_BYTES_PER_LEVEL, CONSUMER_SYNTACTIC_RELEASE_ABORTS_AT,
     CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL, STACK, TOKORA_ABORTS_AT, TOKORA_RELEASE_ABORTS_AT,
   };
-  use policy::{
-    MIN_HEADROOM, MIN_MARGIN_TENTHS, PARSE_DEFAULT_DEBUG, PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW,
-    PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW,
-  };
-
-  // The repointed pair, pinned by the same two-halved shape the shipped pair gets: within the
-  // safety requirement, and the DEEPEST power of two that is.
-  assert!(
-    PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW * MIN_HEADROOM < CONSUMER_LOSSLESS_ABORTS_AT
-      && PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW * 2 * MIN_HEADROOM >= CONSUMER_LOSSLESS_ABORTS_AT,
-    "PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW is not the number the shipped derivation produces \
-     from the lossless row, so it has stopped being what it claims to be — the answer to 'what \
-     would this crate ship if the derivation were pointed at the door the budget is spent on'."
-  );
-  assert!(
-    PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW * MIN_HEADROOM < CONSUMER_LOSSLESS_RELEASE_ABORTS_AT
-      && PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW * 2 * MIN_HEADROOM
-        >= CONSUMER_LOSSLESS_RELEASE_ABORTS_AT,
-    "PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW is not what the shipped derivation produces from \
-     the release lossless row"
-  );
-  assert!(
-    PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW * MIN_MARGIN_TENTHS <= CONSUMER_LOSSLESS_ABORTS_AT * 10,
-    "the repointed debug default would not clear its own binding cell by MIN_MARGIN_TENTHS, the \
-     margin this crate already requires of such a number"
-  );
+  use policy::{PARSE_DEFAULT_DEBUG, PARSE_DEFAULT_RELEASE};
 
   // THE DOOR MISMATCH, AS A COMPILED FACT. Measured at ~13x per level; four is a floor loose
   // enough to survive another platform's codegen and tight enough that the two rows converging
@@ -967,18 +1017,17 @@ const _: () = {
      doors whose per-level costs differ by roughly an order of magnitude, so convergence means a \
      row was edited rather than re-measured — see `measured`'s header for what each door spends."
   );
-  // And the relation that makes the *tokora* row incomparable with the lossless one, stated so a
-  // reader who finds `TOKORA_ABORTS_AT > CONSUMER_SYNTACTIC_ABORTS_AT` above does not conclude the
-  // same ordering must hold here. A Pratt frame is the heavier kind; the lossless row is looser
-  // BECAUSE its levels are cheaper, which is the opposite of evidence that something was edited.
+  // And the relation that makes tokora's row incomparable with the lossless one, stated so a
+  // reader does not reinstate the ordering the old A8 asserted. A Pratt frame is the heavier kind;
+  // the lossless row is looser BECAUSE its levels are cheaper, which is the opposite of evidence
+  // that something was edited.
   assert!(
     CONSUMER_LOSSLESS_ABORTS_AT > TOKORA_ABORTS_AT,
     "the lossless consumer row has fallen to tokora's own Pratt-frame row, which would mean a \
      lossless descent had become as expensive as a Pratt frame"
   );
-  // A release descent is cheaper than a debug one, so more of them fit the same thread. The same
-  // standing order the shipped pair carries, stated once per row now that all three have both
-  // halves measured — tokora's own, the syntactic consumer's, and the lossless consumer's.
+  // A release level is cheaper than a debug one, so more of them fit the same thread. Stated once
+  // per row now that all three have both halves measured.
   assert!(
     CONSUMER_LOSSLESS_RELEASE_ABORTS_AT > CONSUMER_LOSSLESS_ABORTS_AT,
     "the release lossless row is at or below the debug one, which inverts the only thing known \
@@ -997,51 +1046,26 @@ const _: () = {
      down rather than derived"
   );
 
-  // **THE DIRECTION OF THE DEFECT.** The shipped default is derived from the wrong door, and this
-  // is the line that says which way that cuts: below what the right row supports, so the cost is
-  // depth a real document could have used rather than an abort. If this ever inverts, the
-  // mis-pointing has stopped being conservative and the repoint stops being a decision.
+  // **THE REAL FLOOR, replacing the tripwire this file carried for one revision.** That one
+  // asserted the shipped default did NOT clear the deepest document the measured consumer ships,
+  // and it was right to: it recorded that the case for repointing still stood, and it fired the
+  // moment the repoint happened. With the repoint taken, the obligation inverts — the shipped
+  // default must now stay clear of the corpus by the same 2x that consumer enforces on its own
+  // nesting ceiling at compile time. 32 over 11 is 2.9x; the release arm has far more.
   assert!(
-    PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW > PARSE_DEFAULT_DEBUG,
-    "the shipped debug default now EXCEEDS what the door it is enforced on supports. It was \
-     derived from a syntactic-door reading, which was safe only while that door's levels were the \
-     more expensive ones; see `measured::CONSUMER_LOSSLESS_ABORTS_AT`."
+    PARSE_DEFAULT_DEBUG >= CONSUMER_DEEPEST_SHIPPED_DOCUMENT * 2
+      && PARSE_DEFAULT_RELEASE >= CONSUMER_DEEPEST_SHIPPED_DOCUMENT * 2,
+    "a shipped default no longer clears the deepest document the measured consumer ships by 2x — \
+     the floor that consumer holds its OWN ceiling to. Either the default was lowered or the \
+     corpus grew; `measured::CONSUMER_DEEPEST_SHIPPED_DOCUMENT` says which."
   );
-  // **AND WHAT THAT DIRECTION COSTS**, which is the half no arithmetic over the two rows can
-  // reach. The shipped default does not clear the deepest document the measured consumer already
-  // ships by the 2x that same consumer requires of its own nesting ceiling — a floor it escapes
-  // only because the number that binds its lossless door is this one rather than its own. If this
-  // line ever fails, the consumer-side half of the case for repointing has been retired and the
-  // remaining half is that the row is still the wrong door's; re-read `policy`'s header rather
-  // than deleting it.
+  // And the budget still fits the 2 MiB thread at the price of the door that actually spends it,
+  // in both profiles — the cheap side of the same pair the fit tier states on the heavy side.
   assert!(
-    PARSE_DEFAULT_DEBUG < CONSUMER_DEEPEST_SHIPPED_DOCUMENT * 2,
-    "the shipped default now clears the deepest document the measured consumer ships by 2x. That \
-     retires half the case for repointing the derivation; see `policy`'s module header for the \
-     half it does not."
-  );
-
-  // Both repointed arms against the 2 MiB thread, each at ITS OWN per-level cost — which is what
-  // the shipped release assertion cannot do, since `measured` had no release price until now.
-  assert!(
-    PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW * CONSUMER_LOSSLESS_BYTES_PER_LEVEL < STACK,
-    "the repointed debug default does not fit the 2 MiB thread at the lossless per-level cost"
-  );
-  assert!(
-    PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW * CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL < STACK,
-    "the repointed release default does not fit the 2 MiB thread at the RELEASE lossless \
-     per-level cost"
-  );
-  // And the fourth consequence of repointing, as a fact rather than a sentence: the repointed
-  // release arm does NOT fit at the debug price, so the provisional guard above — which prices the
-  // release budget at the debug cost because that was the only cost there was — has to be
-  // re-priced at the release row in the same commit that lifts the arm. Deleting the provisional
-  // `==` without doing so trades a floor for an abort.
-  assert!(
-    PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW * CONSUMER_LOSSLESS_BYTES_PER_LEVEL >= STACK,
-    "the repointed release arm now fits the 2 MiB thread even at the DEBUG per-level cost, which \
-     retires the reason the shipped release assertion has to be re-priced before that arm is \
-     lifted. Re-read that assertion rather than deleting this line."
+    PARSE_DEFAULT_DEBUG * CONSUMER_LOSSLESS_BYTES_PER_LEVEL < STACK
+      && PARSE_DEFAULT_RELEASE * CONSUMER_LOSSLESS_RELEASE_BYTES_PER_LEVEL < STACK,
+    "a shipped default does not fit the 2 MiB thread even at the lossless per-level cost, which \
+     is the cheapest population that spends it"
   );
 };
 
@@ -1073,11 +1097,26 @@ const _: () = {
     "the release segmented budget is below the debug one, which inverts what a cheaper level does \
      to a fixed memory ceiling"
   );
-  // **Delete with PARSE_DEFAULT_RELEASE's twin, and not before**: same missing sweep.
+  // **THE PROVISIONAL LINE THAT STAYS**, and its reason has changed, so read it rather than
+  // pattern-matching it against the unsegmented one that was just deleted.
+  //
+  // That one went because the measurement it was waiting for arrived. This one is NOT waiting on a
+  // missing figure any more either — `measured::CONSUMER_SYNTACTIC_RELEASE_BYTES_PER_LEVEL` exists
+  // now, and deriving this cell from it would give 8192. It stays because that would be a
+  // different decision from the one taken: this budget is a MEMORY policy over heap segments, not
+  // a thread-stack bound, so what a cheaper release level buys here is 8x more segment memory
+  // reached before the refusal rather than 8x more headroom under a wall. Nobody has decided that
+  // 64 MiB should become the effective 512 MiB an 8192-deep segmented parse could touch.
+  //
+  // So: the figure is available, the derivation is one line, and the line is deliberately not
+  // written. Deleting this assertion is how that decision gets taken, and it should be taken
+  // knowingly.
   assert!(
     SEGMENTED_PRATT_RELEASE == SEGMENTED_PRATT_DEBUG,
-    "the release segmented budget has been raised above the debug one without a release per-level \
-     figure in `measured` to derive it from. See SEGMENTED_PRATT_RELEASE."
+    "the release segmented budget has been raised above the debug one. A release per-level figure \
+     now exists to derive it from, so this is no longer blocked on a measurement — it is blocked \
+     on a decision about how much segment memory an unconfigured release parse may reach. See \
+     SEGMENTED_PRATT_RELEASE and policy::SEGMENT_MEMORY_CEILING."
   );
   assert!(
     SEGMENTED_PRATT
@@ -1121,7 +1160,8 @@ const _: () = {
 };
 
 impl RecursionLimiter {
-  /// tokora's own recursion budget for a parse — **16**, in every build — requested explicitly by
+  /// tokora's own recursion budget for a parse — **32** in a debug build and **256** in a release
+  /// one — requested explicitly by
   /// [`ParserContext`](crate::ParserContext) and the input layer instead of inherited from
   /// [`new`](Self::new).
   ///
@@ -1150,7 +1190,7 @@ impl RecursionLimiter {
   /// descent is Pratt frames opts into by hand. Opting in is the point: only the caller knows
   /// whether that precondition holds of their grammar.
   ///
-  /// # Why the default is 16, and why it used to be 64
+  /// # Why the default is 32, and why it was 16, 64 and 500 before that
   ///
   /// **64 was wrong, and it was wrong in the direction that aborts.** It was derived from the
   /// table in `Two Defaults, Two Subjects` — tokora's own worst cell, the debug token driver's
@@ -1160,39 +1200,51 @@ impl RecursionLimiter {
   /// so one level of nesting pays for a tokora frame *and* a consumer frame, and the number to
   /// size against is the sum.
   ///
-  /// Measured on a real consumer grammar, debug, on the same explicitly sized 2 MiB thread: it
-  /// aborts at **51** levels — ~41 KiB each, 2.5× tokora's own — with four further axes at 60, 57,
-  /// 53 and 52. **So 64 sat above the depth at which a real grammar aborts**, and for that
-  /// consumer the limiter could never fire: the native stack got there first, with
-  /// `fatal runtime error: stack overflow` and no diagnostic. That is precisely the failure the
-  /// 500 → 64 change had been made to fix, surviving one layer further out.
+  /// **16 was wrong in the other direction, and for a subtler reason: it was measured at the wrong
+  /// door.** It came from a real consumer grammar aborting at **51** levels, debug, on the same
+  /// 2 MiB thread — the tightest of five axes over architecture, dialect, shape and source
+  /// backing. Those five held one thing fixed that nobody wrote down: every reading is of that
+  /// consumer's **syntactic** door, which takes no [`descend`](crate::InputRef::descend) and
+  /// therefore spends none of this budget. What spends it is that consumer's **lossless** door, one
+  /// level per nesting delimiter, where a level costs about eleven times less. So the shipped
+  /// default bounded one population with a different, far heavier one's frame cost.
   ///
-  /// 16 is the largest power of two leaving more than 3× under the binding cell of 51 — the next
-  /// one up, 32, leaves 1.59×, which is *below* the 1.9× that made 64 look safe and well inside
-  /// the range a different platform's codegen moves. It clears tokora's own tightest cell by 7.8×.
+  /// # The rule that produced 32, and why it has two tiers
   ///
-  /// # **The 51 is a measurement of a door this budget is never spent at**
+  /// **Pointing the old single-tier formula at the right row gives 128, and 128 aborts.** It is
+  /// *above* tokora's own 125, so an unconfigured Pratt parse in a debug build would reach the
+  /// native stack before the limiter — measured, 128 × 16 112 B is 98.3% of a 2 MiB thread — which
+  /// is the failure the whole 500 → 64 → 16 sequence exists to delete, restated with a bigger
+  /// number. **This cell is shared, and no single row bounds it.**
   ///
-  /// Those five axes were varied over architecture, dialect, shape and source backing, and held
-  /// one thing fixed that was not written down: they are all readings of that consumer's
-  /// **syntactic** door, which takes no [`descend`](crate::InputRef::descend) and therefore spends
-  /// none of this budget. What spends it is that consumer's **lossless** door — one level per
-  /// nesting delimiter — where a level costs about eleven times less. Re-running the same
-  /// bisection there gives a binding cell of **667** descents rather than 51 levels, and the same
-  /// formula over it gives **128**; the release table, which had never been taken, gives 3282 and
-  /// **1024**. The figures, the axes and the survive/abort pairs are on
-  /// this module's private `measured`, and what taking the decision moves with it is on the
-  /// header of its `policy` sibling.
+  /// Three populations read it, and their per-level costs span 68×: tokora's two Pratt engines
+  /// (~16.4 KiB), a caller's own hand-written [`descending`](crate::InputRef::descending)
+  /// (modelled at the measured heaviest, ~41 KiB), and a lossless consumer's descent (~3.1 KiB).
+  /// The derivation therefore applies **full headroom to every population that actually spends the
+  /// cell**, and **a bare fit, with no multiplier, to the heaviest population that is only
+  /// modelled**. That asymmetry is the decision: give the modelled row headroom too and the answer
+  /// is 16; give the spending rows only a fit and it is 128.
   ///
-  /// **The direction is the recoverable one**, which is why the value is still 16: the wrong row is
-  /// the *tighter* one, so what the mis-pointing costs is depth rather than safety. What it costs
-  /// is real, though — the measured consumer's deepest shipped fixture spends 11 of these levels
-  /// and an ordinary filter query 10 or 11 (an argument list's `(` is a one-off toll, so
-  /// `f(where: {a: {b: [1]}})` spends 5 for what reads as three-deep), so 16 leaves 1.45× over
-  /// documents that already exist, against the 2× floor that consumer enforces on its *own* nesting
-  /// ceiling at compile time. It escapes that floor only because the binding number is this one.
+  /// **32** is the deepest power of two meeting both — `32 × 3 = 96 < 125`, and
+  /// `32 × 41 120 B = 1.31 MiB < 2 MiB`, with 64 refused by both. It is double what 0.10.0 shipped
+  /// before this change, it clears every population that spends it by at least 3×, and it is the
+  /// first value of this constant derived from the door the budget is actually enforced on.
   ///
-  /// **This is a reduction, and a grammar that legitimately nests deeper must now say so** — with
+  /// **The release arm is 256 and is now a derivation rather than a floor.** The same rule over the
+  /// release rows: the fit refuses 512 at ~4.3 KiB per modelled level, where headroom alone would
+  /// have allowed 1024 — a value that collides exactly with the segmented budget and would have
+  /// made `stacker` buy nothing in a release build. So each tier is the binding one in one profile.
+  ///
+  /// # What it costs a real document
+  ///
+  /// Measured on the same consumer: its deepest shipped fixture spends **11** of these levels over
+  /// 472 fixtures, and an ordinary filter query 10 or 11 — an argument list's `(` is a one-off
+  /// toll, so `f(where: {a: {b: [1]}})` spends 5 for what reads as three-deep. 32 leaves **2.9×**
+  /// over the deepest document that exists, which clears the 2× floor that consumer enforces on its
+  /// *own* nesting ceiling at compile time; 16 left 1.45× and escaped that floor only because the
+  /// binding number was this one rather than the consumer's.
+  ///
+  /// **A grammar that legitimately nests deeper must still say so** — with
   /// [`with_limitation`](Self::with_limitation) through
   /// [`InputContext::with_recursion_limiter`](crate::input::InputContext::with_recursion_limiter),
   /// [`ParserContext::with_recursion_limiter`](crate::ParserContext::with_recursion_limiter), or —
@@ -1224,17 +1276,40 @@ impl RecursionLimiter {
     doc = "`SEGMENTED_PRATT_DEPTH`, published only when that feature is on."
   )]
   ///
-  /// # It is also keyed on the build profile, and today both cells read 16
+  /// # It is keyed on the build profile, and for the first time the two cells differ
   ///
   /// A debug frame and a release frame are not the same size — tokora's own table is ~16.4 KiB
-  /// against ~0.48–0.53 KiB, a 31× spread — and 16 is derived from the **debug** bisection. So the
-  /// constant selects on `debug_assertions`, and a release build will eventually get its own,
-  /// larger figure. It does not have one yet: the five-axis consumer bisection behind 16 has not
-  /// been run against a release build, and extrapolating it from debug's ratio would be the same
-  /// derived-from-the-wrong-population mistake one more time. **The release cell is therefore a
-  /// floor set equal to the debug one**, which is conservative in the recoverable direction, and a
-  /// `const` assertion refuses to let it be raised until the measurement lands. Nothing about
-  /// today's *behaviour* differs between the two profiles.
+  /// against ~0.48–0.53 KiB, a 31× spread — so the constant selects on `debug_assertions`: **32**
+  /// in a debug build, **256** in a release one. For every previous revision both arms held the
+  /// same number and the selection could not be observed. It can now, and that has a cost worth
+  /// stating plainly.
+  ///
+  /// ## The residue: `debug-assertions = false` at `opt-level = 0`
+  ///
+  /// **`debug_assertions` is a proxy for the profile, and it is not `opt-level`.** A build that
+  /// turns debug assertions off while leaving optimisation at zero takes the **release** arm — 256
+  /// — while its frames still cost debug prices. 256 levels of the heaviest modelled debug level is
+  /// ≈10 MiB against a 2 MiB thread. **Nothing refuses that**, and the list of things that were
+  /// checked and cannot is short: there is no `cfg(opt_level)` for a constant to read;
+  /// `native_stack`'s red zone is `stacker`-only and sits on the two Pratt prologues rather than on
+  /// the cell this bounds; and `ci/stack_probe.sh` asserts no threshold by design. While both arms
+  /// held one number this combination was refused at compile time by the assertion that priced the
+  /// release arm at the debug cost; that refusal is what diverging spends.
+  ///
+  /// It is confined: an ordinary debug build and an ordinary release build are both safe at their
+  /// own prices, and a `const` assertion says so. The same caveat also covers a **per-package
+  /// profile override** that compiles tokora differently from the consumer's grammar, which no
+  /// signal available to this crate can see.
+  ///
+  /// **The closure exists and has not been taken.** Cargo passes `OPT_LEVEL` to build scripts, and
+  /// this crate already has one that emits cfgs; reading it and selecting on that instead of on
+  /// `debug_assertions` would make the proxy exact. That is a decision rather than an oversight,
+  /// and it is recorded here so it does not have to be rediscovered.
+  ///
+  /// **A caller who cannot accept the residue sets the budget rather than inheriting it** — the
+  /// knobs are the ones listed above, and passing an explicit
+  /// [`with_limitation`](Self::with_limitation) makes the profile irrelevant.
+  ///
   pub const PARSE_DEFAULT_DEPTH: usize = policy::PARSE_DEFAULT;
 
   /// The recursion budget that is defensible **when every level of the descent is a segmented

--- a/tokora/src/state/recursion_tracker/tests.rs
+++ b/tokora/src/state/recursion_tracker/tests.rs
@@ -102,6 +102,43 @@ fn enabling_stacker_does_not_move_the_shared_default() {
   );
 }
 
+// ══════════════════════════════════════════════════════════════════════════════
+// The number the derivation gives when it is pointed at the door the budget is spent on
+// ══════════════════════════════════════════════════════════════════════════════
+//
+// Same job as the four cells above and for the same reason: `policy` derives these from
+// `measured`, so a literal is the only statement made from OUTSIDE the derivation. It matters more
+// here than for a shipped cell, because nothing else in the tree reads either constant — the
+// compile-time relations beside them pin what the numbers must be *relative to* the measured rows,
+// and these two pin what they are.
+//
+// Unconditional rather than keyed on `debug_assertions`: both are derived from their own measured
+// row in every build, and neither is selected by the profile flag.
+
+/// What repointing [`PARSE_DEFAULT_DEBUG`](super::policy::PARSE_DEFAULT_DEBUG) at the lossless row
+/// produces — and it is not what the issue that found the mis-pointing inferred.
+#[test]
+fn the_repointed_debug_default_is_128() {
+  assert_eq!(
+    super::policy::PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW,
+    128,
+    "the derivation over the lossless row no longer produces 128. Either the row was re-measured \
+     — in which case this literal is the second half of that edit — or MIN_HEADROOM moved, in \
+     which case the shipped default moved too and the four cells above should have reddened first."
+  );
+}
+
+/// The release twin, and the first release figure in this file that is a derivation rather than a
+/// floor.
+#[test]
+fn the_repointed_release_default_is_1024() {
+  assert_eq!(
+    super::policy::PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW,
+    1024,
+    "the derivation over the release lossless row no longer produces 1024"
+  );
+}
+
 #[test]
 fn recursion_increase_saturates_at_max() {
   // At the ceiling `increase` must saturate rather than overflow-panic,

--- a/tokora/src/state/recursion_tracker/tests.rs
+++ b/tokora/src/state/recursion_tracker/tests.rs
@@ -21,31 +21,36 @@ use super::*;
 // literal adds is a statement made from *outside* the derivation, so a derivation that is wrong in
 // its own terms still has something to disagree with.
 
-/// The unsegmented default, debug build.
+/// The unsegmented default, debug build. **32**, from the two-tier rule — see `policy::two_tier`.
 #[cfg(debug_assertions)]
 #[test]
-fn the_parse_default_depth_is_sixteen() {
+fn the_parse_default_depth_is_thirty_two() {
   assert_eq!(
     RecursionLimiter::PARSE_DEFAULT_DEPTH,
-    16,
-    "the shipped debug parse default is 16 — the deepest power of two leaving more than 3x under \
-     the 51 at which a measured consumer grammar aborts on a 2 MiB thread. If this moved on \
-     purpose, the derivation in `policy` moved with it and this literal is the second half of \
-     that edit."
+    32,
+    "the shipped debug parse default is 32 — the deepest power of two leaving MIN_HEADROOM under \
+     the 125 at which tokora's own Pratt driver aborts on a 2 MiB thread AND fitting that thread \
+     at the heaviest modelled per-level cost. If this moved on purpose, the derivation in \
+     `policy` moved with it and this literal is the second half of that edit."
   );
 }
 
-/// The unsegmented default, release build. The same 16, and separately stated because it is a
-/// separate decision: a floor equal to the debug cell until the release bisection exists.
+/// The unsegmented default, release build. **256, not 32**, and separately stated because it is a
+/// separate derivation — the release bisection the floor was waiting for now exists.
+///
+/// Worth reading beside `the_segmented_pratt_depth_is_1024_in_release`: for one revision both the
+/// release parse default and the release segmented budget would have read **1024**, and two
+/// different constants asserting one literal in one profile is a layer that has stopped
+/// discriminating. They differ, and `SEGMENTED_PRATT_RELEASE > PARSE_DEFAULT_RELEASE` compiles it.
 #[cfg(not(debug_assertions))]
 #[test]
-fn the_parse_default_depth_is_sixteen_in_release() {
+fn the_parse_default_depth_is_two_hundred_fifty_six_in_release() {
   assert_eq!(
     RecursionLimiter::PARSE_DEFAULT_DEPTH,
-    16,
-    "the shipped release parse default is a FLOOR equal to the debug one, not a derivation — see \
-     `policy::PARSE_DEFAULT_RELEASE`. Raising it means running the five-axis consumer bisection \
-     against a release build, not extrapolating from debug's ratio."
+    256,
+    "the shipped release parse default is 256 — a DERIVATION now rather than a floor, fixed by the \
+     fit tier at the heaviest modelled RELEASE per-level cost. Note it is not 1024: that is what \
+     the headroom tier alone would have allowed, and it collides with SEGMENTED_PRATT_RELEASE."
   );
 }
 
@@ -82,60 +87,39 @@ fn the_segmented_pratt_depth_is_1024_in_release() {
 /// For one revision `PARSE_DEFAULT_DEPTH` was `if cfg!(feature = "stacker") { 1024 } else { 16 }`,
 /// and the two literal cells above cannot catch that on their own: each one runs in only one
 /// configuration, so each would simply see whichever number its own leg was given. This is the
-/// cross-configuration statement — the same 16 in a `stacker` build as in a plain one — and it is
-/// the runtime twin of the const assertion that prices the default against a 2 MiB thread.
+/// cross-configuration statement — the same number in a `stacker` build as in a plain one — and it
+/// is the runtime twin of the const assertion that prices the default against a 2 MiB thread.
 ///
 /// The reason it holds is not that 1024 is too big for the *Pratt* path. It is that this constant
 /// seeds every `InputContext`, and that cell is read by hand-written descent through
 /// `InputRef::descend` / `descending` from a consumer's own productions — frames the segmented
 /// prologue never touches, since its only two callers are tokora's own Pratt engines.
+///
+/// # Two axes now, and this cell holds one of them fixed
+///
+/// It carried a bare literal for as long as both profile arms held one number, and that was enough:
+/// the only axis that could move the value was the feature. The arms differ now, so a bare literal
+/// makes this a statement about the *profile* as well — and a wrong one, which is how it reds in a
+/// release build while the feature it is about is behaving perfectly. **Measured: this cell was the
+/// only failure in an otherwise green `--release` run of the whole suite**, and no leg of the
+/// standard gate matrix runs one.
+///
+/// So the expected value is selected the way the constant is, and what is left is the claim the
+/// cell is actually for: whatever this profile's number is, `stacker` does not change it.
 #[cfg(feature = "stacker")]
 #[test]
 fn enabling_stacker_does_not_move_the_shared_default() {
+  // Literals, not `policy::PARSE_DEFAULT`: recomputing the expectation from the derivation is what
+  // would make this a tautology. These are the same two numbers the arm cells above state, and
+  // they are stated again here because this cell runs in a configuration neither of them can see.
+  let expected = if cfg!(debug_assertions) { 32 } else { 256 };
   assert_eq!(
     RecursionLimiter::PARSE_DEFAULT_DEPTH,
-    16,
+    expected,
     "the `stacker` feature has moved the SHARED recursion budget. It segments tokora's two Pratt \
      frame prologues and nothing else, so it justifies no change to the cell every unsegmented \
      `descend` reads. The figure it does justify is SEGMENTED_PRATT_DEPTH, which a caller opts \
      into."
-  );
-}
-
-// ══════════════════════════════════════════════════════════════════════════════
-// The number the derivation gives when it is pointed at the door the budget is spent on
-// ══════════════════════════════════════════════════════════════════════════════
-//
-// Same job as the four cells above and for the same reason: `policy` derives these from
-// `measured`, so a literal is the only statement made from OUTSIDE the derivation. It matters more
-// here than for a shipped cell, because nothing else in the tree reads either constant — the
-// compile-time relations beside them pin what the numbers must be *relative to* the measured rows,
-// and these two pin what they are.
-//
-// Unconditional rather than keyed on `debug_assertions`: both are derived from their own measured
-// row in every build, and neither is selected by the profile flag.
-
-/// What repointing [`PARSE_DEFAULT_DEBUG`](super::policy::PARSE_DEFAULT_DEBUG) at the lossless row
-/// produces — and it is not what the issue that found the mis-pointing inferred.
-#[test]
-fn the_repointed_debug_default_is_128() {
-  assert_eq!(
-    super::policy::PARSE_DEFAULT_DEBUG_ON_THE_LOSSLESS_ROW,
-    128,
-    "the derivation over the lossless row no longer produces 128. Either the row was re-measured \
-     — in which case this literal is the second half of that edit — or MIN_HEADROOM moved, in \
-     which case the shipped default moved too and the four cells above should have reddened first."
-  );
-}
-
-/// The release twin, and the first release figure in this file that is a derivation rather than a
-/// floor.
-#[test]
-fn the_repointed_release_default_is_1024() {
-  assert_eq!(
-    super::policy::PARSE_DEFAULT_RELEASE_ON_THE_LOSSLESS_ROW,
-    1024,
-    "the derivation over the release lossless row no longer produces 1024"
   );
 }
 

--- a/tokora/src/state/recursion_tracker/tests.rs
+++ b/tokora/src/state/recursion_tracker/tests.rs
@@ -35,22 +35,24 @@ fn the_parse_default_depth_is_thirty_two() {
   );
 }
 
-/// The unsegmented default, release build. **256, not 32**, and separately stated because it is a
-/// separate derivation — the release bisection the floor was waiting for now exists.
+/// The unsegmented default, release build — **the same 32**, and still stated separately because it
+/// is still a separate decision.
 ///
-/// Worth reading beside `the_segmented_pratt_depth_is_1024_in_release`: for one revision both the
-/// release parse default and the release segmented budget would have read **1024**, and two
-/// different constants asserting one literal in one profile is a layer that has stopped
-/// discriminating. They differ, and `SEGMENTED_PRATT_RELEASE > PARSE_DEFAULT_RELEASE` compiles it.
+/// It is no longer a *floor waiting on a measurement*: the release bisection exists and says 256.
+/// It is a floor because the selection flag cannot observe the profile that sets the frame price,
+/// and cannot observe the consumer's at all. This cell is what catches the arms diverging by
+/// accident; the const assertion pricing both arms at the debug cost is what catches it on
+/// purpose.
 #[cfg(not(debug_assertions))]
 #[test]
-fn the_parse_default_depth_is_two_hundred_fifty_six_in_release() {
+fn the_parse_default_depth_is_thirty_two_in_release() {
   assert_eq!(
     RecursionLimiter::PARSE_DEFAULT_DEPTH,
-    256,
-    "the shipped release parse default is 256 — a DERIVATION now rather than a floor, fixed by the \
-     fit tier at the heaviest modelled RELEASE per-level cost. Note it is not 1024: that is what \
-     the headroom tier alone would have allowed, and it collides with SEGMENTED_PRATT_RELEASE."
+    32,
+    "the shipped release parse default is the SAME 32 the debug arm holds, and not the 256 the \
+     release rows support. `debug_assertions` cannot observe `opt-level`, and it is per crate \
+     while the frames are the consumer's, so a diverged arm is selectable by a build paying debug \
+     prices. 256 is published as OPTIMIZED_PARSE_DEPTH for a caller to pass instead."
   );
 }
 
@@ -95,24 +97,23 @@ fn the_segmented_pratt_depth_is_1024_in_release() {
 /// `InputRef::descend` / `descending` from a consumer's own productions — frames the segmented
 /// prologue never touches, since its only two callers are tokora's own Pratt engines.
 ///
-/// # Two axes now, and this cell holds one of them fixed
+/// # The literal is bare again, and one guard is why
 ///
-/// It carried a bare literal for as long as both profile arms held one number, and that was enough:
-/// the only axis that could move the value was the feature. The arms differ now, so a bare literal
-/// makes this a statement about the *profile* as well — and a wrong one, which is how it reds in a
-/// release build while the feature it is about is behaving perfectly. **Measured: this cell was the
-/// only failure in an otherwise green `--release` run of the whole suite**, and no leg of the
-/// standard gate matrix runs one.
+/// It was briefly keyed on `debug_assertions`, because for one revision the two profile arms held
+/// different numbers and a bare literal made this a statement about the *profile* as well — a
+/// wrong one, which reddened it in a release build while the feature it is about behaved
+/// perfectly. The arms hold one number again, so the keying is gone.
 ///
-/// So the expected value is selected the way the constant is, and what is left is the claim the
-/// cell is actually for: whatever this profile's number is, `stacker` does not change it.
+/// That is safe to rely on **only** because a `const` assertion prices both arms at the debug
+/// frame cost, so they cannot diverge without failing the build first. A round that finds a way to
+/// diverge them has to re-key this cell, and will meet that assertion before it gets here.
 #[cfg(feature = "stacker")]
 #[test]
 fn enabling_stacker_does_not_move_the_shared_default() {
   // Literals, not `policy::PARSE_DEFAULT`: recomputing the expectation from the derivation is what
   // would make this a tautology. These are the same two numbers the arm cells above state, and
   // they are stated again here because this cell runs in a configuration neither of them can see.
-  let expected = if cfg!(debug_assertions) { 32 } else { 256 };
+  let expected = 32;
   assert_eq!(
     RecursionLimiter::PARSE_DEFAULT_DEPTH,
     expected,
@@ -121,6 +122,33 @@ fn enabling_stacker_does_not_move_the_shared_default() {
      `descend` reads. The figure it does justify is SEGMENTED_PRATT_DEPTH, which a caller opts \
      into."
   );
+}
+
+/// **The figure a release build supports, which is published rather than installed.**
+///
+/// Unconditional: it is the same number in both profiles, because it describes what an optimised
+/// *caller's* frames cost and not what this build of tokora happens to be. That is the whole reason
+/// it is a constant to pass rather than an arm of the default.
+#[test]
+fn the_optimized_opt_in_depth_is_256() {
+  assert_eq!(
+    RecursionLimiter::OPTIMIZED_PARSE_DEPTH,
+    256,
+    "the published opt-in figure is 256 — the two-tier derivation over the release rows. If this \
+     moved, `measured`'s release rows moved with it and this literal is the second half of that \
+     edit."
+  );
+}
+
+/// The opt-in has to be worth opting into, stated from outside the derivation.
+///
+/// The `const` assertions say `OPTIMIZED_PARSE > PARSE_DEFAULT` in whichever arm is compiled. This
+/// says it over the two literals, so a round that moved both by the same factor — leaving every
+/// ratio intact and the shipped depth eight times wrong — still reds.
+#[test]
+fn the_opt_in_is_eight_times_the_shipped_default() {
+  assert_eq!(RecursionLimiter::PARSE_DEFAULT_DEPTH, 32);
+  assert_eq!(RecursionLimiter::OPTIMIZED_PARSE_DEPTH, 256);
 }
 
 #[test]


### PR DESCRIPTION
Closes #297.