### PR TITLE
fix(input)!: a scanner stop is readable where the error value cannot say it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,18 +173,12 @@ and will red until they do.
   produced, and `settle_met_ceiling` discards its staged stop when `lex()` yields nothing — so a
   `true` means a real item is refused right now.
 
-  **What it does not answer is named on the method rather than left to be discovered.** A trip
+  **It is the stop question, and it is deliberately not a sufficient root-loop guard.** A trip
   inside a speculative wrapper is restored away *together with the tally that took it* — the refund
-  `TokenLimiter` documents as the correct answer for a bound on the committed stream — so both
-  readings correctly report that the scanner can scan again. The loop that keeps redoing that
-  refundable work is a resource-**placement** problem, and `TokenLimiter`'s own documentation names
-  the fix: a bound on *work performed* belongs on the input as a `TokenBudget`, where no rollback
-  reaches it and where this verdict is durable. Telling a refund-to-spent from a refund-to-usable
-  cannot be done from the stored regime — a limit trip is decided *after* a scan and the tripping
-  scan commits nothing, so `*self.state` is always the pre-trip one — and only running the lexer
-  separates them, which would be a **third** `Lexer::lex` site in a layer whose `RESUME_CENSUS`
-  refuses one and would put unbudgeted lexer work behind a public `&self` reader. The case is left
-  open and measured rather than closed by widening that gate.
+  `TokenLimiter` documents as the correct answer for a bound on the committed stream — so this
+  answers `false`, correctly, while the caller still holds the trip-derived error at the position
+  the attempt began. `InputRef::scanner_outcome`, in the entry below, is the shape a retrying loop
+  matches on; this method is its `Stopped` arm and nothing more.
 
   **Measured in `tokora/tests/root_loop_trip_witness.rs` section 5**, whose lexer is deliberately
   not the earlier sections': it holds the crate's own `TokenLimiter` **by value**, which is the
@@ -202,6 +196,55 @@ and will red until they do.
   **unconditioned** — a driver judging one element must re-raise a trip it caught even where
   grammar code recovered the regime inside that element, which is precisely the conjunct the public
   verdict drops.
+
+- **`InputRef::scanner_attempt` / `InputRef::scanner_outcome` — the root-loop guard, because a
+  boolean cannot be one** (#311). Returns `input::ScannerOutcome`, a four-arm enum: `NoTrip`,
+  `Stopped`, `Stalled`, `Progressed`. Take `input::ScannerAttempt` per **attempt**, at the top of
+  the turn; match the outcome where the failure surfaces.
+
+  **The failure that costs most is one where no stop is in force.** A failing `try_attempt` /
+  `attempt_parse` / rollback-on-drop `Transaction` restores the checkpointed state and a pre-trip
+  `None` boundary, and for a scanner bound held in the lexer state — the **supported** placement
+  `TokenLimiter` documents, not a contract-violating shared counter — the input-side refusal bit is
+  `false` as well. Every live reading of the input is then correctly clean, the caller nonetheless
+  holds the trip-derived error, and the cursor and state are exactly where the attempt began. A loop
+  guarded on `at_scanner_stop` or `scanner_stopped_during_attempt` retries the identical scan and can
+  burn unbounded CPU on attacker-controlled input.
+
+  **The fact that separates that from a real recovery is committed progress, not the scanner's
+  current regime** — which is why the arm needs no scan, no regime probe, and no third `Lexer::lex`
+  site. The trip event survives the rollback because the counter is outside the rollback set, and
+  the committed position is observable without lexing. `Stalled` is *a trip, no stop in force, no
+  committed progress*, and it is **sound rather than heuristic**: the `Lexer` determinism clause
+  says every scan-visible result derives entirely from source, offset and `State`, so an unmoved
+  committed offset means a repeat reproduces the trip.
+
+  **`Stalled` cannot be permanent.** It clears the moment the parse commits anything past where the
+  attempt began — which is exactly what a successful recovery produces — and it is a claim about the
+  attempt that just ran, so a caller that answers it by installing a fresh regime has changed the
+  third input and the *next* capture judges that. Measured:
+  `a_recovery_answering_the_stall_makes_progress_and_the_next_attempt_says_so` sees `[Stalled]` —
+  one turn, not one per turn — and reads the whole document.
+
+  The capture holds `ScannerTripBaseline` rather than restating it, so the nonce and the `'closure`
+  brand carry over; it adds `span().end()`, **committed consumption**, never a cache-front reading —
+  a lookahead fill moves that reading across skipped trivia without committing, and a guard counting
+  it would report a stalled attempt as `Progressed`. That is the drivers' own rule, pinned here by
+  `PROGRESS_CENSUS` (`the_scanner_attempt_capture_reads_committed_consumption`), a **source** census
+  because every door that clears the latch also empties the cache, so the two accessors coincide at
+  every position a behavioural cell can reach. Its unit is per **attempt** where
+  `scanner_trip_snapshot` is per collection, and the two stay separate types because a driver reads
+  its baseline more than once per element loop and an `L::Offset` would cost it `Copy`.
+
+  **It makes the futile retry detectable; it does not make the work bounded.** That is a placement
+  question and `TokenBudget` on the input is the answer, because no rollback reaches it. The two
+  compose, and a root loop facing hostile input wants both. Requiring the budget *in the type* is not
+  representable today — `ParserContext::with_token_budget` returns `Self`, so a budgeted context is
+  not a distinct type — and making it so would change every context construction.
+
+  **Costs** a nonce comparison and a `u64` comparison; then, only when those say a trip happened, a
+  `bool` load, an `Option::is_some` and one `Offset::Ord`. The capture costs one `L::Offset::clone`.
+  No scan, no lookahead fill, no state clone.
 
 - **`ErrorContainer::clear`.** `Errors` is now the only door onto its container (#247), so it has
   to serve the removals that door used to reach through `DerefMut`. The method is defaulted
@@ -2032,6 +2075,13 @@ so a consumer whose extension items take `&self` keeps compiling on both revisio
 resolution silently switched. **The fix is the same UFCS**: `MyExt::scanner_trip_snapshot(inp)` and
 `MyExt::scanner_stopped_during_attempt(inp, scan)`. `input::ScannerTripBaseline` is a new
 glob-reachable name in `tokora::input` on the same terms as `input::ResourceTripBaseline` above.
+
+**`InputRef::scanner_attempt` and `InputRef::scanner_outcome` are the sixth and seventh**, on the
+same terms again: both are `&self`, the paired call passes the capture through inference, and the
+UFCS spellings are `MyExt::scanner_attempt(inp)` and `MyExt::scanner_outcome(inp, &att)`.
+`input::ScannerAttempt` and `input::ScannerOutcome` are new glob-reachable names in `tokora::input`.
+`ScannerOutcome` is `#[non_exhaustive]`, so a downstream `match` must carry a wildcard arm and a
+later arm cannot break it.
 
 #247 removes `Errors`' `DerefMut` and replaces the three legitimate uses it served with inherent
 methods. `Errors` has shipped since 0.7.3 **with no inherent item of its own**, so a consumer who

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,9 +84,27 @@ and will red until they do.
   clear.
 
   **It is a reading of *now*, not a baseline-and-compare, and that is the whole design.** It takes
-  no argument, so there is no placement for a caller to get wrong, and it witnesses no event, so it
-  needs no rollback proof at any nesting depth: a `Checkpoint` that puts the boundary back puts back
-  a live stop, and the reading then reports a live stop — which is what the next scan will do.
+  no argument, so there is no baseline for a caller to place wrongly, and it witnesses no event, so
+  there is no comparison of a rollbackable cell to prove at any nesting depth.
+
+  **Where it holds, and where it does not, is on the method.** A restore reinstates the
+  checkpoint's cursor, lexer state **and** boundary, so a speculative wrapper whose begin point
+  predates a trip — `try_attempt`, `attempt_parse`, a rollback-on-drop `Transaction`, a raw
+  `restore` — leaves this reading clean on its far side. That is not one wrong answer to repair,
+  because the right answer there is decided by where the scanner bound lives, and the only thing
+  that knows is `L::State`. A `TokenLimiter` held **by value** in the state is refunded by the very
+  same restore, so the stop really is gone and `false` is right; a tally the state only **points
+  at** — a shared cell, an atomic, a global — is not refunded, so the next scan trips again and
+  `false` is wrong; a `TokenBudget` on the **input** is outside every checkpoint, so the verdict is
+  the same on both sides of the restore. The first two rows need **opposite** answers after the
+  *same* rollback, which is why no fact carried across it can serve both and why this is a reading
+  rather than a carrier — planting the monotone trip counter in its place, the simplest carrier that
+  does survive a restore, reports `at_scanner_stop() == true` over a restored state that hands the
+  very next call a token. A consumer that speculates reads this **where the failure is produced**,
+  inside the closure or through the guard, or puts the bound on the input. Section 5 of
+  `tokora/tests/root_loop_trip_witness.rs` drives all three wrappers over all three placements, and
+  measures what the wrong one costs: a root loop that files a report every turn and never advances
+  the cursor at all.
 
   **Publishing `scanner_trip_snapshot` / `scanner_tripped_during_attempt` would not have closed
   this, and the entry above records why.** `set_state` / `state_mut` re-key the input's
@@ -107,8 +125,10 @@ and will red until they do.
   `a_token_budget_refusal_outlives_the_re_key_that_clears_a_lexer_trip`.
 
   **What a `false` does not promise** is stated on the method: a cursor rewound behind a live
-  boundary by a rollback reads clean (the region behind the frontier is replayable, so the loop that
-  carries on makes real progress and re-reaches the stop), and a *met* ceiling whose one-shot probe
+  boundary by a rollback reads clean — the region behind the frontier is replayable, so a loop that
+  carries on re-parses a prefix that really is there and re-reaches the stop, but what bounds that
+  is the loop **keeping** the prefix, and one whose retry is itself inside a rolling-back wrapper
+  keeps nothing, consumes nothing and does not terminate — and a *met* ceiling whose one-shot probe
   has not run yet reads clean (only running the lexer separates "would an item be refused" from "is
   there an item", and answering `true` there would report a fully-parsed document as truncated).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,24 +87,22 @@ and will red until they do.
   no argument, so there is no baseline for a caller to place wrongly, and it witnesses no event, so
   there is no comparison of a rollbackable cell to prove at any nesting depth.
 
-  **Where it holds, and where it does not, is on the method.** A restore reinstates the
-  checkpoint's cursor, lexer state **and** boundary, so a speculative wrapper whose begin point
-  predates a trip — `try_attempt`, `attempt_parse`, a rollback-on-drop `Transaction`, a raw
-  `restore` — leaves this reading clean on its far side. That is not one wrong answer to repair,
-  because the right answer there is decided by where the scanner bound lives, and the only thing
-  that knows is `L::State`. A `TokenLimiter` held **by value** in the state is refunded by the very
-  same restore, so the stop really is gone and `false` is right; a tally the state only **points
-  at** — a shared cell, an atomic, a global — is not refunded, so the next scan trips again and
-  `false` is wrong; a `TokenBudget` on the **input** is outside every checkpoint, so the verdict is
-  the same on both sides of the restore. The first two rows need **opposite** answers after the
-  *same* rollback, which is why no fact carried across it can serve both and why this is a reading
-  rather than a carrier — planting the monotone trip counter in its place, the simplest carrier that
-  does survive a restore, reports `at_scanner_stop() == true` over a restored state that hands the
-  very next call a token. A consumer that speculates reads this **where the failure is produced**,
-  inside the closure or through the guard, or puts the bound on the input. Section 5 of
-  `tokora/tests/root_loop_trip_witness.rs` drives all three wrappers over all three placements, and
-  measures what the wrong one costs: a root loop that files a report every turn and never advances
-  the cursor at all.
+  **What it is not is "what the next call would do", and the contract now says so.** The gate
+  drains a **cached** token before it consults either fact, and the budget half is durable and
+  non-positional — so with a lookahead's tokens still waiting at the front this answers `true`
+  while `try_expect_or_stop` hands one of them out. Measured: a `TokenBudget` of two and a
+  `peek::<U4>` over eight tokens leave the reading `true` and the very next call returning
+  `Ok(Some(_))` (`a_refusal_on_record_still_has_cached_tokens_in_front_of_it`). A `true` means *the
+  stream is truncated*, never *stop draining*.
+
+  **And it is narrowly a live query, which two other public contracts take out from under a
+  caller.** `state_mut`/`set_state` drop the poison boundary — the documented limit-recovery path —
+  and every speculative wrapper (`try_attempt`, `attempt_parse`, a rollback-on-drop `Transaction`,
+  a raw `restore`) reinstates a checkpoint that predates the trip. Both leave this reading clean
+  while the scanner may still be stopped, so a root loop is left with an ordering obligation —
+  read it before the re-key, and inside the wrapper — that a loop whose elements speculate cannot
+  always meet. `InputRef::scanner_stopped_during_attempt`, in the entry below, is the
+  attempt-relative reading that carries no such obligation.
 
   **Publishing `scanner_trip_snapshot` / `scanner_tripped_during_attempt` would not have closed
   this, and the entry above records why.** `set_state` / `state_mut` re-key the input's
@@ -128,13 +126,82 @@ and will red until they do.
   boundary by a rollback reads clean — the region behind the frontier is replayable, so a loop that
   carries on re-parses a prefix that really is there and re-reaches the stop, but what bounds that
   is the loop **keeping** the prefix, and one whose retry is itself inside a rolling-back wrapper
-  keeps nothing, consumes nothing and does not terminate — and a *met* ceiling whose one-shot probe
-  has not run yet reads clean (only running the lexer separates "would an item be refused" from "is
-  there an item", and answering `true` there would report a fully-parsed document as truncated).
+  keeps nothing, consumes nothing and does not terminate. That is the shape the attempt-relative
+  verdict below closes. And a *met* ceiling whose one-shot probe has not run yet reads clean (only
+  running the lexer separates "would an item be refused" from "is there an item", and answering
+  `true` there would report a fully-parsed document as truncated).
 
-  The `scanner_trip_snapshot` pair stays crate-internal. It answers a different question — *did a
-  trip happen inside the attempt I am judging*, which is what a driver needs — and that question
-  still has the `set_state` false positive.
+  The attempt-relative reading answers a different question — *did a trip happen inside the attempt
+  I am judging, and is it still in force* — and it is the entry directly below. The **raw**
+  `scanner_tripped_during_attempt` beside it stays crate-internal, because the drivers need the
+  event unconditioned by that second clause.
+
+- **`InputRef::scanner_trip_snapshot` / `InputRef::scanner_stopped_during_attempt` — the
+  **attempt-relative** scanner verdict, rollback-safe and recovery-aware** (#311). Take the baseline
+  once per collection, above the loop; read the verdict wherever the failure surfaces. Its baseline
+  is `input::ScannerTripBaseline`, the scanner twin of `input::ResourceTripBaseline`, carrying the
+  same nonce and the same `'closure` brand — a baseline judged against another input panics, and one
+  cannot be stashed and carried into a later handle invocation, which is what would quietly turn the
+  attempt-relative reading into a session-absolute one.
+
+  **It exists because `at_scanner_stop` is a live query and two public contracts take the record
+  away.** `state_mut`/`set_state` drop the poison boundary, and a speculative wrapper restores a
+  checkpoint predating the trip. A loop that must read the verdict *before* its own re-key, and
+  *inside* a wrapper several frames down, has an ordering obligation it cannot always meet.
+
+  **The counter alone was never publishable, and the entry below records why**: it is monotone, so
+  a loop that recovers exactly as documented reads its own finished document as truncated. What
+  closes that is not a second cell ordered against the trip — the design that would have had to
+  settle its own rollback behaviour at every nesting depth — but a second **question**, asked of
+  the present: the trip event, conjoined with the stop still being in force *now*. Being a question
+  rather than a record is what makes it need no ordering and no rollback proof.
+
+  **Two carriers can hold a scanner stop and they clear on opposite terms**, so both are asked. A
+  `TokenBudget` refusal is never cleared — no `Checkpoint` carries the tally, no re-key touches it,
+  and there is no `token_budget_mut` — so for a bound placed there the verdict is durable by
+  construction. A lexer-side trip clears exactly when the installed regime stops refusing.
+
+  **The residue it closes** is the one `at_scanner_stop` names first: a lookahead trips, latches
+  the frontier *ahead* of the committed cursor, and still returns `Ok` with a short window. Every
+  positional witness reads clean there, and stays clean while the cached pre-trip tokens drain,
+  because draining them never carries the cursor to the frontier. This reading is not positional —
+  it asks whether a stop is latched at all — so it answers `true` from the moment the lookahead
+  latched.
+
+  **A `true` is sound rather than conservative.** Both publishers of a scanner trip require an item
+  that exists — `latch_if_limit_tripped` is reached from `classify` about an item the lexer
+  produced, and `settle_met_ceiling` discards its staged stop when `lex()` yields nothing — so a
+  `true` means a real item is refused right now.
+
+  **What it does not answer is named on the method rather than left to be discovered.** A trip
+  inside a speculative wrapper is restored away *together with the tally that took it* — the refund
+  `TokenLimiter` documents as the correct answer for a bound on the committed stream — so both
+  readings correctly report that the scanner can scan again. The loop that keeps redoing that
+  refundable work is a resource-**placement** problem, and `TokenLimiter`'s own documentation names
+  the fix: a bound on *work performed* belongs on the input as a `TokenBudget`, where no rollback
+  reaches it and where this verdict is durable. Telling a refund-to-spent from a refund-to-usable
+  cannot be done from the stored regime — a limit trip is decided *after* a scan and the tripping
+  scan commits nothing, so `*self.state` is always the pre-trip one — and only running the lexer
+  separates them, which would be a **third** `Lexer::lex` site in a layer whose `RESUME_CENSUS`
+  refuses one and would put unbudgeted lexer work behind a public `&self` reader. The case is left
+  open and measured rather than closed by widening that gate.
+
+  **Measured in `tokora/tests/root_loop_trip_witness.rs` section 5**, whose lexer is deliberately
+  not the earlier sections': it holds the crate's own `TokenLimiter` **by value**, which is the
+  placement the `Lexer` determinism clause requires, where `SLexer`'s `Rc<Cell<_>>` tally is that
+  clause's own named violation (*"a shared counter"*) and cannot decide a question about restores.
+  The five-point table — latched ahead, draining, at the frontier, re-keyed, recovered — runs under
+  **both** emitters and answers `(false, true)`, `(false, true)`, `(true, true)`, `(false, false)`,
+  `(false, false)` against `at_scanner_stop`: the first two rows are the gain, and the last two are
+  where a monotone counter would be a permanent false positive.
+
+  **Costs** a nonce comparison and a `u64` comparison; then, only if those say a trip happened, a
+  `bool` load and an `Option::is_some`. No scan, no lookahead fill, no caller code at all.
+
+  The raw `scanner_tripped_during_attempt` stays crate-internal. The drivers need the event
+  **unconditioned** — a driver judging one element must re-raise a trip it caught even where
+  grammar code recovered the regime inside that element, which is precisely the conjunct the public
+  verdict drops.
 
 - **`ErrorContainer::clear`.** `Errors` is now the only door onto its container (#247), so it has
   to serve the removals that door used to reach through `DerefMut`. The method is defaulted
@@ -1956,6 +2023,15 @@ still compile on both revisions. **The fix is the same UFCS**: `MyExt::at_scanne
 `ci/name_collision/` scores its two rows `ok*` for the same narrow reason as the four above (the
 template's consumer takes `&mut self`; tokora's item takes `&self`), which is why this paragraph
 exists rather than the probe's baseline standing in for it.
+
+**`InputRef::scanner_trip_snapshot` and `InputRef::scanner_stopped_during_attempt` are the fourth
+and fifth**, and they are the scanner twins of the descent pair above, so every word of that
+paragraph transfers verbatim — including the part that matters. The paired call passes the baseline
+through inference (`let scan = inp.scanner_trip_snapshot(); … inp.scanner_stopped_during_attempt(scan)`),
+so a consumer whose extension items take `&self` keeps compiling on both revisions with the
+resolution silently switched. **The fix is the same UFCS**: `MyExt::scanner_trip_snapshot(inp)` and
+`MyExt::scanner_stopped_during_attempt(inp, scan)`. `input::ScannerTripBaseline` is a new
+glob-reachable name in `tokora::input` on the same terms as `input::ResourceTripBaseline` above.
 
 #247 removes `Errors`' `DerefMut` and replaces the three legitimate uses it served with inherent
 methods. `Errors` has shipped since 0.7.3 **with no inherent item of its own**, so a consumer who

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,56 @@ and will red until they do.
   Read it through `InputRef::token_budget`, which is already `pub`; there is still no
   `token_budget_mut`.
 
+- **`InputRef::at_scanner_stop` — the scanner half of "does this failure end the document",
+  readable on the one exit no error value reaches** (#311). A **rejecting** (fail-fast) `Emitter`
+  reports a lexer-resource trip by *returning* the value its `From<<L::Token as Token>::Error>`
+  builds — that `Err` **is** the report, not a refusal to make one — and `scan_with(..)?`
+  propagates it from **inside** `try_expect_or_stop`, before that call can reach the arm raising a
+  terminal-marked `UnexpectedEot`. A document-root loop then holds an ordinary-looking grammar
+  error over an exhausted scanner, and **no care in the grammar's `MaybeTerminal` repairs it**:
+  there is nothing terminal-marked on that path to delegate to, and calling `try_expect_or_stop`
+  does not help because the unmarked error originates inside that call.
+
+  The stop is nonetheless already **on record** when that `Err` arrives. The poison boundary is
+  latched inside the crate's terminal predicate, ahead of the diagnostic ever being offered to the
+  emitter — that ordering exists precisely so an emitter's answer cannot decide whether the input
+  remembers its own stop. This method reads it, together with the input-layer `TokenBudget`'s
+  recorded refusal (`TokenBudgetTally::refused_an_item`, in the entry above) which no re-key can
+  clear.
+
+  **It is a reading of *now*, not a baseline-and-compare, and that is the whole design.** It takes
+  no argument, so there is no placement for a caller to get wrong, and it witnesses no event, so it
+  needs no rollback proof at any nesting depth: a `Checkpoint` that puts the boundary back puts back
+  a live stop, and the reading then reports a live stop — which is what the next scan will do.
+
+  **Publishing `scanner_trip_snapshot` / `scanner_tripped_during_attempt` would not have closed
+  this, and the entry above records why.** `set_state` / `state_mut` re-key the input's
+  forward-scanning facts, and dropping the poison boundary there is the **documented**
+  limit-recovery path; the counter is monotone and neither touches it, so a fully recovered document
+  reads as truncated. That is now pinned, not argued: planting the counter reading in this method's
+  place reds `a_documented_widening_leaves_the_witness_reporting_a_finished_document` at `Err(Eot)`
+  for an `Ok(7)`. The live reading goes clean there because the regime that owned the stop is gone.
+
+  **Measured in both directions**, in `tokora/tests/root_loop_trip_witness.rs` section 4. Without
+  the reading, a root loop that meets an ordinary-looking failure by re-keying the lexer regime —
+  which is what `state_mut` is for, and which drops the boundary — retries against a tally that is
+  still spent and files **one diagnostic per remaining token**, at three document lengths; with it,
+  zero at every length, and the loop ends the document on the same turn. The non-vacuity control is
+  the same pair under a budget nothing reaches: both loops read the whole document and file nothing.
+  The two halves are pinned by disjoint cells — removing the boundary read reds the
+  rejecting-emitter cells, removing the budget read reds
+  `a_token_budget_refusal_outlives_the_re_key_that_clears_a_lexer_trip`.
+
+  **What a `false` does not promise** is stated on the method: a cursor rewound behind a live
+  boundary by a rollback reads clean (the region behind the frontier is replayable, so the loop that
+  carries on makes real progress and re-reaches the stop), and a *met* ceiling whose one-shot probe
+  has not run yet reads clean (only running the lexer separates "would an item be refused" from "is
+  there an item", and answering `true` there would report a fully-parsed document as truncated).
+
+  The `scanner_trip_snapshot` pair stays crate-internal. It answers a different question — *did a
+  trip happen inside the attempt I am judging*, which is what a driver needs — and that question
+  still has the `set_state` false positive.
+
 - **`ErrorContainer::clear`.** `Errors` is now the only door onto its container (#247), so it has
   to serve the removals that door used to reach through `DerefMut`. The method is defaulted
   through `pop`, so an existing implementation keeps compiling unchanged; the four built-in
@@ -318,16 +368,17 @@ and will red until they do.
   The caller receives an ordinary grammar error over an exhausted scanner, and no delegation in its
   `MaybeTerminal` can repair it, because nothing on the path is marked to delegate to — the same
   fact `scanner_tripped_during_attempt` documents from the other side when it says it answers where
-  the error value cannot. **So no public witness answers the rejecting-emitter path today.** That
-  gap is real and it is *older than this release*: the pair has been crate-internal throughout, so
-  its visibility has never changed the answer in either direction. Section 4 of that suite pins the
-  gap as a defect, beside the control that shows an accepting emitter marks the same stop.
+  the error value cannot. That exit is answered by `InputRef::at_scanner_stop`, in the entry above;
+  it is not answered by publishing the withdrawn pair, and that entry says why.
 
   **The descent pair has no such exposure**, and the reason is the channel rather than luck: a
   descent refusal is *returned* by `InputRef::descend` and never routed through an emitter, so no
   emitter can unmark it or convert it away from the counter that already recorded it.
   `the_descent_witness_holds_under_a_rejecting_emitter` runs the amplification loop under a
   fail-fast emitter and gets one refusal, one stop, nothing filed.
+
+  Its **scanner** counterpart is `InputRef::at_scanner_stop`, in the entry above. It is not this
+  pair's twin made public — it is a different reading, and that is what closed the gap.
 
   **The baseline is a type, not a `usize`.** `ResourceTripBaseline` is opaque — no accessor, no
   `PartialEq`, no constructor, and a hand-written `Debug` that renders `ResourceTripBaseline(..)`
@@ -1875,6 +1926,16 @@ the coverage for that case, which is why it is here rather than in the probe's b
 `input::ResourceTripBaseline` is a new glob-reachable name in `tokora::input`; the probe scores it
 `glob-err`, the disclosed outcome — a `use tokora::input::*` alongside another glob exporting the
 same name is rejected by the compiler rather than silently resolved.
+
+**`InputRef::at_scanner_stop` is a third new inherent method on the same type**, and every word
+above transfers: it is `pub fn at_scanner_stop(&self) -> bool`, so a consumer who wrote that name
+on `InputRef` as an extension item runs their item on the base and tokora's here. It takes **no
+argument**, so unlike the pair above there is no inferred type to make the switch invisible — but
+`bool` is the sort of return an extension would also have, so a call in a boolean position can
+still compile on both revisions. **The fix is the same UFCS**: `MyExt::at_scanner_stop(inp)`.
+`ci/name_collision/` scores its two rows `ok*` for the same narrow reason as the four above (the
+template's consumer takes `&mut self`; tokora's item takes `&self`), which is why this paragraph
+exists rather than the probe's baseline standing in for it.
 
 #247 removes `Errors`' `DerefMut` and replaces the three legitimate uses it served with inherent
 methods. `Errors` has shipped since 0.7.3 **with no inherent item of its own**, so a consumer who

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,20 +211,49 @@ and will red until they do.
   guarded on `at_scanner_stop` or `scanner_stopped_during_attempt` retries the identical scan and can
   burn unbounded CPU on attacker-controlled input.
 
-  **The fact that separates that from a real recovery is committed progress, not the scanner's
-  current regime** — which is why the arm needs no scan, no regime probe, and no third `Lexer::lex`
-  site. The trip event survives the rollback because the counter is outside the rollback set, and
-  the committed position is observable without lexing. `Stalled` is *a trip, no stop in force, no
-  committed progress*, and it is **sound rather than heuristic**: the `Lexer` determinism clause
-  says every scan-visible result derives entirely from source, offset and `State`, so an unmoved
-  committed offset means a repeat reproduces the trip.
+  **The partition is the `Lexer` determinism clause's own three inputs, and none of them needs a
+  scan to read** — so no regime probe and no third `Lexer::lex` site. `Stalled` is *a trip, no stop
+  in force, and all three inputs unchanged*: the source (constant), an offset **equal** to the
+  capture's, and the same lexer regime. It is sound rather than heuristic, because that is exactly
+  the clause's own precondition for a scan reproducing its result.
 
-  **`Stalled` cannot be permanent.** It clears the moment the parse commits anything past where the
-  attempt began — which is exactly what a successful recovery produces — and it is a claim about the
-  attempt that just ran, so a caller that answers it by installing a fresh regime has changed the
-  third input and the *next* capture judges that. Measured:
+  Each way the third clause can fail is its **own arm** rather than folded into the stall, because
+  they license opposite decisions. `ReKeyed` — the documented `set_state` / `state_mut` recovery
+  replaced the regime, typically **without moving the committed end**; calling that a stall would
+  reject a parse the fresh regime can finish. `Rewound` — a rollback landed *below* the capture, so
+  the capture describes a position the input has left and supports no claim about the one it is at.
+  `Progressed` — the parse committed past the capture. Testing "did not advance" instead of
+  "equals" folded both of the first two into `Stalled`; the enum is `#[non_exhaustive]`, so the
+  arms are additive.
+
+  **A `State` cannot be compared** — it is bounded `Debug + Clone` — so the crate now names one:
+  `Input::regime`, a generation stamped by `install_rekey`, the sole state-surgery site, and
+  **checkpointed** so a restore puts a regime's name back with the regime. There are exactly three
+  writers of `*state` — a commit (which moves the offset), a restore (which carries its own saved
+  generation) and a surgery — so **equal generation ∧ equal offset ⇒ equal `State`**. The
+  destructuring census in `input::lineage` classifies the new cell and is what keeps that trichotomy
+  from silently gaining a fourth member.
+
+  **`Stalled` cannot be permanent.** It clears when either input it tests moves: a commit past the
+  capture (`Progressed`) or a regime replacement (`ReKeyed`). Measured:
   `a_recovery_answering_the_stall_makes_progress_and_the_next_attempt_says_so` sees `[Stalled]` —
   one turn, not one per turn — and reads the whole document.
+
+  **The capture is affine, and that is load-bearing rather than tidy.** `ScannerAttempt` is not
+  `Clone` and `scanner_outcome` consumes it, because a reusable capture recreates the retry the arm
+  exists to close: hoist one out of the loop — the natural thing to write — and once any turn
+  retains progress past its `at`, every later rolled-back turn still compares *greater* than that
+  stale offset and reads `Progressed`. Three doctests pin it: the one-capture control compiles, and
+  spending one twice or cloning it does not. It is also why the pair is two types —
+  `ScannerTripBaseline` must stay `Copy` for the drivers that read a baseline more than once per
+  element loop, and because the split already existed for the `L::Offset`, making the attempt half
+  one-shot costs the driver half nothing.
+
+  **`InputRef::judge_scanner`** is the shape a root loop should reach for: it takes the capture,
+  runs the closure and returns `(ScannerOutcome, T)`, binding capture, judged work and verdict into
+  one turn, so neither placement exists to get wrong. The pair stays public as the lower-level
+  surface; affinity is what stops it being misused, and a capture held across turns and spent late
+  costs one stale verdict rather than a loop.
 
   The capture holds `ScannerTripBaseline` rather than restating it, so the nonce and the `'closure`
   brand carry over; it adds `span().end()`, **committed consumption**, never a cache-front reading —
@@ -2082,6 +2111,11 @@ UFCS spellings are `MyExt::scanner_attempt(inp)` and `MyExt::scanner_outcome(inp
 `input::ScannerAttempt` and `input::ScannerOutcome` are new glob-reachable names in `tokora::input`.
 `ScannerOutcome` is `#[non_exhaustive]`, so a downstream `match` must carry a wildcard arm and a
 later arm cannot break it.
+
+**`InputRef::judge_scanner` is the eighth**, on the same terms — `&mut self` this time, so it
+competes at the *same* first step the `inherent_method` template's consumer does; its two rows score
+`loud` rather than `ok*`, which is the counter-control the paragraphs above describe and not an
+exception to them. The UFCS spelling is `MyExt::judge_scanner(inp, f)`.
 
 #247 removes `Errors`' `DerefMut` and replaces the three legitimate uses it served with inherent
 methods. `Errors` has shipped since 0.7.3 **with no inherent item of its own**, so a consumer who

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,12 +227,28 @@ and will red until they do.
   arms are additive.
 
   **A `State` cannot be compared** — it is bounded `Debug + Clone` — so the crate now names one:
-  `Input::regime`, a generation stamped by `install_rekey`, the sole state-surgery site, and
-  **checkpointed** so a restore puts a regime's name back with the regime. There are exactly three
-  writers of `*state` — a commit (which moves the offset), a restore (which carries its own saved
-  generation) and a surgery — so **equal generation ∧ equal offset ⇒ equal `State`**. The
-  destructuring census in `input::lineage` classifies the new cell and is what keeps that trichotomy
-  from silently gaining a fourth member.
+  `Input::regime`, an **id** stamped by `install_rekey`, the sole state-surgery site, and
+  **checkpointed** so a restore puts a regime's name back with the regime. Three things make the
+  standing-in exact, and each is load-bearing:
+
+  - **the writers are three, and one names the regime.** A commit moves the committed offset, a
+    restore carries its own saved id, a surgery allocates a new one — so *equal id ∧ equal offset ⇒
+    equal `State`*. The destructuring census in `input::lineage` keeps that trichotomy from silently
+    gaining a fourth member;
+  - **there is no public path to the live `State`.** A census of assignment *sites* is a claim about
+    writes where the conclusion needed is about **values**, and the two coincide only for a type that
+    cannot be mutated through a shared reference — which `Debug + Clone` does not give. A `State`
+    holding a `Cell<Mode>` is valid, and a `&L::State` would let safe code flip it at the same
+    offset with no writer involved. **`InputRef::state`, `ParseState::state` and `Checkpoint::state`
+    therefore return owned clones** (breaking; see below). What is left is a `Clone` that *shares*
+    its interior mutability, which is the determinism clause's own named violation;
+  - **the id is allocated, not derived.** A separate monotone source, **outside** the rollback set,
+    for the reason the checkpoint-id source is: deriving the next id from the checkpointed cell is
+    not injective, and the counterexample is public — save at `g`, install B (`g+1`), roll back,
+    install C (`g+1`), two regimes wearing one name. At `REGIME_EXHAUSTED` the allocator stops and
+    that id is **excluded from equality**, so exhaustion forces `ReKeyed` rather than a false
+    `Stalled`. An earlier draft saturated an ordinary value and documented the harmless direction;
+    the harmful one was what it did.
 
   **`Stalled` cannot be permanent.** It clears when either input it tests moves: a commit past the
   capture (`Progressed`) or a regime replacement (`ReKeyed`). Measured:
@@ -661,6 +677,36 @@ and will red until they do.
   baseline in `input::input_ref::tests`.
 
 ### Changed (breaking)
+
+- **`InputRef::state`, `ParseState::state` and `Checkpoint::state` return the state BY VALUE**
+  (#311). They handed out `&L::State`; they now hand out an owned clone.
+
+  **A shared reference to the live state is a public path to scan-visible state that skips every
+  door this crate tracks.** `State` is bounded `Debug + Clone` and nothing more, so a valid one may
+  hold interior mutability — a `Cell<Mode>` a grammar flips to change how the region ahead lexes.
+  Through a `&L::State`, safe code could flip it without `set_state` or `state_mut`, and the input
+  would scan under a regime nothing on it records: `InputRef::scanner_outcome` would then answer
+  `ScannerOutcome::Stalled` — *repeating reproduces the trip* — over an input where repeating now
+  succeeds, and reject a recoverable parse. `Checkpoint::state` is the same hole one step back,
+  since the state a checkpoint holds is one a restore will install.
+
+  The alternative was to ask `State` implementors for a comparable identity. That moves an
+  obligation onto every downstream lexer that no compiler checks — a defaulted trait method walks
+  implementors straight past it, and a required one breaks all seven in-crate impls and every
+  downstream one while still being satisfiable by returning a constant. **Removing the capability
+  is enforced; requesting the discipline is not.**
+
+  **The blast radius is narrower than the signature suggests.** `inp.state().field` and
+  `inp.state().method()` both keep compiling, through auto-ref on the temporary; what breaks is
+  binding the reference (`let s: &L::State = inp.state();`) and dereferencing it. Measured across
+  this workspace: **two call sites**, both `*state.state()` in a test. The cost is one
+  `L::State::clone` per read — `state()` is a diagnostic accessor, not a scan path, and `state_mut`
+  (which re-keys eagerly) remains the way to change the regime.
+
+  What is **not** covered is a `Clone` that *shares* its interior mutability rather than
+  deep-copying it — an `Rc<Cell<_>>` tally and its family. That is already the `Lexer` determinism
+  clause's own named violation (*"a shared counter"*), and the input layer's behaviour under one is
+  unspecified-but-bounded, here as everywhere else on this branch.
 
 - **`RecursionLimiter::PARSE_DEFAULT_DEPTH` is 32, in every build, and was 16** (#297). Every
   unconfigured parse gets twice the depth. The profile arms hold the same number, deliberately, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -678,6 +678,38 @@ and will red until they do.
 
 ### Changed (breaking)
 
+- **`CachedToken::state` and `CachedToken::into_components` are crate-internal** (#311). The regime
+  a cached token carries is now an opaque payload: carried, cloned and moved, never read.
+
+  **This is the same hole as the accessor above, reached through the cache.** A cached token's
+  `State` is the regime that produced it, and the input **installs** it when the token is consumed.
+  Prefill a token, capture a scanner attempt, flip a `Cell<Mode>` in that token's post-state through
+  `InputRef::cache()`, then consume it inside a failing `try_attempt`: the scan trips under the
+  altered mode, the rollback restores the live state, the regime id and the offset **while the
+  consumed pre-save entry stays absent**, and the retry re-lexes from an unaltered state and can
+  succeed — over an input `scanner_outcome` has just called `Stalled`. That is a legitimately
+  deep-cloned `State`, not the shared-counter violation, so it was inside the boundary the previous
+  entry drew.
+
+  **The cut is at the type, not at the doors.** Every public surface that hands out lookahead hands
+  out a `CachedToken` — `InputRef::cache()` and the `Cache` views behind it, `peek_one`, every
+  `peek*` and `sync_*_then_peek*` — so closing the projection closes all of them at once, including
+  the ones nobody has written yet. `token`, `into_token`, `as_ref`, `map_token` and `Clone` stay
+  public, so a `Cache` implementation stores, returns, splits and clones entries exactly as before;
+  it never needed to read one. `CachedToken::new` was already crate-internal, so a regime cannot be
+  fabricated either — a cache can only hand back entries it was given.
+
+  **Blast radius: nothing in this workspace changed.** `cargo check --all-features --all-targets`
+  is clean without a single call-site edit — the conformance kit, the fuzz harness, the benches and
+  every test compile untouched, because the projection had no consumer outside `cache` itself.
+  A downstream consumer that read a peeked token's post-state loses that; `into_token` gives the
+  token and span.
+
+  `InputRef::cache()` itself is **kept**. With the regime unprojectable it exposes nothing unsound,
+  and withdrawing a diagnostic accessor that no longer leaks would be breakage bought for nothing.
+  The full per-projection enumeration, derived from the types that hold an `L::State` rather than
+  from the doors that were found, is on `InputRef::scanner_outcome`.
+
 - **`InputRef::state`, `ParseState::state` and `Checkpoint::state` return the state BY VALUE**
   (#311). They handed out `&L::State`; they now hand out an owned clone.
 

--- a/ci/name_collision/no_collision.txt
+++ b/ci/name_collision/no_collision.txt
@@ -120,6 +120,27 @@ scanner_trip_snapshot/discarded
 scanner_stopped_during_attempt/used
 scanner_stopped_during_attempt/discarded
 
+# ── `InputRef::scanner_attempt` / `scanner_outcome` — the same shape, seventh and eighth ──
+#
+# `pub fn scanner_attempt(&self) -> ScannerAttempt<'_, '_, L>` and
+# `pub fn scanner_outcome(&self, since: &ScannerAttempt<'_, '_, L>) -> ScannerOutcome`, both `&self`
+# on `InputRef`. The `recursion` analysis transfers unamended once more: the `inherent_method`
+# template's consumer is `fn NAME(&mut self) -> u8`, the probe's receiver expression already has
+# type `&mut InputRef<..>`, the consumer's item is found at the FIRST step of the receiver walk and
+# tokora's `&self` item one autoref step later, so the earlier pick wins on both sides and tokora's
+# item is never a candidate. Same controls as the four rows above.
+#
+# `scanner_outcome` returns an ENUM rather than a `bool` or a `u8`, so a consumer's `-> u8`
+# extension item would be a type mismatch at most call sites rather than a silent steal — but the
+# paired call passes the capture through inference exactly as the two pairs above do, which is the
+# shape that can still switch with no diagnostic. Disclosed with them in the CHANGELOG's
+# "Source-breaking additions that can change behaviour with no diagnostic at the call site" section,
+# with the UFCS spellings that restore the consumer's items.
+scanner_attempt/used
+scanner_attempt/discarded
+scanner_outcome/used
+scanner_outcome/discarded
+
 # ── `Emitter::commit_lexer_error` — the SAME rule, in the mirror ──────────────────────────
 #
 # tokora's is `fn commit_lexer_error(&mut self, ..)` on the `Emitter` trait. The

--- a/ci/name_collision/no_collision.txt
+++ b/ci/name_collision/no_collision.txt
@@ -96,6 +96,30 @@ tripped_during_attempt/discarded
 at_scanner_stop/used
 at_scanner_stop/discarded
 
+# ── `InputRef::scanner_trip_snapshot` / `scanner_stopped_during_attempt` — the same shape ─
+#
+# `pub fn scanner_trip_snapshot(&self) -> ScannerTripBaseline<'_>` and
+# `pub fn scanner_stopped_during_attempt(&self, since: ScannerTripBaseline<'_>) -> bool`, both
+# `&self` on `InputRef`, so the `recursion` analysis transfers unamended for the fifth and sixth
+# time: the `inherent_method` template's consumer is `fn NAME(&mut self) -> u8`, the probe's
+# receiver expression already has type `&mut InputRef<..>`, the consumer's item is found at the
+# FIRST step of the receiver walk and tokora's `&self` item one autoref step later. The earlier
+# pick wins on both sides. Same controls as the descent twins directly above — `recursion` /
+# `token_budget` for the shape, `descend` / `descending` on the same owner as the counter-control
+# that scores `loud` when the receivers agree.
+#
+# These are the **scanner** twins of `trip_snapshot` / `tripped_during_attempt`, and the paragraph
+# on those rows applies word for word, including the part that matters: the paired call passes the
+# baseline through inference, so a consumer whose extension item takes `&self` could take the call
+# with no diagnostic. That is disclosed in the CHANGELOG's "Source-breaking additions that can
+# change behaviour with no diagnostic at the call site" section, with the UFCS spelling that
+# restores the consumer's item — the two new names are added to the same entry rather than given
+# one of their own, because the analysis and the remedy are identical.
+scanner_trip_snapshot/used
+scanner_trip_snapshot/discarded
+scanner_stopped_during_attempt/used
+scanner_stopped_during_attempt/discarded
+
 # ── `Emitter::commit_lexer_error` — the SAME rule, in the mirror ──────────────────────────
 #
 # tokora's is `fn commit_lexer_error(&mut self, ..)` on the `Emitter` trait. The

--- a/ci/name_collision/no_collision.txt
+++ b/ci/name_collision/no_collision.txt
@@ -74,6 +74,28 @@ trip_snapshot/discarded
 tripped_during_attempt/used
 tripped_during_attempt/discarded
 
+# ── `InputRef::at_scanner_stop` — the `recursion` shape, fourth time ─────────────────────
+#
+# `pub fn at_scanner_stop(&self) -> bool` on `InputRef`, so the analysis on `recursion` above
+# transfers unamended: the `inherent_method` template's consumer is `fn NAME(&mut self) -> u8`, the
+# probe's receiver expression already has type `&mut InputRef<..>`, and the consumer's item is
+# found at the FIRST step of the receiver walk while tokora's `&self` item is one autoref step
+# later. The earlier pick wins on both sides and tokora's item is never a candidate. Same controls:
+# `recursion` / `token_budget` / the `trip_snapshot` pair for the shape, `descend` / `descending`
+# on the same owner as the counter-control that scores `loud` when the receivers agree.
+#
+# Read these two rows exactly as those: **"the `&mut self` consumer keeps its call"**, never as
+# "this name cannot be stolen". It can, by a consumer whose extension item takes `&self`, and the
+# harness cannot generate that consumer. That case is disclosed in the CHANGELOG's "Source-breaking
+# additions that can change behaviour with no diagnostic at the call site" section, with the UFCS
+# spelling that restores the consumer's item.
+#
+# This one takes NO argument where `tripped_during_attempt` takes one, so there is no inferred
+# argument type to hide which item won — the disclosure is written against a `bool` in a boolean
+# position, which is the shape that can still switch silently.
+at_scanner_stop/used
+at_scanner_stop/discarded
+
 # ── `Emitter::commit_lexer_error` — the SAME rule, in the mirror ──────────────────────────
 #
 # tokora's is `fn commit_lexer_error(&mut self, ..)` on the `Emitter` trait. The

--- a/tokora/src/cache/mod.rs
+++ b/tokora/src/cache/mod.rs
@@ -523,6 +523,51 @@ impl<T, State, Span> PeekedTokenExt<T, Span>
 }
 
 /// A cached token with its associated state.
+///
+/// # The `State` is a payload, not a projection
+///
+/// Every public surface that hands out a lookahead token hands out this type —
+/// [`InputRef::cache`](crate::InputRef::cache) and the [`Cache`] views behind it,
+/// [`InputRef::peek_one`](crate::InputRef::peek_one), and every `peek` / `sync_*_then_peek`
+/// result. The `State` it carries is the lexer regime that produced the token, and the input
+/// **installs** that regime when the token is consumed — so a public way to reach it is a public
+/// way to reach a regime the input will later make live. See the `state` accessor's own note for what that
+/// buys an adversary.
+///
+/// So the regime is carried, never read. What is public is everything that does not touch it:
+///
+/// ```rust
+/// use tokora::{cache::CachedToken, span::Spanned};
+///
+/// fn read_the_token<T, S, Sp>(cached: &CachedToken<T, S, Sp>) -> Spanned<&T, &Sp> {
+///   cached.token()
+/// }
+/// ```
+///
+/// Reading the regime does not compile:
+///
+/// ```compile_fail
+/// use tokora::cache::CachedToken;
+///
+/// fn read_the_regime<T, S, Sp>(cached: &CachedToken<T, S, Sp>) -> &S {
+///   // error[E0624]: method `state` is private
+///   cached.state()
+/// }
+/// ```
+///
+/// Neither does taking it apart to get at it:
+///
+/// ```compile_fail
+/// use tokora::cache::CachedToken;
+///
+/// fn split_out_the_regime<T, S, Sp>(cached: CachedToken<T, S, Sp>) -> S {
+///   // error[E0624]: method `into_components` is private
+///   cached.into_components().1
+/// }
+/// ```
+///
+/// Nor can one be **fabricated** — the constructor is crate-internal, so a [`Cache`]
+/// implementation can only ever hand back entries it was given.
 pub struct CachedToken<T, State, Span> {
   pub(crate) token: Spanned<T, Span>,
   pub(crate) state: State,
@@ -583,16 +628,49 @@ impl<T, State, Span> CachedToken<T, State, Span> {
     }
   }
 
-  /// Returns a reference to the state.
+  /// Returns a reference to the state — **crate-internal**.
+  ///
+  /// # The state a cached token carries is an opaque payload, and that is a wall
+  ///
+  /// A cached token's `State` is the lexer regime that produced it, and the input **installs** it
+  /// when the token is consumed. A public projection of it would therefore be a public path to a
+  /// regime the input will later make live — and [`State`](crate::state::State) is bounded
+  /// `Debug + Clone` and nothing more, so a perfectly valid one may hold interior mutability. A
+  /// grammar handed `&L::State` from the cache could flip a `Cell<Mode>` inside a token's
+  /// post-state, consume that token to install the altered regime, and have a rollback restore the
+  /// live state, the regime id and the offset while the consumed entry stays absent — the retry
+  /// then re-lexes from an unaltered state and can succeed, over an input
+  /// [`InputRef::scanner_outcome`](crate::InputRef::scanner_outcome) has just called
+  /// [`Stalled`](crate::input::ScannerOutcome::Stalled).
+  ///
+  /// **This is the one type through which that can happen**, so it is where the cut is made rather
+  /// than at each door. Every public surface that hands out a cached token —
+  /// [`InputRef::cache`](crate::InputRef::cache) and the [`Cache`] views behind it,
+  /// [`InputRef::peek_one`](crate::InputRef::peek_one), every `peek` and `sync_*_then_peek`
+  /// result — hands out this type, so closing it here closes all of them at once, including the
+  /// ones nobody has written yet.
+  ///
+  /// What survives is everything that does not read the regime: [`token`](Self::token),
+  /// [`into_token`](Self::into_token), [`as_ref`](Self::as_ref), [`map_token`](Self::map_token)
+  /// and [`Clone`]. A [`Cache`] implementation therefore still stores, returns, splits and clones
+  /// entries exactly as before — it never needed to read one — while nothing downstream can read
+  /// or fabricate a regime, since [`new`](Self::new) is crate-internal too.
+  // Every reader is feature-gated — the `conformance` cache kit and the in-crate suites — so the
+  // bare configuration has none, and the crate's `#![deny(warnings)]` calls that dead. It is kept
+  // rather than folded into the `pub(crate)` field it wraps because this is where the wall above
+  // is documented, and a field access is not a place to hang that.
+  #[allow(dead_code)]
   #[inline(always)]
-  pub const fn state(&self) -> &State {
+  pub(crate) const fn state(&self) -> &State {
     &self.state
   }
 
-  /// Consumes the cached token and returns the extras.
+  /// Consumes the cached token and returns the extras — **crate-internal**, for
+  /// [`state`](Self::state)'s reason. [`into_token`](Self::into_token) is the public half, and it
+  /// hands back exactly the part that is not a regime.
   #[inline(always)]
   #[allow(clippy::type_complexity)]
-  pub fn into_components(self) -> (Spanned<T, Span>, State) {
+  pub(crate) fn into_components(self) -> (Spanned<T, Span>, State) {
     (self.token, self.state)
   }
 }

--- a/tokora/src/input/checkpoint.rs
+++ b/tokora/src/input/checkpoint.rs
@@ -125,6 +125,14 @@ pub struct Checkpoint<'a, 'closure, L: Lexer<'a>> {
   /// the restored frontier stays paired with it; a saved `None` re-lexes and re-trips
   /// if the limit is reached again.
   pub(crate) poison_boundary: Option<L::Offset>,
+  /// The **regime generation** at save time (see [`Input::regime`](crate::input::Input)).
+  ///
+  /// In the same restore group as the boundary above and the `state` field, and for one reason: a
+  /// restore that puts a regime back must put back its name. Without it a state surgery performed
+  /// after the save and then rolled back would leave the input holding the *saved* `State` under a
+  /// *post-surgery* generation, and every reader that compares the two would call an identical
+  /// regime a different one.
+  pub(crate) regime: u64,
   /// The cache's monotone push count at save time.
   ///
   /// The cache memoizes token *values* but not the scan *side effects* of the region a
@@ -163,6 +171,7 @@ impl<'a, 'closure, L: Lexer<'a>> Checkpoint<'a, 'closure, L> {
     emitted_error_end: L::Offset,
     front_reported_end: Option<L::Offset>,
     poison_boundary: Option<L::Offset>,
+    regime: u64,
     cache_pushes: u64,
     #[cfg(all(
       debug_assertions,
@@ -180,6 +189,7 @@ impl<'a, 'closure, L: Lexer<'a>> Checkpoint<'a, 'closure, L> {
       emitted_error_end,
       front_reported_end,
       poison_boundary,
+      regime,
       cache_pushes,
       #[cfg(all(
         debug_assertions,

--- a/tokora/src/input/checkpoint.rs
+++ b/tokora/src/input/checkpoint.rs
@@ -211,7 +211,15 @@ impl<'a, 'closure, L: Lexer<'a>> Checkpoint<'a, 'closure, L> {
 
   /// Returns the state of the checkpoint.
   #[inline(always)]
-  pub const fn state(&self) -> &L::State {
-    &self.state
+  /// Returns the state of the checkpoint, **by value**.
+  ///
+  /// A clone for [`InputRef::state`](crate::InputRef::state)'s reason, one step further back: the
+  /// state a checkpoint holds is the one a [`restore`](crate::InputRef::restore) will *install*,
+  /// so a shared reference to it is a path to a future live regime. A `State` carrying interior
+  /// mutability could be flipped through it and then restored, installing a regime under the
+  /// generation the checkpoint saved — the same untracked-surgery hole, taken through the
+  /// `unstable-raw` door instead of the ordinary one.
+  pub fn state(&self) -> L::State {
+    self.state.clone()
   }
 }

--- a/tokora/src/input/input_ref/census_tests.rs
+++ b/tokora/src/input/input_ref/census_tests.rs
@@ -3414,3 +3414,38 @@ fn posture_census_expected_tokens_closure_is_named_only_where_report_skipped() {
     }
   }
 }
+
+/// PROGRESS_CENSUS — the root-loop guard's capture measures **committed consumption**, never a
+/// cache-front cursor.
+///
+/// The same rule, and the same reason, as the collection drivers'
+/// `every_progress_guard_reads_committed_progress`: a lookahead fill moves the cursor across
+/// skipped trivia without committing anything, so a cursor-keyed capture reads false progress and
+/// turns a stalled attempt into `ScannerOutcome::Progressed` — the one direction that re-opens the
+/// unbounded retry that arm exists to close.
+///
+/// It is a **source** census because the two accessors coincide at every position this crate's own
+/// suites can drive the pair to. Reaching *trip, no stop in force, cache still filled* needs a trip
+/// whose latch was cleared without clearing the cache, and every door that clears the latch
+/// (`set_state`, `state_mut`, a checkpoint restore) empties or truncates the cache in the same
+/// step. So the metric cannot be pinned by a behavioural cell, and is pinned here instead.
+#[test]
+fn the_scanner_attempt_capture_reads_committed_consumption() {
+  let descent = SOURCES
+    .iter()
+    .find(|(name, _)| *name == "descent.rs")
+    .expect("descent.rs is censused")
+    .1;
+  let body = method_body(descent, "scanner_attempt");
+  assert!(
+    body.contains("self.span().end_ref()"),
+    "PROGRESS_CENSUS drift: `scanner_attempt` must capture `self.span().end_ref()` — committed \
+     consumption — as the position a stall compares against (grep PROGRESS_CENSUS)."
+  );
+  assert!(
+    !body.contains("cursor("),
+    "PROGRESS_CENSUS drift: `scanner_attempt` reads a cache-front cursor. A lookahead fill moves \
+     it across skipped trivia without committing, so the capture would read false progress and \
+     report a stalled attempt as `Progressed` (grep PROGRESS_CENSUS)."
+  );
+}

--- a/tokora/src/input/input_ref/descent.rs
+++ b/tokora/src/input/input_ref/descent.rs
@@ -1174,34 +1174,22 @@ where
   /// catches a trip, does not recover the regime, and then fails ordinarily is re-raised as a
   /// stop. It fails closed, never open.
   ///
-  /// # What it does NOT answer, and why
+  /// # It is the stop question, and it is NOT a sufficient root-loop guard
   ///
-  /// **A trip inside a speculative wrapper that rolled back.**
+  /// A trip inside a speculative wrapper is restored away *together with the tally that took it*.
   /// [`try_attempt`](Self::try_attempt), [`attempt_parse`](Self::attempt_parse) and a
-  /// rollback-on-drop [`Transaction`] restore a checkpoint that predates the trip, so the boundary
-  /// comes back as `None` and this reads clean. The *event* survives — the counter is outside the
-  /// rollback set — but the second conjunct does not, and that is not a defect of the conjunct:
-  /// the same restore reinstates the tally the checkpoint saved, which is the refund
-  /// [`TokenLimiter`](crate::state::token_tracker::TokenLimiter) documents as *the correct answer*
-  /// for a bound on the committed stream. After that rollback the scanner really can scan again,
-  /// and both readings say so correctly.
+  /// rollback-on-drop [`Transaction`] reinstate the checkpointed state and a pre-trip `None`
+  /// boundary, and for a scanner bound held in the lexer state — the supported placement
+  /// [`TokenLimiter`](crate::state::token_tracker::TokenLimiter) documents — the input-side refusal
+  /// bit is `false` too. This method then answers `false`, **correctly**: the restore reinstated
+  /// the tally the checkpoint saved, which is the refund that type documents as the right answer
+  /// for a bound on the committed stream, so a scan from there really does yield a token.
   ///
-  /// What is left over is a **loop** that keeps redoing refundable work: it trips, rolls back, and
-  /// retries from the state it just failed in, never advancing. That is a resource-**placement**
-  /// problem, and `TokenLimiter`'s own documentation names the fix — a bound on *work performed*
-  /// belongs on the input, as a [`TokenBudget`](crate::input::TokenBudget), where no rollback
-  /// reaches it and where this verdict is durable. Measured both ways in
-  /// `a_state_side_bound_under_speculation_is_refunded_and_neither_reading_closes_it`.
-  ///
-  /// Telling *"the tally was refunded to a spent state"* from *"the tally was refunded to a
-  /// usable one"* cannot be done from the stored regime, because a limit trip is decided **after**
-  /// a scan and the tripping scan commits nothing — so `*self.state` is always the pre-trip regime
-  /// and answers `Ok` over a scanner that is stopped. Only running the lexer separates them, which
-  /// is the same sentence `settle_met_ceiling`'s one-shot probe is built on; and a probe here would
-  /// be a **third** `Lexer::lex` site in this layer, which `RESUME_CENSUS`
-  /// (`resume_census_one_pairing_site`) refuses — *"a third invocation is a third way to produce an
-  /// item"* — and which would put unbudgeted lexer work behind a public `&self` reader. So the case
-  /// is left open and named rather than closed by widening that gate.
+  /// The caller nonetheless holds the trip-derived error with the cursor and state exactly where
+  /// the attempt began, and a loop guarded on this boolean alone retries the identical scan for
+  /// ever. **Match [`scanner_outcome`](Self::scanner_outcome) instead**, whose
+  /// [`Stalled`](crate::input::ScannerOutcome::Stalled) arm is precisely that state; this method is
+  /// its [`Stopped`](crate::input::ScannerOutcome::Stopped) arm and nothing more.
   ///
   /// # Measured
   ///
@@ -1232,6 +1220,131 @@ where
     // Two carriers can hold a scanner stop and the trip counter does not say which one did, so
     // both are asked. The budget's is the durable one and is asked first.
     self.token_budget.refused_an_item() || self.stop_still_latched()
+  }
+
+  /// Captures one attempt's scanner bookkeeping — the trip baseline and the committed position —
+  /// for [`scanner_outcome`](Self::scanner_outcome).
+  ///
+  /// Taken **per attempt**, immediately before the thing being judged runs.
+  /// [`scanner_trip_snapshot`](Self::scanner_trip_snapshot) beside it is the *driver*'s value and
+  /// is taken per collection; the two units are different because the two questions are. *"Is the
+  /// scanner spent"* does not stop being true of a later element, so hoisting that baseline is
+  /// right; *"did **this** attempt trip without committing anything"* is about one attempt and
+  /// nothing else, so hoisting **this** one would compare a later failure against a position many
+  /// elements ago and call every one of them progress.
+  ///
+  /// Costs one `L::Offset::clone` on top of the baseline's `u64` load and nonce derivation. That
+  /// clone is caller code and is the only step here that can unwind; nothing durable is in flight
+  /// on a `&self` read, so there is nothing for it to tear.
+  #[inline]
+  pub fn scanner_attempt(&self) -> ScannerAttempt<'inp, 'closure, L> {
+    ScannerAttempt {
+      trips: self.scanner_trip_snapshot(),
+      // PROGRESS_CENSUS — committed consumption, never the cache-front reading. A lookahead fill
+      // moves that reading across skipped trivia without consuming anything, and a no-progress
+      // guard counting it would call a stalled attempt progress. Same rule, and the same reason,
+      // as the collection drivers' own guards.
+      at: self.span().end_ref().clone(),
+    }
+  }
+
+  /// What the attempt that took `since` as its [`scanner_attempt`](Self::scanner_attempt) capture
+  /// did to the scanner — the **root-loop guard**, and the reading a retrying loop must match on.
+  ///
+  /// ```text
+  /// loop {
+  ///   let att = inp.scanner_attempt();          // per ATTEMPT, at the top of the turn
+  ///   match definition(inp) {                    // may speculate internally
+  ///     Ok(true)  => {}
+  ///     Ok(false) => return Ok(()),
+  ///     Err(e) => match inp.scanner_outcome(&att) {
+  ///       ScannerOutcome::Stopped => return Err(e),   // the document is truncated
+  ///       ScannerOutcome::Stalled => return Err(e),   // retrying would repeat this exactly
+  ///       _ => report(),                              // an ordinary syntax error: file and go on
+  ///     },
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// # Why a boolean could not be this
+  ///
+  /// [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt) answers *"is a stop
+  /// in force"*, and it is **correct** and **not a sufficient loop guard**, because the failure
+  /// that costs most is one where no stop is in force. A failing
+  /// [`try_attempt`](Self::try_attempt) restores the checkpointed state and a pre-trip `None`
+  /// boundary; for a scanner bound held in the lexer state — the supported placement
+  /// [`TokenLimiter`](crate::state::token_tracker::TokenLimiter) documents, not a violating shared
+  /// counter — the input-side refusal bit is `false` as well. Every live reading of the input is
+  /// then correctly clean, the caller nonetheless holds the trip-derived error, and the cursor and
+  /// state are exactly where the attempt began. A loop guarded on the boolean retries the identical
+  /// scan and can burn unbounded CPU on attacker-controlled input.
+  ///
+  /// The fact that separates that from a real recovery is not the scanner's current regime — which
+  /// is why no probe of the regime, and no scan, is needed — but **committed progress**. The trip
+  /// event survives the rollback because the counter is outside the rollback set, and the committed
+  /// position is observable without lexing. A trip with no committed progress after it is
+  /// [`Stalled`](ScannerOutcome::Stalled); a trip with progress is
+  /// [`Progressed`](ScannerOutcome::Progressed).
+  ///
+  /// # Why `Stalled` is sound rather than a guess
+  ///
+  /// The [`Lexer`](crate::Lexer) contract's determinism clause is the proof: *every scan-visible
+  /// result … must derive **entirely** from the source, the offset being lexed at, and the lexer
+  /// `State`*. `Stalled` says the trip happened and the committed offset is unmoved, so re-running
+  /// the attempt varies none of the three — the same trip is reproduced. It is a claim about the
+  /// attempt that just ran, so it stays true even for a caller that goes on to install a fresh
+  /// regime: that caller has changed the third input, and the *next* attempt's capture is what
+  /// judges it.
+  ///
+  /// The one lexer shape it does not hold for is the one the determinism clause already excludes —
+  /// a tally the state merely points at, whose behaviour under a restore is
+  /// unspecified-but-bounded.
+  ///
+  /// # What clears each arm
+  ///
+  /// - [`Stopped`](ScannerOutcome::Stopped) clears where its carrier dies: a
+  ///   [`TokenBudget`](crate::input::TokenBudget) refusal never clears, and a lexer-side latch
+  ///   clears at [`set_state`](Self::set_state) / [`state_mut`](Self::state_mut) or a restore of a
+  ///   `None` boundary. Unchanged from
+  ///   [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt), which is this
+  ///   arm.
+  /// - [`Stalled`](ScannerOutcome::Stalled) clears the moment the parse **commits** anything past
+  ///   where the attempt began — which is exactly what a successful recovery produces, and the
+  ///   only thing that distinguishes one from a retry. It cannot be permanent: an attempt that
+  ///   consumes even one token is [`Progressed`](ScannerOutcome::Progressed), and an attempt with
+  ///   no trip in it is [`NoTrip`](ScannerOutcome::NoTrip) whatever the position did.
+  ///
+  /// # It is not a substitute for placing the bound where the work is
+  ///
+  /// This makes the futile retry **detectable**, which is what a loop needs to stop. It does not
+  /// make the work **bounded** — that is a placement question, and
+  /// [`TokenBudget`](crate::input::TokenBudget) on the input is the answer, because no rollback
+  /// reaches it. A root loop that must hold against hostile input wants both: this to end the loop,
+  /// and the budget to bound what any loop can spend.
+  ///
+  /// # Costs
+  ///
+  /// A nonce comparison, a `u64` comparison, and — only when those say a trip happened — a `bool`
+  /// load, an `Option::is_some`, and one `Offset::Ord` comparison. No scan, no lookahead fill, no
+  /// state clone.
+  ///
+  /// # Panics
+  ///
+  /// If `since` came from a different input than `self`.
+  #[inline]
+  pub fn scanner_outcome(&self, since: &ScannerAttempt<'inp, 'closure, L>) -> ScannerOutcome {
+    if !self.scanner_tripped_during_attempt(since.trips) {
+      return ScannerOutcome::NoTrip;
+    }
+    if self.token_budget.refused_an_item() || self.stop_still_latched() {
+      return ScannerOutcome::Stopped;
+    }
+    // Strictly advanced, not merely different: a restore can put the committed end back BELOW the
+    // capture, and moving backwards is not progress.
+    if self.span().end_ref() > &since.at {
+      return ScannerOutcome::Progressed;
+    }
+    ScannerOutcome::Stalled
   }
 
   /// Whether a terminal scanner stop is latched **anywhere**, positionally unqualified — the

--- a/tokora/src/input/input_ref/descent.rs
+++ b/tokora/src/input/input_ref/descent.rs
@@ -1334,17 +1334,42 @@ where
   ///   both from one saved pair. The destructuring census in `input::lineage` is what keeps that
   ///   trichotomy from silently gaining a fourth member.
   ///
-  ///   **And there is no public path to the live `State` at all.** A census of *assignment sites*
-  ///   is a claim about writes, and the conclusion needed is about **values** — the two coincide
-  ///   only for a type that cannot be mutated through a shared reference, which `Debug + Clone`
-  ///   does not give. A `State` holding a `Cell<Mode>` is perfectly valid, and a `&L::State`
-  ///   handed to safe code would let a grammar flip it at the same offset with no writer involved,
-  ///   leaving this reading to answer `Stalled` over an input where a repeat now succeeds.
-  ///   [`state`](Self::state) and [`Checkpoint::state`](crate::input::Checkpoint::state)
-  ///   therefore hand back **owned clones**; the capability is gone rather than deprecated. What
-  ///   is left is a `Clone` that *shares* its interior mutability rather than deep-copying it,
-  ///   which is the [`Lexer`](crate::Lexer) determinism clause's own named violation and out of
-  ///   scope here as everywhere else on this reading.
+  ///   **And no public projection reaches a live-or-installable `State` at all.** A census of
+  ///   *assignment sites* is a claim about writes, and the conclusion needed is about **values** —
+  ///   the two coincide only for a type that cannot be mutated through a shared reference, which
+  ///   `Debug + Clone` does not give. A `State` holding a `Cell<Mode>` is perfectly valid, so any
+  ///   `&L::State` handed to safe code lets a grammar flip it with no writer involved. The
+  ///   enumeration below is derived from the **types that hold one**, not from the doors that were
+  ///   found:
+  ///
+  ///   | holder | public projection | verdict |
+  ///   |---|---|---|
+  ///   | `Input` | none; fields private, not constructible while a handle lives | closed by construction |
+  ///   | [`InputRef`] | [`state`](Self::state) | owned clone |
+  ///   | [`InputRef`] | [`state_mut`](Self::state_mut), [`set_state`](Self::set_state) | **tracked** — both allocate a new regime id |
+  ///   | [`InputRef`] | [`lexer`](Self::lexer) | an owned `L` built from a clone; its `Lexer::state` is the caller's own copy |
+  ///   | [`InputRef`] | [`cache`](Self::cache), and every [`Cache`](crate::cache::Cache) view behind it | reaches only [`CachedToken`](crate::cache::CachedToken), whose regime is not projectable |
+  ///   | [`InputRef`] | every `peek*` and `sync_*_then_peek*` result | same — they are all `CachedToken` |
+  ///   | [`InputRef`] | `next`, `try_expect*`, `consume_cached_*` | yield `Spanned<L::Token, L::Span>` — provably state-free |
+  ///   | [`ParseState`](crate::ParseState) | `state` / `state_mut` | forward the two rows above |
+  ///   | [`Checkpoint`](crate::input::Checkpoint) | `state` | owned clone |
+  ///   | [`Checkpoint`](crate::input::Checkpoint) | `cursor` | an offset — provably state-free |
+  ///   | [`CachedToken`](crate::cache::CachedToken) | `state`, `into_components`, `new` | crate-internal: not readable, not fabricable |
+  ///   | [`CachedToken`](crate::cache::CachedToken) | `token`, `into_token`, `as_ref`, `map_token`, `Clone` | carry the regime as an opaque payload |
+  ///   | `PeekedTokenExt` | `token`, `span` | state-free |
+  ///   | `ThroughEntry`, `AtFrontier`, `Resume`, `Session` | not public | closed by visibility |
+  ///
+  ///   The cut for the whole cache/peek family is made at **`CachedToken`**, not at each door,
+  ///   because every one of those doors hands out that one type — so it holds for the doors that
+  ///   do not exist yet as well.
+  ///
+  ///   Two things sit **outside** this table rather than in it, both by the same rule the crate
+  ///   already applies to a lexer. [`Cache`](crate::cache::Cache) and [`Lexer`](crate::Lexer) are
+  ///   *caller-implemented infrastructure*: a cache owns the entries it stores and can hand back
+  ///   the wrong one, which is a cache-conformance violation, and a `Clone` that **shares** its
+  ///   interior mutability rather than deep-copying it is the determinism clause's own named
+  ///   violation. Under either, this crate's behaviour is unspecified-but-bounded — the same
+  ///   posture, and the same boundary, as everywhere else on this reading.
   ///
   ///   **The id is allocated, not derived.** Its source is monotone and outside the rollback set,
   ///   because deriving the next id from the checkpointed cell is not injective: save at `g`,

--- a/tokora/src/input/input_ref/descent.rs
+++ b/tokora/src/input/input_ref/descent.rs
@@ -1240,6 +1240,9 @@ where
   pub fn scanner_attempt(&self) -> ScannerAttempt<'inp, 'closure, L> {
     ScannerAttempt {
       trips: self.scanner_trip_snapshot(),
+      // The third determinism input's name. Read before the position for no reason but order;
+      // both are plain reads off cells this handle borrows.
+      regime: *self.regime,
       // PROGRESS_CENSUS — committed consumption, never the cache-front reading. A lookahead fill
       // moves that reading across skipped trivia without consuming anything, and a no-progress
       // guard counting it would call a stalled attempt progress. Same rule, and the same reason,
@@ -1279,26 +1282,60 @@ where
   /// state are exactly where the attempt began. A loop guarded on the boolean retries the identical
   /// scan and can burn unbounded CPU on attacker-controlled input.
   ///
-  /// The fact that separates that from a real recovery is not the scanner's current regime — which
-  /// is why no probe of the regime, and no scan, is needed — but **committed progress**. The trip
-  /// event survives the rollback because the counter is outside the rollback set, and the committed
-  /// position is observable without lexing. A trip with no committed progress after it is
-  /// [`Stalled`](ScannerOutcome::Stalled); a trip with progress is
-  /// [`Progressed`](ScannerOutcome::Progressed).
+  /// The facts that separate that from a real recovery are the determinism clause's own inputs, and
+  /// none of them needs a scan to read. The trip event survives the rollback because the counter is
+  /// outside the rollback set; the committed offset is observable directly; and the regime has a
+  /// name (`Input::regime`) because a `State` cannot be compared. A trip
+  /// after which all three are unchanged is [`Stalled`](ScannerOutcome::Stalled), and each way that
+  /// can fail is its own arm.
   ///
-  /// # Why `Stalled` is sound rather than a guess
+  /// # The partition, and why it is exhaustive and disjoint
   ///
-  /// The [`Lexer`](crate::Lexer) contract's determinism clause is the proof: *every scan-visible
+  /// Four facts are read, in this order, first match winning:
+  ///
+  /// 1. **did a trip happen inside the attempt** — the session counter against the capture's, which
+  ///    is outside the rollback set. `no` ⇒ [`NoTrip`](ScannerOutcome::NoTrip).
+  /// 2. **is a stop in force now** — the input budget's durable refusal, or a latched frontier.
+  ///    `yes` ⇒ [`Stopped`](ScannerOutcome::Stopped).
+  /// 3. **is the lexer regime the one the capture saw** — the
+  ///    `Input::regime` generation. `no` ⇒
+  ///    [`ReKeyed`](ScannerOutcome::ReKeyed).
+  /// 4. **where is the committed end relative to the capture's** — an `Ord` comparison, whose three
+  ///    outcomes are [`Progressed`](ScannerOutcome::Progressed),
+  ///    [`Stalled`](ScannerOutcome::Stalled) and [`Rewound`](ScannerOutcome::Rewound).
+  ///
+  /// **Disjoint** because the arms are the branches of a single `if`/`if`/`if`/`match` chain — no
+  /// input reaches two of them. **Exhaustive** because the first three are booleans whose `false`
+  /// falls through and the fourth is a total trichotomy on [`Ord`], so every combination of the
+  /// four facts lands in exactly one arm.
+  ///
+  /// # Why `Stalled` is sound rather than a guess, and why it is the EQUAL arm
+  ///
+  /// The [`Lexer`](crate::Lexer) contract's determinism clause is the theorem: *every scan-visible
   /// result … must derive **entirely** from the source, the offset being lexed at, and the lexer
-  /// `State`*. `Stalled` says the trip happened and the committed offset is unmoved, so re-running
-  /// the attempt varies none of the three — the same trip is reproduced. It is a claim about the
-  /// attempt that just ran, so it stays true even for a caller that goes on to install a fresh
-  /// regime: that caller has changed the third input, and the *next* attempt's capture is what
-  /// judges it.
+  /// `State`*. So a repeat reproduces a trip exactly when all three are unchanged, and `Stalled`
+  /// has to test all three:
   ///
-  /// The one lexer shape it does not hold for is the one the determinism clause already excludes —
-  /// a tally the state merely points at, whose behaviour under a restore is
-  /// unspecified-but-bounded.
+  /// - the **source** never changes;
+  /// - the **offset** is tested for *equality*, not for "did not advance". A rewind also fails to
+  ///   advance, and a capture describing a position the input has left supports no claim about the
+  ///   one it is at now — that is [`Rewound`](ScannerOutcome::Rewound), and folding it into a stall
+  ///   would be a repetition claim with nothing behind it;
+  /// - the **`State`** cannot be compared — it is bounded `Debug + Clone` and nothing more — so the
+  ///   generation stands in for it, and the standing-in is exact rather than approximate. There are
+  ///   exactly three writers of `*state`: a **commit**, which threads the lexer's post-token state
+  ///   forward and moves the committed span with it; a **restore**, which installs a checkpoint's
+  ///   saved pair *and* the generation that names it; and a **surgery**
+  ///   ([`set_state`](Self::set_state) / [`state_mut`](Self::state_mut)) through `install_rekey`,
+  ///   the sole bump site. Given that trichotomy, **equal generation ∧ equal committed offset ⇒
+  ///   equal `State`**: a commit would have moved the offset, a surgery would have moved the
+  ///   generation, and a restore carries both from the same saved pair. The write census in
+  ///   `input::lineage` is what keeps the trichotomy from silently gaining a fourth member.
+  ///
+  /// The predicate therefore matches the theorem rather than approximating it. An earlier version
+  /// tested only "not advanced", which was strictly weaker in both directions — it called a
+  /// documented `state_mut` recovery a stall (rejecting a recoverable parse) and swallowed a rewind
+  /// into the same arm.
   ///
   /// # What clears each arm
   ///
@@ -1308,11 +1345,14 @@ where
   ///   `None` boundary. Unchanged from
   ///   [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt), which is this
   ///   arm.
-  /// - [`Stalled`](ScannerOutcome::Stalled) clears the moment the parse **commits** anything past
-  ///   where the attempt began — which is exactly what a successful recovery produces, and the
-  ///   only thing that distinguishes one from a retry. It cannot be permanent: an attempt that
-  ///   consumes even one token is [`Progressed`](ScannerOutcome::Progressed), and an attempt with
-  ///   no trip in it is [`NoTrip`](ScannerOutcome::NoTrip) whatever the position did.
+  /// - [`Stalled`](ScannerOutcome::Stalled) clears on **either** of the two inputs it tests
+  ///   moving: the parse commits anything past where the attempt began
+  ///   ([`Progressed`](ScannerOutcome::Progressed)), or the regime is replaced
+  ///   ([`ReKeyed`](ScannerOutcome::ReKeyed)). Both are what a successful recovery produces, and
+  ///   between them they are the only things that distinguish a recovery from a retry. It cannot
+  ///   be permanent: an attempt that consumes even one token, or that takes the documented
+  ///   recovery door, is a different arm, and an attempt with no trip in it is
+  ///   [`NoTrip`](ScannerOutcome::NoTrip) whatever the position did.
   ///
   /// # It is not a substitute for placing the bound where the work is
   ///
@@ -1332,19 +1372,72 @@ where
   ///
   /// If `since` came from a different input than `self`.
   #[inline]
-  pub fn scanner_outcome(&self, since: &ScannerAttempt<'inp, 'closure, L>) -> ScannerOutcome {
+  pub fn scanner_outcome(&self, since: ScannerAttempt<'inp, 'closure, L>) -> ScannerOutcome {
+    // ── the partition, first match wins; see the doc's exhaustive/disjoint argument ──
     if !self.scanner_tripped_during_attempt(since.trips) {
       return ScannerOutcome::NoTrip;
     }
     if self.token_budget.refused_an_item() || self.stop_still_latched() {
       return ScannerOutcome::Stopped;
     }
-    // Strictly advanced, not merely different: a restore can put the committed end back BELOW the
-    // capture, and moving backwards is not progress.
-    if self.span().end_ref() > &since.at {
-      return ScannerOutcome::Progressed;
+    // The THIRD determinism input, before either position test: a replaced regime is the strongest
+    // statement about repeatability there is, and it holds whatever the offset did.
+    if *self.regime != since.regime {
+      return ScannerOutcome::ReKeyed;
     }
-    ScannerOutcome::Stalled
+    // Trichotomy on `Offset: Ord`, so the three arms below are exhaustive and disjoint by
+    // construction. `Stalled` is the EQUAL arm and nothing else — "not advanced" would fold a
+    // rewind into it and claim a repetition the capture cannot support.
+    match self.span().end_ref().cmp(&since.at) {
+      core::cmp::Ordering::Greater => ScannerOutcome::Progressed,
+      core::cmp::Ordering::Less => ScannerOutcome::Rewound,
+      core::cmp::Ordering::Equal => ScannerOutcome::Stalled,
+    }
+  }
+
+  /// Judges one turn: takes the capture, runs `f`, and hands back its value beside the
+  /// [`ScannerOutcome`] for exactly that span of the parse.
+  ///
+  /// **The shape a retrying root loop should reach for**, because it is the one that cannot be
+  /// misplaced. [`scanner_attempt`](Self::scanner_attempt) and
+  /// [`scanner_outcome`](Self::scanner_outcome) are the lower-level surface, and the capture being
+  /// affine already makes a *reused* one a compile error — but a capture can still be taken outside
+  /// a loop and spent late, which costs one stale verdict. Here capture, judged work and verdict
+  /// are bound into a single turn, so neither placement exists to get wrong.
+  ///
+  /// ```text
+  /// loop {
+  ///   let (outcome, parsed) = inp.judge_scanner(|inp| definition(inp));
+  ///   match parsed {
+  ///     Ok(true)  => {}
+  ///     Ok(false) => return Ok(()),
+  ///     Err(e) => match outcome {
+  ///       ScannerOutcome::Stopped | ScannerOutcome::Stalled => return Err(e),
+  ///       _ => report(),
+  ///     },
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// The outcome comes **first** in the tuple so a caller destructuring it cannot quietly drop it
+  /// the way a trailing element invites; `f`'s value is returned untouched, including an `Err`,
+  /// because judging is not deciding.
+  ///
+  /// It adds no rollback and no guard of its own — `f` receives the same handle, and whatever it
+  /// does with [`try_attempt`](Self::try_attempt) or a [`Transaction`] is its own business. The
+  /// only thing this owns is the pair of readings around it.
+  ///
+  /// Costs exactly [`scanner_attempt`](Self::scanner_attempt) plus
+  /// [`scanner_outcome`](Self::scanner_outcome): one `L::Offset::clone` and, on an attempt that did
+  /// not trip, a nonce and a `u64` comparison.
+  #[inline]
+  pub fn judge_scanner<F, T>(&mut self, f: F) -> (ScannerOutcome, T)
+  where
+    F: FnOnce(&mut Self) -> T,
+  {
+    let attempt = self.scanner_attempt();
+    let value = f(self);
+    (self.scanner_outcome(attempt), value)
   }
 
   /// Whether a terminal scanner stop is latched **anywhere**, positionally unqualified — the

--- a/tokora/src/input/input_ref/descent.rs
+++ b/tokora/src/input/input_ref/descent.rs
@@ -1321,16 +1321,37 @@ where
   ///   advance, and a capture describing a position the input has left supports no claim about the
   ///   one it is at now — that is [`Rewound`](ScannerOutcome::Rewound), and folding it into a stall
   ///   would be a repetition claim with nothing behind it;
-  /// - the **`State`** cannot be compared — it is bounded `Debug + Clone` and nothing more — so the
-  ///   generation stands in for it, and the standing-in is exact rather than approximate. There are
-  ///   exactly three writers of `*state`: a **commit**, which threads the lexer's post-token state
-  ///   forward and moves the committed span with it; a **restore**, which installs a checkpoint's
-  ///   saved pair *and* the generation that names it; and a **surgery**
-  ///   ([`set_state`](Self::set_state) / [`state_mut`](Self::state_mut)) through `install_rekey`,
-  ///   the sole bump site. Given that trichotomy, **equal generation ∧ equal committed offset ⇒
-  ///   equal `State`**: a commit would have moved the offset, a surgery would have moved the
-  ///   generation, and a restore carries both from the same saved pair. The write census in
-  ///   `input::lineage` is what keeps the trichotomy from silently gaining a fourth member.
+  /// - the **`State`** cannot be compared — it is bounded `Debug + Clone` and nothing more — so a
+  ///   regime **id** stands in for it, and the standing-in is exact rather than approximate. Two
+  ///   things make it so, and each is load-bearing:
+  ///
+  ///   **The writers are three, and one of them names the regime.** A **commit** threads the
+  ///   lexer's post-token state forward and moves the committed span with it; a **restore**
+  ///   installs a checkpoint's saved pair *and* the id that names it; a **surgery**
+  ///   ([`set_state`](Self::set_state) / [`state_mut`](Self::state_mut)) goes through
+  ///   `install_rekey`, the sole allocation site. So **equal id ∧ equal committed offset ⇒ equal
+  ///   `State`**: a commit would have moved the offset, a surgery the id, and a restore carries
+  ///   both from one saved pair. The destructuring census in `input::lineage` is what keeps that
+  ///   trichotomy from silently gaining a fourth member.
+  ///
+  ///   **And there is no public path to the live `State` at all.** A census of *assignment sites*
+  ///   is a claim about writes, and the conclusion needed is about **values** — the two coincide
+  ///   only for a type that cannot be mutated through a shared reference, which `Debug + Clone`
+  ///   does not give. A `State` holding a `Cell<Mode>` is perfectly valid, and a `&L::State`
+  ///   handed to safe code would let a grammar flip it at the same offset with no writer involved,
+  ///   leaving this reading to answer `Stalled` over an input where a repeat now succeeds.
+  ///   [`state`](Self::state) and [`Checkpoint::state`](crate::input::Checkpoint::state)
+  ///   therefore hand back **owned clones**; the capability is gone rather than deprecated. What
+  ///   is left is a `Clone` that *shares* its interior mutability rather than deep-copying it,
+  ///   which is the [`Lexer`](crate::Lexer) determinism clause's own named violation and out of
+  ///   scope here as everywhere else on this reading.
+  ///
+  ///   **The id is allocated, not derived.** Its source is monotone and outside the rollback set,
+  ///   because deriving the next id from the checkpointed cell is not injective: save at `g`,
+  ///   install B (`g + 1`), roll back to `g`, install C (`g + 1`) — two regimes, one name. At
+  ///   `REGIME_EXHAUSTED` the allocator stops and that id is
+  ///   excluded from equality, so exhaustion forces
+  ///   [`ReKeyed`](ScannerOutcome::ReKeyed) rather than a false stall.
   ///
   /// The predicate therefore matches the theorem rather than approximating it. An earlier version
   /// tested only "not advanced", which was strictly weaker in both directions — it called a
@@ -1382,7 +1403,7 @@ where
     }
     // The THIRD determinism input, before either position test: a replaced regime is the strongest
     // statement about repeatability there is, and it holds whatever the offset did.
-    if *self.regime != since.regime {
+    if !crate::input::same_regime(*self.regime, since.regime) {
       return ScannerOutcome::ReKeyed;
     }
     // Trichotomy on `Offset: Ord`, so the three arms below are exhaustive and disjoint by

--- a/tokora/src/input/input_ref/descent.rs
+++ b/tokora/src/input/input_ref/descent.rs
@@ -921,6 +921,336 @@ where
     *self.resource_trips == crate::input::TRIP_COUNTER_EXHAUSTED
       || *self.resource_trips != since.count
   }
+
+  /// Snapshots the session's **scanner-trip counter** — how many times the scanner has tripped a
+  /// lexer resource limit in this input session — for a rollback-proof terminality witness.
+  ///
+  /// The scanner twin of [`trip_snapshot`](Self::trip_snapshot), used identically: take the
+  /// baseline once per **collection**, hand it back to
+  /// [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt) when judging that
+  /// attempt. The crate's own drivers spend it on the raw, unconditioned
+  /// `scanner_tripped_during_attempt` instead, which stays private for the reason that verdict's
+  /// docs give.
+  ///
+  /// **This, and not the poison boundary beside it, is what a recovery gate judges a scanner stop
+  /// with.** The latch is a lineage memo: a [`Checkpoint`](crate::input::Checkpoint) carries it
+  /// and a restore copies it back, so comparing it across a rollback compares a restored value
+  /// against what it was restored to. Reading it inside the attempt fixes one level and the level
+  /// below reopens it — grammar code that catches a stop inside an inner
+  /// [`try_attempt`](Self::try_attempt) has that rollback erase the latch before an outer gate
+  /// looks. This counter is outside the rollback set entirely and is therefore depth-independent.
+  ///
+  /// # Per COLLECTION, where the descent baseline is per ELEMENT
+  ///
+  /// The two facts decay differently, so their baselines belong at different units and neither can
+  /// be derived from the other. A descent trip that grammar code caught and parsed past stops
+  /// being true of the input; a spent scanner budget does not — the token stream ends where it
+  /// ended, and every attempt after it reads a view the stop truncated. So this baseline is taken
+  /// **once per collection**, above the loop, where hoisting the descent one would be the defect:
+  /// taken per element it is re-read after the trip an earlier element caught, and *element 1
+  /// tripped and accepted, element 2 declines* then concludes cleanly over a spent budget. That
+  /// asymmetry is why the two baselines are two **types**: the swap does not compile, in either
+  /// direction, at any of the sites that take both.
+  ///
+  /// # The monotone counter alone is not publishable, and this is why
+  ///
+  /// [`set_state`](Self::set_state) and [`state_mut`](Self::state_mut) re-key the input's
+  /// forward-scanning facts, and dropping the poison boundary there is **the documented
+  /// limit-recovery path** — swap in a fresh or bigger-budget state and scanning resumes past the
+  /// old boundary. Neither touches this counter, which is monotone and never cleared. So a loop
+  /// doing exactly what the section above prescribes — one baseline, taken above the loop — can
+  /// trip, recover through the documented path, read the rest of the document and reach a genuine
+  /// end of input with the raw event still answering `true`, rejecting a fully recovered parse as
+  /// truncated. Measured, not reasoned about: an eight-token source under a scan budget of three,
+  /// recovered with `set_state`, consumed all eight and the witness still said tripped.
+  ///
+  /// That is correct use under two conflicting public contracts rather than caller misuse. What
+  /// closes it is **not** a second cell ordered against the trip — the design that had to settle
+  /// its own rollback behaviour at every nesting depth — but a second *question*, asked of the
+  /// regime that is installed now: [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt)
+  /// is this event **and** [`Lexer::check`](crate::Lexer::check) still refusing, and that is the
+  /// public pair. The raw event stays crate-internal because the drivers need it unconditioned:
+  /// a driver judging one element must re-raise a trip it caught even where grammar code recovered
+  /// the regime inside that element, which is precisely the conjunct the public verdict drops.
+  ///
+  /// # The two public readings beside this one, and which question each answers
+  ///
+  /// [`at_scanner_stop`](Self::at_scanner_stop) is the **positional** reading: is a stop on record
+  /// *at the committed cursor*, now. It takes no baseline, it goes clean across a `set_state`
+  /// recovery because the boundary dies with the regime that owned it — and it also goes clean
+  /// across a speculative wrapper's rollback, because that restores a checkpoint predating the
+  /// trip. Planting this monotone counter in its place reds
+  /// `a_documented_widening_leaves_the_witness_reporting_a_finished_document`, at `Err(Eot)` for an
+  /// `Ok(7)`: a fully recovered document reported as truncated.
+  ///
+  /// [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt) is the
+  /// **attempt-relative** reading, and it is this counter conjoined with a stop still being
+  /// latched — positionally unqualified, which is how it answers the lookahead residue the
+  /// positional reading is blind to. The latch supplies what the counter alone gets wrong at a
+  /// recovery, since both state-surgery doors drop it. Neither half is publishable on its own,
+  /// which is why the raw event is still not.
+  ///
+  /// It answers the **rejecting-emitter** path this pair exists for, and answers it without a
+  /// baseline. A rejecting (fail-fast) emitter reports a lexer-resource trip by returning the value
+  /// its `From<<L::Token as Token>::Error>` builds, and `scan_with(..)?` propagates that value from
+  /// **inside** [`try_expect_or_stop`](Self::try_expect_or_stop), before the call can reach the arm
+  /// that raises a terminal stop; no care in the grammar's
+  /// [`MaybeTerminal`](crate::error::MaybeTerminal) repairs that, because nothing on the path is
+  /// terminal-marked to delegate to. The **boundary is latched anyway** — inside the crate's
+  /// terminal predicate, ahead of the diagnostic ever being offered to the emitter — so the stop is
+  /// on record when the rejection arrives, and the live reading finds it.
+  /// `tokora/tests/root_loop_trip_witness.rs` section 4 is the measurement, including the growth
+  /// the reading removes: without it a re-keying root loop files one diagnostic per remaining
+  /// token, at three document lengths.
+  ///
+  /// [`try_expect_or_stop`](Self::try_expect_or_stop) still covers **the declining exits** and is
+  /// still the primitive to build a decline on: its contract is that a terminal stop is an error
+  /// and never a decline, and it reads the same live boundary. What it cannot do is speak on the
+  /// path where the emitter's `Err` overtakes it, which is why the verdict above exists beside it.
+  ///
+  /// None of that changes this pair's own answer or its visibility. An **attempt-relative** verdict
+  /// is a different question from a live one — this one is what a *driver* judging one element or
+  /// one speculative parse needs, where the live reading is what a *root loop* holding an `Err`
+  /// needs — and the `set_state` false positive above is the reason it stays where it is.
+  ///
+  /// Costs one `u64` load per attempt — one machine word on a 64-bit target, two on a 32-bit one
+  /// — and no scan, no lookahead fill and no token commit reads it. Unlike its descent twin this
+  /// baseline is taken **once per collection** rather than per element, so the 32-bit cost lands
+  /// once per driver rather than once per element.
+  #[inline(always)]
+  pub fn scanner_trip_snapshot(&self) -> ScannerTripBaseline<'closure> {
+    ScannerTripBaseline {
+      count: *self.scanner_trips,
+      nonce: self.scanner_trip_nonce(),
+      _brand: PhantomData,
+    }
+  }
+
+  /// The identity of **this** input, for [`ScannerTripBaseline`]'s nonce: the address of the
+  /// scanner-trip slot it borrows.
+  ///
+  /// The same derivation the descent baseline's `trip_nonce` uses, off this witness's own cell.
+  /// Two simultaneously-live inputs are distinct structs at distinct addresses and the slot is a
+  /// `u64`, so it is never zero-sized and the two can never collide.
+  #[inline(always)]
+  fn scanner_trip_nonce(&self) -> usize {
+    core::ptr::from_ref(&*self.scanner_trips).addr()
+  }
+
+  /// Whether the **scanner tripped a resource limit during the attempt** that took `since` as its
+  /// [`scanner_trip_snapshot`](Self::scanner_trip_snapshot) baseline.
+  ///
+  /// The depth-proof input-side witness for scanner terminality, read by the recovery gate beside
+  /// [`MaybeTerminal::is_terminal`](crate::error::MaybeTerminal) and
+  /// [`tripped_during_attempt`](Self::tripped_during_attempt). It answers where the error value
+  /// cannot: a *rejecting* emitter reports a scanner trip by returning the value its
+  /// `From<<L::Token as Token>::Error>` builds, and nothing on that path constructs an
+  /// [`UnexpectedEnd`](crate::error::UnexpectedEnd) for
+  /// [`into_terminal`](crate::error::UnexpectedEnd::into_terminal) to mark.
+  ///
+  /// It is not the only thing that answers there any more, and it is not the public one:
+  /// [`at_scanner_stop`](Self::at_scanner_stop) reads the same fact **live** — no baseline, no
+  /// placement — which is what makes it publishable where this is not. The two are different
+  /// questions, not two spellings of one: this is *did a trip happen inside the attempt I am
+  /// judging*, which is what a driver needs; that is *is the scanner stopped here now*, which is
+  /// what a root loop holding an `Err` needs.
+  ///
+  /// **Attempt-relative, not session-absolute**, and a **count** rather than a flag — the same two
+  /// disciplines [`tripped_during_attempt`](Self::tripped_during_attempt) documents at length, for
+  /// the same two reasons. Its granularity floor is the same as well: this witnesses that *a* trip
+  /// happened while the attempt ran, not that the `Err` in hand *is* that trip, so a unit that
+  /// catches a trip and then fails ordinarily is re-raised. It fails closed, never open — with the
+  /// one exception [`scanner_trip_snapshot`](Self::scanner_trip_snapshot) records, which is a
+  /// state-regime recovery it cannot see, and which is why that pair is crate-internal.
+  ///
+  /// Its baseline's granularity is **not** the descent one's: see
+  /// [`scanner_trip_snapshot`](Self::scanner_trip_snapshot), which is per *collection* where the
+  /// descent baseline is per *element*.
+  ///
+  /// Costs one `u64` load and a comparison.
+  ///
+  /// **When it runs is not this doc's to state**, and the only thing worth adding here is that it
+  /// is not the same answer as its twin's.
+  /// [`tripped_during_attempt`](Self::tripped_during_attempt) carries the one copy of that model,
+  /// derived from every call site in the crate; this verdict is its **own column** in that table,
+  /// differing from the descent column in both the order it is evaluated in and which closer
+  /// classes reach it. Read the values there rather than here — a copy of them here is how the
+  /// three previous versions of that model each went stale.
+  ///
+  /// # Panics
+  ///
+  /// If `since` came from a different input than `self`.
+  #[inline(always)]
+  pub(crate) fn scanner_tripped_during_attempt(
+    &self,
+    since: ScannerTripBaseline<'closure>,
+  ) -> bool {
+    assert!(
+      since.nonce == self.scanner_trip_nonce(),
+      "ScannerTripBaseline came from a different input than the one judging it. A baseline is \
+       only meaningful against its own input's counter; comparing it here would answer about a \
+       parse this handle knows nothing about. Take the baseline from the same handle that reads \
+       the verdict."
+    );
+    *self.scanner_trips == crate::input::TRIP_COUNTER_EXHAUSTED
+      || *self.scanner_trips != since.count
+  }
+
+  /// Whether the **scanner is stopped for the attempt** that took `since` as its
+  /// [`scanner_trip_snapshot`](Self::scanner_trip_snapshot) baseline: a trip was recorded while
+  /// that attempt ran, **and** a stop is still latched.
+  ///
+  /// This is the public **attempt-relative** scanner verdict.
+  /// [`at_scanner_stop`](Self::at_scanner_stop) beside it is the **positional** one — is a stop on
+  /// record *at the committed cursor*, now — and the two are not two spellings of one question.
+  ///
+  /// ```text
+  /// loop {
+  ///   let scan = inp.scanner_trip_snapshot();      // per COLLECTION, above the loop
+  ///   match definition(inp) {
+  ///     Ok(true)  => {}
+  ///     Ok(false) => return Ok(()),
+  ///     Err(e) => {
+  ///       if e.is_terminal() || inp.scanner_stopped_during_attempt(scan) {
+  ///         return Err(e);                         // the document is over
+  ///       }
+  ///       report();
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// # The residue it closes: a stop latched AHEAD of the cursor
+  ///
+  /// An element's own lookahead ([`peek`](Self::peek), [`peek_one`](Self::peek_one)) can trip,
+  /// latch the frontier *ahead* of the committed cursor, and still return `Ok` with a short
+  /// window. Every positional witness reads clean there while the stop is live and already
+  /// diagnosed — that is the first residue [`at_scanner_stop`](Self::at_scanner_stop) names, and
+  /// it stays clean as the cached pre-trip tokens drain, because draining them does not carry the
+  /// cursor to the frontier. This reading is **not positional**: it asks whether a stop is latched
+  /// at all, so it answers `true` from the moment the lookahead latched.
+  ///
+  /// Measured as rows 1 and 2 of
+  /// `the_attempt_relative_verdict_answers_where_the_positional_reading_is_blind`, under both
+  /// emitters: `(at_scanner_stop, this) == (false, true)`.
+  ///
+  /// # The conjunct is the whole design, and it is what makes publishing possible
+  ///
+  /// A carrier that only records the **event** is a permanent false positive: the counter is
+  /// monotone, nothing clears it, and a loop that recovers exactly as this crate documents then
+  /// reads its own finished document as truncated. That is what kept the raw pair crate-internal,
+  /// and a recovery *generation* — a second cell ordered against the trip — is the design that
+  /// would have had to settle its own rollback behaviour at every nesting depth to fix it.
+  ///
+  /// The second conjunct is no such cell. It is the state the crate already keeps, asked in the
+  /// present tense, and both public state-surgery doors clear it as a side effect of what they
+  /// already do.
+  ///
+  /// # Which carrier is still in force, and what clears each
+  ///
+  /// The counter records that *a* scanner trip happened; it does not record **which** of the two
+  /// carriers took it, so both are asked. They clear on opposite terms, and that asymmetry is the
+  /// contract rather than an implementation detail:
+  ///
+  /// - a [`TokenBudget`](crate::input::TokenBudget) refusal —
+  ///   [`TokenBudgetTally::refused_an_item`](crate::input::TokenBudgetTally::refused_an_item) — is
+  ///   **never** cleared. No [`Checkpoint`](crate::input::Checkpoint) carries the tally, no re-key
+  ///   touches it, and there is no `token_budget_mut` to lower it. For a bound placed there the
+  ///   verdict is durable by construction, at any depth, across every rollback;
+  /// - a **lexer-side** trip is carried by the poison boundary, and clears exactly where that
+  ///   boundary dies: [`set_state`](Self::set_state) and [`state_mut`](Self::state_mut), which is
+  ///   the documented limit-recovery path, and a [`Checkpoint`](crate::input::Checkpoint) restore
+  ///   whose saved boundary is `None`.
+  ///
+  /// # Why a `true` is sound
+  ///
+  /// Both publishers of a scanner trip require an item that **exists** —
+  /// `latch_if_limit_tripped` is reached from `classify` about an item the lexer produced, and
+  /// `settle_met_ceiling` discards its staged stop without publishing when `lexer.lex()` yields
+  /// nothing. So a `true` means a real item was refused and the record of it is still standing.
+  ///
+  /// The **granularity floor** its raw half documents is unchanged: this witnesses that *a* trip
+  /// happened while the attempt ran, not that the `Err` in hand **is** that trip. A unit that
+  /// catches a trip, does not recover the regime, and then fails ordinarily is re-raised as a
+  /// stop. It fails closed, never open.
+  ///
+  /// # What it does NOT answer, and why
+  ///
+  /// **A trip inside a speculative wrapper that rolled back.**
+  /// [`try_attempt`](Self::try_attempt), [`attempt_parse`](Self::attempt_parse) and a
+  /// rollback-on-drop [`Transaction`] restore a checkpoint that predates the trip, so the boundary
+  /// comes back as `None` and this reads clean. The *event* survives — the counter is outside the
+  /// rollback set — but the second conjunct does not, and that is not a defect of the conjunct:
+  /// the same restore reinstates the tally the checkpoint saved, which is the refund
+  /// [`TokenLimiter`](crate::state::token_tracker::TokenLimiter) documents as *the correct answer*
+  /// for a bound on the committed stream. After that rollback the scanner really can scan again,
+  /// and both readings say so correctly.
+  ///
+  /// What is left over is a **loop** that keeps redoing refundable work: it trips, rolls back, and
+  /// retries from the state it just failed in, never advancing. That is a resource-**placement**
+  /// problem, and `TokenLimiter`'s own documentation names the fix — a bound on *work performed*
+  /// belongs on the input, as a [`TokenBudget`](crate::input::TokenBudget), where no rollback
+  /// reaches it and where this verdict is durable. Measured both ways in
+  /// `a_state_side_bound_under_speculation_is_refunded_and_neither_reading_closes_it`.
+  ///
+  /// Telling *"the tally was refunded to a spent state"* from *"the tally was refunded to a
+  /// usable one"* cannot be done from the stored regime, because a limit trip is decided **after**
+  /// a scan and the tripping scan commits nothing — so `*self.state` is always the pre-trip regime
+  /// and answers `Ok` over a scanner that is stopped. Only running the lexer separates them, which
+  /// is the same sentence `settle_met_ceiling`'s one-shot probe is built on; and a probe here would
+  /// be a **third** `Lexer::lex` site in this layer, which `RESUME_CENSUS`
+  /// (`resume_census_one_pairing_site`) refuses — *"a third invocation is a third way to produce an
+  /// item"* — and which would put unbudgeted lexer work behind a public `&self` reader. So the case
+  /// is left open and named rather than closed by widening that gate.
+  ///
+  /// # Measured
+  ///
+  /// `tokora/tests/root_loop_trip_witness.rs` section 5.
+  /// `the_attempt_relative_verdict_answers_where_the_positional_reading_is_blind` is the five-point
+  /// table — latched ahead, draining, at the frontier, re-keyed, recovered — under **both**
+  /// emitters; `a_baseline_taken_after_the_trip_does_not_charge_this_attempt_with_it` pins that it
+  /// is attempt-relative and not *"is this scanner spent"*;
+  /// `an_input_side_bound_outlives_every_one_of_the_three_rollbacks` is the durable carrier through
+  /// all three wrappers.
+  ///
+  /// # Costs
+  ///
+  /// A nonce comparison and a `u64` comparison — the raw event's whole cost — then, only if those
+  /// say a trip happened, a `bool` load and an `Option::is_some`. No scan, no lookahead fill, no
+  /// caller code at all.
+  ///
+  /// # Panics
+  ///
+  /// If `since` came from a different input than `self`.
+  #[inline]
+  pub fn scanner_stopped_during_attempt(&self, since: ScannerTripBaseline<'closure>) -> bool {
+    // The event first, and it is also the short circuit: no trip inside the attempt means no
+    // verdict, and nothing below is read. This ordering is the cost claim.
+    if !self.scanner_tripped_during_attempt(since) {
+      return false;
+    }
+    // Two carriers can hold a scanner stop and the trip counter does not say which one did, so
+    // both are asked. The budget's is the durable one and is asked first.
+    self.token_budget.refused_an_item() || self.stop_still_latched()
+  }
+
+  /// Whether a terminal scanner stop is latched **anywhere**, positionally unqualified — the
+  /// recovery-aware conjunct of
+  /// [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt).
+  ///
+  /// Deliberately not [`reached_boundary`](Self::reached_boundary): the whole residue this verdict
+  /// closes is a boundary latched *ahead* of the committed cursor by a lookahead, which every
+  /// positional reading is blind to. Presence, not position — the same fact
+  /// `latched_during_attempt` compares for the drivers' absence exits, without the comparison.
+  ///
+  /// Being the boundary rather than a cell of its own is what makes it recovery-aware for free:
+  /// [`set_state`](Self::set_state) and [`state_mut`](Self::state_mut) drop it, and that *is* the
+  /// documented limit-recovery path, so nothing has to decide separately what counts as a
+  /// recovery.
+  #[inline]
+  fn stop_still_latched(&self) -> bool {
+    self.poison_boundary.is_some()
+  }
 }
 
 /// One live level of recursive descent, held for the length of the frame that entered it.

--- a/tokora/src/input/input_ref/mod.rs
+++ b/tokora/src/input/input_ref/mod.rs
@@ -956,8 +956,12 @@ where
   ///
   /// # It is a reading of NOW, which is what makes it right across the recovery path
   ///
-  /// It takes no baseline and witnesses no event. It answers *"will a scan from here yield the
-  /// stop rather than a token?"*, and the two facts it reads are the two the scanner itself
+  /// It takes no baseline and witnesses no event. It answers *"is a scan from here already
+  /// refused, on the record this input holds?"* — which is the crate's own terminal gate inside
+  /// [`try_expect_or_stop`](Self::try_expect_or_stop), read without consuming: that gate drains a
+  /// cached token first and asks the same two facts only once nothing is waiting, which is exactly
+  /// when the committed cursor and the lex frontier are the same offset. So this never disagrees
+  /// with what the primitive beside it would do. The two facts are the two the scanner itself
   /// refuses on:
   ///
   /// - [`TokenBudgetTally::refused_an_item`](crate::input::TokenBudgetTally::refused_an_item) — the
@@ -977,23 +981,70 @@ where
   /// recovered with `set_state`, all eight consumed and the witness still `true`. This reading goes
   /// `false` the moment the regime that owned the stop dies, because there is nothing left to read.
   ///
-  /// For the same reason it needs no rollback proof at any nesting depth. A witness that *compares*
-  /// a rollbackable cell across an attempt compares a restored value against what it was restored
-  /// to; this one is not a comparison. A [`Checkpoint`](crate::input::Checkpoint) that puts the
-  /// boundary back puts back a live stop, and this then reports a live stop — which is what the
-  /// next scan will do.
+  /// For the same reason it needs no baseline at any nesting depth. A witness that *compares* a
+  /// rollbackable cell across an attempt compares a restored value against what it was restored
+  /// to; this one is not a comparison, so there is no placement of a baseline for a caller to get
+  /// wrong.
+  ///
+  /// # A ROLLBACK restores the record, and it restores it in both directions
+  ///
+  /// [`try_attempt`](Self::try_attempt), [`attempt_parse`](Self::attempt_parse), a rollback-on-drop
+  /// [`Transaction`] and a raw [`restore`](Self::restore) all reinstate the
+  /// [`Checkpoint`](crate::input::Checkpoint)'s saved cursor, saved lexer state **and** saved
+  /// boundary. A checkpoint taken *after* a trip puts a live stop back and this reports it. A
+  /// checkpoint taken *before* one — which is every speculative wrapper's own begin point — puts a
+  /// `None` boundary back at a rewound cursor, so an attempt that tripped inside propagates the
+  /// rejecting emitter's ordinary-looking `Err` with nothing left on the input to read, and this
+  /// answers `false`.
+  ///
+  /// **That is not one wrong answer to repair, because the right answer there is not one answer.**
+  /// It depends on where the scanner bound lives, and the only thing that knows is `L::State`:
+  ///
+  /// - **by value in the state**, the placement
+  ///   [`TokenLimiter`](crate::state::token_tracker::TokenLimiter) documents — the restore
+  ///   reinstalls the saved tally, *everything spent after it is given back*, and an abandoned
+  ///   speculation's tokens are not in the committed stream. The stop really is gone, and `false`
+  ///   is the **right** answer;
+  /// - **reachable from the state rather than held in it** — a shared cell, an atomic, a global.
+  ///   The restore hands back a clone that still points at the spent tally, so the very next scan
+  ///   trips again: the stop is still in force and `false` is the **wrong** answer;
+  /// - **on the input**, as a [`TokenBudget`](crate::input::TokenBudget). No `Checkpoint` carries
+  ///   its tally, so the refusal — and this reading of it — survives every rollback at every depth.
+  ///
+  /// The first two rows need **opposite** answers after the *same* restore, so no fact carried
+  /// across that restore can serve both, at any placement: what separates them is `L::State`
+  /// itself, which is precisely the thing the restore puts back. What a consumer that speculates
+  /// does instead is itself a placement rather than a discipline, and there are two:
+  ///
+  /// - **read this where the failure is produced** — inside the closure, or through the guard,
+  ///   before the wrapper decides. The record is there; the rollback is what discards it, together
+  ///   with everything else the attempt did;
+  /// - or **put the scanner bound on the input**, which is what
+  ///   [`TokenBudget`](crate::input::TokenBudget) is for and what
+  ///   [`TokenLimiter`](crate::state::token_tracker::TokenLimiter)'s own documentation ends on: a
+  ///   bound on *work performed* belongs where no rollback reaches, because work an attempt
+  ///   performed and then rolled back was still performed.
+  ///
+  /// Measured in `tests/root_loop_trip_witness.rs` — the three rows are
+  /// `every_speculative_wrapper_restores_a_checkpoint_that_predates_the_trip`,
+  /// `a_by_value_state_bound_makes_the_same_false_the_right_answer` and
+  /// `an_input_side_bound_outlives_every_one_of_the_three_rollbacks`, each driven through all
+  /// three wrappers; what the wrong placement costs is
+  /// `the_verdict_read_after_the_rollback_leaves_the_loop_without_progress`.
   ///
   /// # What a `false` does not promise
   ///
-  /// Two residues, named rather than implied, and both are **bounded by real progress** rather than
-  /// by a caller's discipline:
+  /// Two more residues, named rather than implied:
   ///
   /// - **the cursor rewound behind a live boundary.** An element may latch a trip, open an
   ///   [`attempt`](Self::attempt), consume the cached pre-trip tokens and decline; the restore
   ///   rewinds the cursor behind the boundary while the latch survives. Every positional witness
-  ///   reads clean there. Lexing *strictly before* the frontier still proceeds, so the loop that
-  ///   carries on re-parses a prefix that really is there and re-reaches the stop — it does not
-  ///   loop over a spent scanner;
+  ///   reads clean there. Lexing *strictly before* the frontier still proceeds, so a loop that
+  ///   carries on re-parses a prefix that really is there and re-reaches the stop — but what bounds
+  ///   it is the loop **keeping** that prefix. One whose retry is itself inside a rolling-back
+  ///   wrapper keeps nothing and consumes nothing, and then does not terminate at all; a root loop
+  ///   needs its own no-progress guard for the same reason every collection driver in this crate
+  ///   has one;
   /// - **a met ceiling with the one-shot probe unspent.** A budget of `N` over a document of `N`
   ///   items has met its ceiling and refused nothing, and *"would an item be refused?"* is not
   ///   *"is there an item?"* — only running the lexer separates them, which is what the probe is

--- a/tokora/src/input/input_ref/mod.rs
+++ b/tokora/src/input/input_ref/mod.rs
@@ -336,6 +336,9 @@ where
   /// The regime generation — see [`Input::regime`](super::Input). Borrowed beside the boundary it
   /// shares a restore group with.
   pub(super) regime: &'closure mut u64,
+  /// The regime-id allocator — see [`Input::regime_seq`](super::Input). Monotone, outside the
+  /// rollback set, and the only source `install_rekey` reads.
+  pub(super) regime_seq: &'closure mut u64,
   /// The **recursion budget**, borrowed from the owning [`Input`](super::Input) — see that field
   /// for why it is outside the rollback set. Read through [`recursion`](Self::recursion); its
   /// only writer is the [`Descent`] guard [`descend`](Self::descend) hands out.
@@ -669,10 +672,37 @@ where
     self.input
   }
 
-  /// Returns a reference to the current lexer state (extras).
+  /// Returns the current lexer state (extras), **by value**.
+  ///
+  /// # It hands out a clone, and that is a wall rather than a convenience
+  ///
+  /// A shared reference to the *live* state would be a public path to scan-visible state that
+  /// skips every door this crate tracks. [`State`](crate::state::State) is bounded
+  /// `Debug + Clone` and nothing more, so a perfectly valid one may hold interior mutability — a
+  /// `Cell<Mode>` a grammar flips to change how the region ahead lexes. Through a `&L::State`,
+  /// safe code could flip it without [`set_state`](Self::set_state) or
+  /// [`state_mut`](Self::state_mut), and the input would be scanning under a regime nothing on it
+  /// records. [`scanner_outcome`](Self::scanner_outcome) would then report
+  /// [`Stalled`](crate::input::ScannerOutcome::Stalled) — *repeating reproduces the trip* — over an
+  /// input where repeating can now succeed, and reject a recoverable parse.
+  ///
+  /// Cloning removes the capability rather than asking a `State` implementor not to use it: the
+  /// value handed back is the caller's own, and mutating it cannot reach the input. That is what
+  /// lets the regime generation stand for `State` **identity** — with this door closed, the only
+  /// writers of the live state are a commit, a restore, and the two surgery methods, and the last
+  /// two are exactly `install_rekey`, which stamps a fresh id. See
+  /// [`scanner_outcome`](Self::scanner_outcome) for the whole argument.
+  ///
+  /// The one shape it does not cover is a `State` whose `Clone` **shares** its interior mutability
+  /// rather than deep-copying it — an `Rc<Cell<_>>` tally and its family. That is already the
+  /// [`Lexer`](crate::Lexer) determinism clause's own named violation (*"a shared counter"*), and
+  /// the input layer's behaviour under one is unspecified-but-bounded, here as everywhere else.
+  ///
+  /// Costs one `L::State::clone`. To *change* the state, use [`state_mut`](Self::state_mut), which
+  /// re-keys eagerly, or [`set_state`](Self::set_state).
   #[inline(always)]
-  pub const fn state(&self) -> &L::State {
-    self.state
+  pub fn state(&self) -> L::State {
+    self.state.clone()
   }
 
   /// Returns whether this input is **final** — the last chunk of a stream, or a
@@ -922,12 +952,19 @@ where
     // Disarming after the clear instead leaves a window in which the front is gone and the
     // watermark still claims a live report for it. Measured, not hypothesized: with the disarm
     // below the clear, `a_rekey_interrupted_by_caller_code_still_witnesses_itself` fails.
-    // The regime's name changes with the regime. This is the ONE bump site, and it is what makes
-    // "equal generation and equal committed offset" imply an equal `State`: the other two writers
-    // of `*self.state` either advance the offset (a commit) or carry their own saved generation
-    // (a restore). Saturating for the trip counters' reason — an equality test needs consecutive
-    // values to differ, and the ceiling's tie is the conservative direction.
-    *self.regime = self.regime.saturating_add(1);
+    // The regime's name changes with the regime. This is the ONE allocation site.
+    //
+    // It reads the ALLOCATOR, not the current id: deriving the next name from the checkpointed
+    // cell is not injective, and the counterexample is public — save at `g`, install B (`g + 1`),
+    // roll back to `g`, install C (`g + 1`), and B and C wear one name. The allocator is outside
+    // the rollback set for exactly the reason the checkpoint-id source is.
+    //
+    // `saturating_add` here means the ceiling hands out `REGIME_EXHAUSTED` for ever, and that
+    // sentinel is excluded from equality at the reading — so exhaustion forces "changed", never
+    // "same". Saturating INTO an ordinary value would do the opposite and answer `Stalled` across
+    // a re-key, which is the false stop.
+    *self.regime_seq = self.regime_seq.saturating_add(1);
+    *self.regime = *self.regime_seq;
     let settled = (
       core::mem::replace(self.emitted_error_end, committed),
       // The front-report watermark dies with the regime that lexed its subject. Taken HERE,

--- a/tokora/src/input/input_ref/mod.rs
+++ b/tokora/src/input/input_ref/mod.rs
@@ -111,20 +111,47 @@ pub enum ScannerOutcome {
   /// A trip happened, and a stop is **still in force**: the input budget has refused an item, or a
   /// terminal frontier is latched. The document is truncated — this is the arm that ends it.
   Stopped,
-  /// A trip happened, no stop is in force any more, and the attempt **committed nothing**.
+  /// A trip happened, no stop is in force, and **all three determinism inputs are unchanged**:
+  /// the source (which never changes), the committed offset (equal to the capture's), and the
+  /// lexer regime (same `Input::regime` generation, which together with the
+  /// equal offset implies an equal [`State`](crate::state::State)).
   ///
   /// The trip was rolled back — by [`try_attempt`](InputRef::try_attempt),
-  /// [`attempt_parse`](InputRef::attempt_parse), a rollback-on-drop
-  /// [`Transaction`] or a raw [`restore`](InputRef::restore) — or re-keyed away by
-  /// [`state_mut`](InputRef::state_mut), and the committed cursor is where it was when the attempt
-  /// began. By the [`Lexer`](crate::Lexer) determinism contract — scanning is a pure function of
-  /// source, offset and [`State`](crate::state::State) — **repeating the attempt from here
-  /// reproduces the same trip**, so a loop that retries without changing the regime cannot
-  /// terminate. It is a statement about *this* attempt, not an instruction: a caller that goes on
-  /// to install a fresh regime has changed the third input and is no longer covered by it.
+  /// [`attempt_parse`](InputRef::attempt_parse), a rollback-on-drop [`Transaction`] or a raw
+  /// [`restore`](InputRef::restore) — and nothing else about the scan's inputs moved. By the
+  /// [`Lexer`](crate::Lexer) determinism contract, *every scan-visible result derives entirely from
+  /// the source, the offset being lexed at, and the lexer `State`*, so **repeating the attempt from
+  /// here reproduces the same trip** and a loop that retries cannot terminate.
+  ///
+  /// It is a statement about *this* attempt, not an instruction. A caller that goes on to install
+  /// a fresh regime has changed the third input, and the next attempt's capture judges that.
   Stalled,
-  /// A trip happened, no stop is in force, and the attempt **committed progress**: the regime was
-  /// recovered, or the trip was caught and parsed past. The stream moved on and a retry is not a
+  /// A trip happened, no stop is in force, and the **lexer regime was replaced** during the
+  /// attempt — [`set_state`](InputRef::set_state) or [`state_mut`](InputRef::state_mut), the
+  /// documented limit-recovery path — without that replacement being rolled back.
+  ///
+  /// Split out of [`Stalled`](Self::Stalled) rather than folded into it because the two license
+  /// opposite decisions: the third determinism input *did* change, so a retry under the new regime
+  /// may well succeed, and reporting this as a stall would reject a recoverable parse. The
+  /// committed offset is not consulted — a re-key that also progressed is still a re-key, and this
+  /// is the stronger statement about repeatability.
+  ///
+  /// Conservative in one direction only: a `state_mut()` whose `&mut` the caller never wrote
+  /// through still lands here, because the generation is stamped by the door and not by the
+  /// mutation. That errs toward *carry on*, never toward a false stop.
+  ReKeyed,
+  /// A trip happened, no stop is in force, the regime is unchanged, and the committed offset is
+  /// **below** the capture — the attempt, or something it called, rewound past where this capture
+  /// was taken.
+  ///
+  /// Reachable through a session point settled below the capture, or a raw
+  /// [`restore`](InputRef::restore) to an older checkpoint. The capture describes a position the
+  /// input has left, so it can say nothing about repeating from the one it is at now: this is
+  /// neither a stall nor progress, and folding it into either would be a claim the capture does
+  /// not support. Take a fresh [`scanner_attempt`](InputRef::scanner_attempt) and judge again.
+  Rewound,
+  /// A trip happened, no stop is in force, the regime is unchanged, and the attempt **committed
+  /// progress**: the trip was caught and parsed past. The stream moved on and a retry is not a
   /// repeat.
   Progressed,
 }
@@ -144,12 +171,86 @@ pub enum ScannerOutcome {
 /// lookahead that filled the cache has consumed nothing, and a no-progress guard that counted it
 /// would call a stalled attempt progress. That is the same rule the collection drivers' own
 /// no-progress guards are censused against (`no_progress_guards_measure_committed_consumption`).
-#[derive(Debug, Clone)]
+/// # Affine: one capture judges one attempt, and cannot judge a second
+///
+/// It is deliberately **not** [`Clone`], and [`InputRef::scanner_outcome`] takes it **by value**.
+/// A borrowing reader over a copyable capture is the same defect the guard exists to close, one
+/// level up: hoist a capture out of the loop — the natural thing to write — and once any turn
+/// retains progress past its `at`, every later rolled-back turn still compares *greater* than that
+/// stale offset and reads [`Progressed`](ScannerOutcome::Progressed). The unbounded retry comes
+/// straight back through the guard meant to stop it. Consuming the capture makes the second reading
+/// a compile error rather than a wrong answer.
+///
+/// That is also why the pair is two types rather than one.
+/// [`ScannerTripBaseline`] must stay [`Copy`]: the collection drivers read their baseline more than
+/// once per element loop, and forcing them to re-take it is the placement defect that type exists
+/// to make hard. The *attempt* has the opposite requirement, and because the split was already
+/// there for the `L::Offset`'s sake, making this half one-shot costs the driver half nothing.
+///
+/// **The control first**, because a `compile_fail` that fails for the wrong reason proves nothing.
+/// One capture judging one attempt compiles, so the scaffolding — the bounds, the borrow of `inp`
+/// — is sound:
+///
+/// ```rust
+/// use tokora::{InputRef, Lexer, ParseContext, input::ScannerOutcome};
+///
+/// fn judge_once<'inp, L, Ctx>(inp: &mut InputRef<'inp, '_, L, Ctx>) -> ScannerOutcome
+/// where
+///   L: Lexer<'inp>,
+///   Ctx: ParseContext<'inp, L>,
+/// {
+///   let attempt = inp.scanner_attempt();
+///   inp.scanner_outcome(attempt)
+/// }
+/// ```
+///
+/// Spend one capture twice — the hoisted-out-of-the-loop shape — and it stops compiling:
+///
+/// ```compile_fail
+/// use tokora::{InputRef, Lexer, ParseContext, input::ScannerOutcome};
+///
+/// fn judge_twice<'inp, L, Ctx>(inp: &mut InputRef<'inp, '_, L, Ctx>) -> ScannerOutcome
+/// where
+///   L: Lexer<'inp>,
+///   Ctx: ParseContext<'inp, L>,
+/// {
+///   let attempt = inp.scanner_attempt();
+///   let _first = inp.scanner_outcome(attempt);
+///   // error[E0382]: use of moved value: `attempt`
+///   inp.scanner_outcome(attempt)
+/// }
+/// ```
+///
+/// And cloning around that does not compile either, because the type has no [`Clone`]:
+///
+/// ```compile_fail
+/// use tokora::{InputRef, Lexer, ParseContext, input::ScannerOutcome};
+///
+/// fn judge_a_clone<'inp, L, Ctx>(inp: &mut InputRef<'inp, '_, L, Ctx>) -> ScannerOutcome
+/// where
+///   L: Lexer<'inp>,
+///   Ctx: ParseContext<'inp, L>,
+/// {
+///   let attempt = inp.scanner_attempt();
+///   // error[E0599]: no method named `clone` found
+///   let copy = attempt.clone();
+///   let _first = inp.scanner_outcome(attempt);
+///   inp.scanner_outcome(copy)
+/// }
+/// ```
+///
+/// A capture **held** across turns and spent late is still possible and still bounded — it is one
+/// stale verdict, not a loop, because spending it consumes it. [`InputRef::judge_scanner`] removes
+/// even that by binding capture, judged work and verdict into a single turn, and is the shape a
+/// root loop should reach for first.
+#[derive(Debug)]
 pub struct ScannerAttempt<'inp, 'closure, L: Lexer<'inp>> {
   /// The trip baseline, carrying the count, the nonce and the brand.
   pub(crate) trips: ScannerTripBaseline<'closure>,
   /// `span().end()` when the attempt began — the committed consumption a stall compares against.
   pub(crate) at: L::Offset,
+  /// The regime generation when the attempt began — the third determinism input, made comparable.
+  pub(crate) regime: u64,
 }
 
 #[cfg(test)]
@@ -232,6 +333,9 @@ where
   /// field for the invariant and the three writers that keep it inductive.
   pub(super) front_reported_end: &'closure mut Option<L::Offset>,
   pub(super) poison_boundary: &'closure mut Option<L::Offset>,
+  /// The regime generation — see [`Input::regime`](super::Input). Borrowed beside the boundary it
+  /// shares a restore group with.
+  pub(super) regime: &'closure mut u64,
   /// The **recursion budget**, borrowed from the owning [`Input`](super::Input) — see that field
   /// for why it is outside the rollback set. Read through [`recursion`](Self::recursion); its
   /// only writer is the [`Descent`] guard [`descend`](Self::descend) hands out.
@@ -818,6 +922,12 @@ where
     // Disarming after the clear instead leaves a window in which the front is gone and the
     // watermark still claims a live report for it. Measured, not hypothesized: with the disarm
     // below the clear, `a_rekey_interrupted_by_caller_code_still_witnesses_itself` fails.
+    // The regime's name changes with the regime. This is the ONE bump site, and it is what makes
+    // "equal generation and equal committed offset" imply an equal `State`: the other two writers
+    // of `*self.state` either advance the offset (a commit) or carry their own saved generation
+    // (a restore). Saturating for the trip counters' reason — an equality test needs consecutive
+    // values to differ, and the ceiling's tie is the conservative direction.
+    *self.regime = self.regime.saturating_add(1);
     let settled = (
       core::mem::replace(self.emitted_error_end, committed),
       // The front-report watermark dies with the regime that lexed its subject. Taken HERE,
@@ -1097,8 +1207,8 @@ where
   ///
   /// A loop that keeps redoing refundable work is detected by
   /// [`scanner_outcome`](Self::scanner_outcome)'s
-  /// [`Stalled`](crate::input::ScannerOutcome::Stalled) arm — a trip with no committed progress
-  /// after it — and bounded by putting the budget on the input. What *this* method does not answer,
+  /// [`Stalled`](crate::input::ScannerOutcome::Stalled) arm — a trip after which none of the
+  /// determinism clause's three inputs moved — and bounded by putting the budget on the input. What *this* method does not answer,
   /// and [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt) does, is the
   /// other residue in this list: a stop latched **ahead** of the committed cursor by a lookahead,
   /// which every positional reading — this one included — is blind to. **This method stays the
@@ -3271,6 +3381,8 @@ where
       emitted_error_end,
       front_reported_end,
       poison_boundary,
+      // A pure `u64` copy, in the same group as the boundary above it.
+      *self.regime,
       cache_pushes,
       #[cfg(all(
         debug_assertions,
@@ -3741,6 +3853,7 @@ where
       emitted_error_end,
       front_reported_end,
       poison_boundary,
+      regime,
       cache_pushes,
       ..
     } = checkpoint;
@@ -3806,6 +3919,9 @@ where
       core::mem::replace(self.front_reported_end, front_reported_end),
       core::mem::replace(self.poison_boundary, poison_boundary),
     );
+    // The regime's name, put back with the regime `install_position` is about to install. A `u64`
+    // store among the other no-caller-code facts; nothing can run between it and the state write.
+    *self.regime = regime;
     let replaced = self.install_position(clamped, spare, state);
 
     // ── PHASE 3 — the one drop site, with the rollback whole. ──

--- a/tokora/src/input/input_ref/mod.rs
+++ b/tokora/src/input/input_ref/mod.rs
@@ -56,25 +56,48 @@ pub use descent::ResourceTripBaseline;
 /// The baseline half of the **scanner-trip witness**, and the reason the swap with
 /// [`ResourceTripBaseline`] does not compile.
 ///
-/// Crate-internal, like the pair that issues it — [`InputRef::scanner_trip_snapshot`] records why,
-/// and names [`InputRef::at_scanner_stop`] as the public reading a consumer takes instead.
 /// A distinct type rather than a bare `usize` because the two baselines have **opposite**
 /// granularities (this one per collection, the descent one per element) and every site that reads
 /// both takes both, so an argument swap was a plausible boolean and a silent wrong answer. It is
-/// a compile error now. The `'closure` brand its public sibling carries is deliberately absent:
-/// the impl block that issues this one elides the handle lifetime, and the misuse the brand rules
-/// out — a baseline escaping the handle — is not reachable from outside a crate that does not
-/// publish the pair.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct ScannerTripBaseline {
+/// a compile error now.
+///
+/// Taken by [`InputRef::scanner_trip_snapshot`] and spent by
+/// [`InputRef::scanner_stopped_during_attempt`], which is the **public** verdict; the raw
+/// event-only reading beside it stays crate-internal, for the reason that method records.
+///
+/// It carries the same two guards its public sibling does, and for the same reasons: a `nonce`, so
+/// a baseline judged against a different input panics rather than answering about a parse that
+/// handle knows nothing about, and a `'closure` brand, so a baseline cannot be stashed and carried
+/// into another handle invocation — which would silently turn the attempt-relative reading into a
+/// session-absolute one. Those guards used to be absent here, justified by the pair being
+/// crate-internal; publishing it is what removed the justification.
+#[derive(Clone, Copy)]
+pub struct ScannerTripBaseline<'closure> {
   /// The counter's value when the baseline was taken.
   count: u64,
+  /// The identity of the input that issued it: the address of that input's scanner-trip slot.
+  /// Distinct inputs are distinct structs at distinct addresses, and the slot is a `u64` so it is
+  /// never zero-sized.
+  nonce: usize,
+  /// Invariant in `'closure`, through the fn-pointer form rather than a bare reference — the
+  /// shape [`ResourceTripBaseline`] documents the measured map for.
+  _brand: PhantomData<fn(&'closure ()) -> &'closure ()>,
+}
+
+/// Prints neither field, and that is the point rather than an omission — the reasoning is
+/// [`ResourceTripBaseline`]'s, verbatim. A derive would render `count`, which is the
+/// session-absolute reading the type exists to make unspellable, and `nonce`, which is the address
+/// of an internal slot.
+impl core::fmt::Debug for ScannerTripBaseline<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_str("ScannerTripBaseline")
+  }
 }
 
 #[cfg(test)]
-impl ScannerTripBaseline {
+impl ScannerTripBaseline<'_> {
   /// The raw count, for the in-crate cells that assert exact trip tallies rather than the
-  /// attempt-relative verdict. There is no such door on the public sibling.
+  /// attempt-relative verdict. There is no such door on the public surface.
   #[inline(always)]
   pub(crate) const fn count(self) -> u64 {
     self.count
@@ -956,13 +979,19 @@ where
   ///
   /// # It is a reading of NOW, which is what makes it right across the recovery path
   ///
-  /// It takes no baseline and witnesses no event. It answers *"is a scan from here already
-  /// refused, on the record this input holds?"* — which is the crate's own terminal gate inside
-  /// [`try_expect_or_stop`](Self::try_expect_or_stop), read without consuming: that gate drains a
-  /// cached token first and asks the same two facts only once nothing is waiting, which is exactly
-  /// when the committed cursor and the lex frontier are the same offset. So this never disagrees
-  /// with what the primitive beside it would do. The two facts are the two the scanner itself
-  /// refuses on:
+  /// It takes no baseline and witnesses no event. It answers *"is a stop on record at the
+  /// committed cursor?"* — the same two facts the crate's own terminal gate inside
+  /// [`try_expect_or_stop`](Self::try_expect_or_stop) consults, read without consuming.
+  ///
+  /// **It is not, however, "what that call would do next".** That gate drains a **cached** token
+  /// first and only then consults these facts, and the budget half below is durable and
+  /// *non-positional* — so with a lookahead's tokens still waiting at the front, this answers
+  /// `true` while `try_expect_or_stop` hands one of them out. Measured, not reasoned about: a
+  /// [`TokenBudget`](crate::input::TokenBudget) of two and a `peek::<U4>` over eight tokens leaves
+  /// this reading `true` and the very next `try_expect_or_stop` returning `Ok(Some(_))`
+  /// (`a_refusal_on_record_still_has_cached_tokens_in_front_of_it`). A loop that treats a `true`
+  /// as *"stop draining"* rather than as *"the stream is truncated"* therefore drops tokens that
+  /// are already lexed and paid for. The two facts are the two the scanner itself refuses on:
   ///
   /// - [`TokenBudgetTally::refused_an_item`](crate::input::TokenBudgetTally::refused_an_item) — the
   ///   input-layer budget's recorded refusal. No [`Checkpoint`](crate::input::Checkpoint) carries
@@ -997,40 +1026,41 @@ where
   /// rejecting emitter's ordinary-looking `Err` with nothing left on the input to read, and this
   /// answers `false`.
   ///
-  /// **That is not one wrong answer to repair, because the right answer there is not one answer.**
-  /// It depends on where the scanner bound lives, and the only thing that knows is `L::State`:
+  /// **That `false` is not wrong about the input — it is the wrong question for the caller.** The
+  /// [`Lexer`](crate::Lexer) contract requires limit accounting to derive entirely from source,
+  /// offset and [`State`](crate::state::State), and
+  /// [`TokenLimiter`](crate::state::token_tracker::TokenLimiter) documents the consequence from the
+  /// other side: a restore reinstalls the saved tally, *everything spent after it is given back*,
+  /// because an abandoned speculation's tokens are not in the committed stream. So after that
+  /// rollback a scan from the restored cursor really does yield a token, and this reading says so
+  /// correctly. What the caller has lost is not the state of the input but the **history of the
+  /// attempt**: the wrapper's next turn re-derives the identical trip, and a root loop reading only
+  /// this one files a report every turn without ever advancing the cursor.
   ///
-  /// - **by value in the state**, the placement
-  ///   [`TokenLimiter`](crate::state::token_tracker::TokenLimiter) documents — the restore
-  ///   reinstalls the saved tally, *everything spent after it is given back*, and an abandoned
-  ///   speculation's tokens are not in the committed stream. The stop really is gone, and `false`
-  ///   is the **right** answer;
-  /// - **reachable from the state rather than held in it** — a shared cell, an atomic, a global.
-  ///   The restore hands back a clone that still points at the spent tally, so the very next scan
-  ///   trips again: the stop is still in force and `false` is the **wrong** answer;
-  /// - **on the input**, as a [`TokenBudget`](crate::input::TokenBudget). No `Checkpoint` carries
-  ///   its tally, so the refusal — and this reading of it — survives every rollback at every depth.
+  /// The loop that keeps redoing refundable work is a resource-**placement** problem, and it is
+  /// named with its fix below. What *this* method does not answer, and
+  /// [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt) does, is the other
+  /// residue in this list: a stop latched **ahead** of the committed cursor by a lookahead, which
+  /// every positional reading — this one included — is blind to. **This method stays the narrow
+  /// live query**: is a stop on record *here*, now.
   ///
-  /// The first two rows need **opposite** answers after the *same* restore, so no fact carried
-  /// across that restore can serve both, at any placement: what separates them is `L::State`
-  /// itself, which is precisely the thing the restore puts back. What a consumer that speculates
-  /// does instead is itself a placement rather than a discipline, and there are two:
+  /// One bound belongs on neither of them but on the caller's choice of where to put it. A
+  /// [`TokenBudget`](crate::input::TokenBudget) on the **input** is outside every
+  /// [`Checkpoint`](crate::input::Checkpoint), so its refusal — and this reading of it — survives
+  /// any rollback; that is the placement for a bound on *work performed*, which is where
+  /// `TokenLimiter`'s own documentation sends it. A tally the state merely **points at** — a shared
+  /// counter, an ambient global — is not a third option: the [`Lexer`](crate::Lexer) determinism
+  /// clause names it as a contract violation, and the input layer's behaviour under one is
+  /// unspecified-but-bounded rather than a case either reading owes an answer to.
   ///
-  /// - **read this where the failure is produced** — inside the closure, or through the guard,
-  ///   before the wrapper decides. The record is there; the rollback is what discards it, together
-  ///   with everything else the attempt did;
-  /// - or **put the scanner bound on the input**, which is what
-  ///   [`TokenBudget`](crate::input::TokenBudget) is for and what
-  ///   [`TokenLimiter`](crate::state::token_tracker::TokenLimiter)'s own documentation ends on: a
-  ///   bound on *work performed* belongs where no rollback reaches, because work an attempt
-  ///   performed and then rolled back was still performed.
-  ///
-  /// Measured in `tests/root_loop_trip_witness.rs` — the three rows are
-  /// `every_speculative_wrapper_restores_a_checkpoint_that_predates_the_trip`,
-  /// `a_by_value_state_bound_makes_the_same_false_the_right_answer` and
-  /// `an_input_side_bound_outlives_every_one_of_the_three_rollbacks`, each driven through all
-  /// three wrappers; what the wrong placement costs is
-  /// `the_verdict_read_after_the_rollback_leaves_the_loop_without_progress`.
+  /// Measured in `tests/root_loop_trip_witness.rs` section 5:
+  /// `every_speculative_wrapper_restores_a_checkpoint_that_predates_the_trip` drives all three
+  /// wrappers over a conforming limiter,
+  /// `an_input_side_bound_outlives_every_one_of_the_three_rollbacks` is the `TokenBudget` row,
+  /// `the_attempt_relative_verdict_answers_where_the_positional_reading_is_blind` is the
+  /// five-point table the two readings differ in, and
+  /// `a_state_side_bound_under_speculation_is_refunded_and_neither_reading_closes_it` measures the
+  /// loop that neither reading ends and the placement that does.
   ///
   /// # What a `false` does not promise
   ///
@@ -1042,9 +1072,10 @@ where
   ///   reads clean there. Lexing *strictly before* the frontier still proceeds, so a loop that
   ///   carries on re-parses a prefix that really is there and re-reaches the stop — but what bounds
   ///   it is the loop **keeping** that prefix. One whose retry is itself inside a rolling-back
-  ///   wrapper keeps nothing and consumes nothing, and then does not terminate at all; a root loop
-  ///   needs its own no-progress guard for the same reason every collection driver in this crate
-  ///   has one;
+  ///   wrapper keeps nothing and consumes nothing, and then does not terminate at all — which is
+  ///   the shape [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt) exists
+  ///   for, and which a root loop otherwise needs its own no-progress guard against, for the same
+  ///   reason every collection driver in this crate has one;
   /// - **a met ceiling with the one-shot probe unspent.** A budget of `N` over a document of `N`
   ///   items has met its ceiling and refused nothing, and *"would an item be refused?"* is not
   ///   *"is there an item?"* — only running the lexer separates them, which is what the probe is
@@ -1100,145 +1131,6 @@ where
   #[inline(always)]
   pub(crate) fn latched_during_attempt(&self, since: &Option<L::Offset>) -> bool {
     self.poison_boundary.is_some() && *self.poison_boundary != *since
-  }
-
-  /// Snapshots the session's **scanner-trip counter** — how many times the scanner has tripped a
-  /// lexer resource limit in this input session — for a rollback-proof terminality witness.
-  ///
-  /// The scanner twin of [`trip_snapshot`](Self::trip_snapshot), used identically: take the
-  /// baseline once per attempt, hand it back to
-  /// [`scanner_tripped_during_attempt`](Self::scanner_tripped_during_attempt) when judging that
-  /// attempt.
-  ///
-  /// **This, and not the poison boundary beside it, is what a recovery gate judges a scanner stop
-  /// with.** The latch is a lineage memo: a [`Checkpoint`](crate::input::Checkpoint) carries it
-  /// and a restore copies it back, so comparing it across a rollback compares a restored value
-  /// against what it was restored to. Reading it inside the attempt fixes one level and the level
-  /// below reopens it — grammar code that catches a stop inside an inner
-  /// [`try_attempt`](Self::try_attempt) has that rollback erase the latch before an outer gate
-  /// looks. This counter is outside the rollback set entirely and is therefore depth-independent.
-  ///
-  /// # Per COLLECTION, where the descent baseline is per ELEMENT
-  ///
-  /// The two facts decay differently, so their baselines belong at different units and neither can
-  /// be derived from the other. A descent trip that grammar code caught and parsed past stops
-  /// being true of the input; a spent scanner budget does not — the token stream ends where it
-  /// ended, and every attempt after it reads a view the stop truncated. So this baseline is taken
-  /// **once per collection**, above the loop, where hoisting the descent one would be the defect:
-  /// taken per element it is re-read after the trip an earlier element caught, and *element 1
-  /// tripped and accepted, element 2 declines* then concludes cleanly over a spent budget. That
-  /// asymmetry is why the two baselines are two **types**: the swap does not compile, in either
-  /// direction, at any of the sites that take both.
-  ///
-  /// # Why this pair is NOT public, where the descent pair is
-  ///
-  /// It was published for one round and withdrawn before release, and the reason is a second
-  /// public contract it cannot see. [`set_state`](Self::set_state) and
-  /// [`state_mut`](Self::state_mut) re-key the input's forward-scanning facts, and dropping the
-  /// poison boundary there is **the documented limit-recovery path** — swap in a fresh or
-  /// bigger-budget state and scanning resumes past the old boundary. Neither touches this counter,
-  /// which is monotone and never cleared. So a loop doing exactly what the section above
-  /// prescribes — one baseline, taken above the loop — can trip, recover through the documented
-  /// path, read the rest of the document and reach a genuine end of input with this witness still
-  /// answering `true`, rejecting a fully recovered parse as truncated. Measured, not reasoned
-  /// about: an eight-token source under a scan budget of three, recovered with `set_state`,
-  /// consumed all eight and the witness still said tripped.
-  ///
-  /// That is correct use under two conflicting public contracts rather than caller misuse, and
-  /// making the verdict account for a state-regime recovery is a change to this crate's terminal
-  /// law — a recovery generation ordered against the trip, in a cell whose own rollback behaviour
-  /// has to be settled — which every one of the twelve collection drivers, the recovery gate and
-  /// `skip_then_retry` would inherit. That is a design round, not a visibility change, so the pair
-  /// stays crate-internal until it has had one.
-  ///
-  /// # What a consumer reads instead, and why it is not this
-  ///
-  /// [`at_scanner_stop`](Self::at_scanner_stop) is the public scanner verdict, and it is a reading
-  /// of **now** rather than a comparison against a baseline: the input-layer budget's recorded
-  /// refusal, or the poison boundary at the committed cursor. That is what lets it be published
-  /// where this pair cannot be. It goes clean across the `set_state` recovery, because the boundary
-  /// dies with the regime that owned it and there is nothing left to read — where this counter,
-  /// being monotone, keeps answering `true` over a document the recovery finished. Planting the
-  /// counter reading in its place reds
-  /// `a_documented_widening_leaves_the_witness_reporting_a_finished_document`, at `Err(Eot)` for an
-  /// `Ok(7)`: a fully recovered document reported as truncated.
-  ///
-  /// It answers the **rejecting-emitter** path this pair exists for, and answers it without a
-  /// baseline. A rejecting (fail-fast) emitter reports a lexer-resource trip by returning the value
-  /// its `From<<L::Token as Token>::Error>` builds, and `scan_with(..)?` propagates that value from
-  /// **inside** [`try_expect_or_stop`](Self::try_expect_or_stop), before the call can reach the arm
-  /// that raises a terminal stop; no care in the grammar's
-  /// [`MaybeTerminal`](crate::error::MaybeTerminal) repairs that, because nothing on the path is
-  /// terminal-marked to delegate to. The **boundary is latched anyway** — inside the crate's
-  /// terminal predicate, ahead of the diagnostic ever being offered to the emitter — so the stop is
-  /// on record when the rejection arrives, and the live reading finds it.
-  /// `tokora/tests/root_loop_trip_witness.rs` section 4 is the measurement, including the growth
-  /// the reading removes: without it a re-keying root loop files one diagnostic per remaining
-  /// token, at three document lengths.
-  ///
-  /// [`try_expect_or_stop`](Self::try_expect_or_stop) still covers **the declining exits** and is
-  /// still the primitive to build a decline on: its contract is that a terminal stop is an error
-  /// and never a decline, and it reads the same live boundary. What it cannot do is speak on the
-  /// path where the emitter's `Err` overtakes it, which is why the verdict above exists beside it.
-  ///
-  /// None of that changes this pair's own answer or its visibility. An **attempt-relative** verdict
-  /// is a different question from a live one — this one is what a *driver* judging one element or
-  /// one speculative parse needs, where the live reading is what a *root loop* holding an `Err`
-  /// needs — and the `set_state` false positive above is the reason it stays where it is.
-  ///
-  /// Costs one `u64` load per attempt — one machine word on a 64-bit target, two on a 32-bit one
-  /// — and no scan, no lookahead fill and no token commit reads it. Unlike its descent twin this
-  /// baseline is taken **once per collection** rather than per element, so the 32-bit cost lands
-  /// once per driver rather than once per element.
-  #[inline(always)]
-  pub(crate) const fn scanner_trip_snapshot(&self) -> ScannerTripBaseline {
-    ScannerTripBaseline {
-      count: *self.scanner_trips,
-    }
-  }
-
-  /// Whether the **scanner tripped a resource limit during the attempt** that took `since` as its
-  /// [`scanner_trip_snapshot`](Self::scanner_trip_snapshot) baseline.
-  ///
-  /// The depth-proof input-side witness for scanner terminality, read by the recovery gate beside
-  /// [`MaybeTerminal::is_terminal`](crate::error::MaybeTerminal) and
-  /// [`tripped_during_attempt`](Self::tripped_during_attempt). It answers where the error value
-  /// cannot: a *rejecting* emitter reports a scanner trip by returning the value its
-  /// `From<<L::Token as Token>::Error>` builds, and nothing on that path constructs an
-  /// [`UnexpectedEnd`](crate::error::UnexpectedEnd) for
-  /// [`into_terminal`](crate::error::UnexpectedEnd::into_terminal) to mark.
-  ///
-  /// It is not the only thing that answers there any more, and it is not the public one:
-  /// [`at_scanner_stop`](Self::at_scanner_stop) reads the same fact **live** — no baseline, no
-  /// placement — which is what makes it publishable where this is not. The two are different
-  /// questions, not two spellings of one: this is *did a trip happen inside the attempt I am
-  /// judging*, which is what a driver needs; that is *is the scanner stopped here now*, which is
-  /// what a root loop holding an `Err` needs.
-  ///
-  /// **Attempt-relative, not session-absolute**, and a **count** rather than a flag — the same two
-  /// disciplines [`tripped_during_attempt`](Self::tripped_during_attempt) documents at length, for
-  /// the same two reasons. Its granularity floor is the same as well: this witnesses that *a* trip
-  /// happened while the attempt ran, not that the `Err` in hand *is* that trip, so a unit that
-  /// catches a trip and then fails ordinarily is re-raised. It fails closed, never open — with the
-  /// one exception [`scanner_trip_snapshot`](Self::scanner_trip_snapshot) records, which is a
-  /// state-regime recovery it cannot see, and which is why that pair is crate-internal.
-  ///
-  /// Its baseline's granularity is **not** the descent one's: see
-  /// [`scanner_trip_snapshot`](Self::scanner_trip_snapshot), which is per *collection* where the
-  /// descent baseline is per *element*.
-  ///
-  /// Costs one `u64` load and a comparison.
-  ///
-  /// **When it runs is not this doc's to state**, and the only thing worth adding here is that it
-  /// is not the same answer as its twin's.
-  /// [`tripped_during_attempt`](Self::tripped_during_attempt) carries the one copy of that model,
-  /// derived from every call site in the crate; this verdict is its **own column** in that table,
-  /// differing from the descent column in both the order it is evaluated in and which closer
-  /// classes reach it. Read the values there rather than here — a copy of them here is how the
-  /// three previous versions of that model each went stale.
-  #[inline(always)]
-  pub(crate) const fn scanner_tripped_during_attempt(&self, since: ScannerTripBaseline) -> bool {
-    *self.scanner_trips == super::TRIP_COUNTER_EXHAUSTED || *self.scanner_trips != since.count
   }
 
   /// The **token budget** this parse's lexer produces items against: the ceiling, and what has

--- a/tokora/src/input/input_ref/mod.rs
+++ b/tokora/src/input/input_ref/mod.rs
@@ -94,6 +94,64 @@ impl core::fmt::Debug for ScannerTripBaseline<'_> {
   }
 }
 
+/// What one attempt did to the scanner — the shape a retrying root loop matches on.
+///
+/// Taken with [`InputRef::scanner_attempt`] and read with [`InputRef::scanner_outcome`]. It exists
+/// because a **boolean** cannot be a sufficient root-loop guard: *"the document is over"* and
+/// *"repeating this attempt repeats it"* are different facts, and the second one has no `true` to
+/// hang on — a speculative wrapper restores the checkpointed state and a pre-trip `None` boundary,
+/// so every live reading of the input is correctly clean while the retry is futile. An `enum`
+/// makes the loop's decision exhaustive by construction, which a `bool` cannot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ScannerOutcome {
+  /// No scanner resource trip happened while the attempt ran. The ordinary case, and the only one
+  /// a parse that never meets a limit ever sees.
+  NoTrip,
+  /// A trip happened, and a stop is **still in force**: the input budget has refused an item, or a
+  /// terminal frontier is latched. The document is truncated — this is the arm that ends it.
+  Stopped,
+  /// A trip happened, no stop is in force any more, and the attempt **committed nothing**.
+  ///
+  /// The trip was rolled back — by [`try_attempt`](InputRef::try_attempt),
+  /// [`attempt_parse`](InputRef::attempt_parse), a rollback-on-drop
+  /// [`Transaction`] or a raw [`restore`](InputRef::restore) — or re-keyed away by
+  /// [`state_mut`](InputRef::state_mut), and the committed cursor is where it was when the attempt
+  /// began. By the [`Lexer`](crate::Lexer) determinism contract — scanning is a pure function of
+  /// source, offset and [`State`](crate::state::State) — **repeating the attempt from here
+  /// reproduces the same trip**, so a loop that retries without changing the regime cannot
+  /// terminate. It is a statement about *this* attempt, not an instruction: a caller that goes on
+  /// to install a fresh regime has changed the third input and is no longer covered by it.
+  Stalled,
+  /// A trip happened, no stop is in force, and the attempt **committed progress**: the regime was
+  /// recovered, or the trip was caught and parsed past. The stream moved on and a retry is not a
+  /// repeat.
+  Progressed,
+}
+
+/// One attempt's scanner bookkeeping: the trip baseline, and the committed position it started at.
+///
+/// The root-loop counterpart of [`ScannerTripBaseline`], which is the *driver*'s value and stays
+/// count-only for a measured reason — a driver reads its baseline more than once per element loop,
+/// so that one is [`Copy`] and this one, carrying an `L::Offset`, could not be. The two units
+/// differ as well: this is taken **per attempt**, where the driver baseline is taken per
+/// collection.
+///
+/// It holds the driver baseline rather than restating it, so the nonce and the `'closure` brand —
+/// and the misuse each rules out — carry over unchanged.
+///
+/// The position is **committed consumption** (`span().end()`), never a cache-front reading: a
+/// lookahead that filled the cache has consumed nothing, and a no-progress guard that counted it
+/// would call a stalled attempt progress. That is the same rule the collection drivers' own
+/// no-progress guards are censused against (`no_progress_guards_measure_committed_consumption`).
+#[derive(Debug, Clone)]
+pub struct ScannerAttempt<'inp, 'closure, L: Lexer<'inp>> {
+  /// The trip baseline, carrying the count, the nonce and the brand.
+  pub(crate) trips: ScannerTripBaseline<'closure>,
+  /// `span().end()` when the attempt began — the committed consumption a stall compares against.
+  pub(crate) at: L::Offset,
+}
+
 #[cfg(test)]
 impl ScannerTripBaseline<'_> {
   /// The raw count, for the in-crate cells that assert exact trip tallies rather than the
@@ -1037,12 +1095,14 @@ where
   /// attempt**: the wrapper's next turn re-derives the identical trip, and a root loop reading only
   /// this one files a report every turn without ever advancing the cursor.
   ///
-  /// The loop that keeps redoing refundable work is a resource-**placement** problem, and it is
-  /// named with its fix below. What *this* method does not answer, and
-  /// [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt) does, is the other
-  /// residue in this list: a stop latched **ahead** of the committed cursor by a lookahead, which
-  /// every positional reading — this one included — is blind to. **This method stays the narrow
-  /// live query**: is a stop on record *here*, now.
+  /// A loop that keeps redoing refundable work is detected by
+  /// [`scanner_outcome`](Self::scanner_outcome)'s
+  /// [`Stalled`](crate::input::ScannerOutcome::Stalled) arm — a trip with no committed progress
+  /// after it — and bounded by putting the budget on the input. What *this* method does not answer,
+  /// and [`scanner_stopped_during_attempt`](Self::scanner_stopped_during_attempt) does, is the
+  /// other residue in this list: a stop latched **ahead** of the committed cursor by a lookahead,
+  /// which every positional reading — this one included — is blind to. **This method stays the
+  /// narrow live query**: is a stop on record *here*, now.
   ///
   /// One bound belongs on neither of them but on the caller's choice of where to put it. A
   /// [`TokenBudget`](crate::input::TokenBudget) on the **input** is outside every
@@ -1059,8 +1119,8 @@ where
   /// `an_input_side_bound_outlives_every_one_of_the_three_rollbacks` is the `TokenBudget` row,
   /// `the_attempt_relative_verdict_answers_where_the_positional_reading_is_blind` is the
   /// five-point table the two readings differ in, and
-  /// `a_state_side_bound_under_speculation_is_refunded_and_neither_reading_closes_it` measures the
-  /// loop that neither reading ends and the placement that does.
+  /// `the_stall_outcome_ends_a_speculating_loop_the_boolean_cannot` measures the loop no boolean
+  /// ends and the outcome does.
   ///
   /// # What a `false` does not promise
   ///

--- a/tokora/src/input/input_ref/mod.rs
+++ b/tokora/src/input/input_ref/mod.rs
@@ -56,7 +56,8 @@ pub use descent::ResourceTripBaseline;
 /// The baseline half of the **scanner-trip witness**, and the reason the swap with
 /// [`ResourceTripBaseline`] does not compile.
 ///
-/// Crate-internal, like the pair that issues it — [`InputRef::scanner_trip_snapshot`] records why.
+/// Crate-internal, like the pair that issues it — [`InputRef::scanner_trip_snapshot`] records why,
+/// and names [`InputRef::at_scanner_stop`] as the public reading a consumer takes instead.
 /// A distinct type rather than a bare `usize` because the two baselines have **opposite**
 /// granularities (this one per collection, the descent one per element) and every site that reads
 /// both takes both, so an argument swap was a plausible boolean and a silent wrong answer. It is
@@ -910,6 +911,107 @@ where
     self.reached_boundary(self.cursor().as_inner())
   }
 
+  /// Returns whether a **terminal scanner stop is in force at the committed cursor** — the input
+  /// has spent a scanner resource budget it cannot get past, and the parse has consumed up to it.
+  ///
+  /// This is the public answer to *"did this failure end the document, or is it an ordinary
+  /// grammar error?"* for the **scanner** half of terminality. Its descent half is
+  /// [`tripped_during_attempt`](Self::tripped_during_attempt), and neither subsumes the other: a
+  /// descent trip latches no boundary — it has a control stack rather than a position — so this
+  /// reads `false` for one, exactly as the crate's own positional scanner witness does.
+  ///
+  /// ```text
+  /// loop {
+  ///   let trips = inp.trip_snapshot();
+  ///   match definition(inp) {
+  ///     Ok(true)  => {}
+  ///     Ok(false) => return Ok(()),
+  ///     Err(e) => {
+  ///       if e.is_terminal() || inp.tripped_during_attempt(trips) || inp.at_scanner_stop() {
+  ///         return Err(e);                 // the document is over
+  ///       }
+  ///       report();                        // an ordinary syntax error: file it and carry on
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// # The exit no other public reading covers
+  ///
+  /// [`try_expect_or_stop`](Self::try_expect_or_stop) raises a terminal-marked
+  /// [`UnexpectedEot`](crate::error::UnexpectedEot) on **the declining exits**, and that is the
+  /// whole answer wherever the caller reaches one. A *rejecting* (fail-fast)
+  /// [`Emitter`](crate::Emitter) does not let it: it reports a lexer-resource trip by **returning**
+  /// the value its `From<<L::Token as Token>::Error>` builds — that `Err` *is* the report, not a
+  /// refusal to make one — and the scan propagates it from **inside** that very call, before the
+  /// arm that would raise the terminal stop can run. The caller receives an ordinary grammar error
+  /// over an exhausted scanner, and no care in the grammar's
+  /// [`MaybeTerminal`](crate::error::MaybeTerminal) repairs it, because nothing on that path is
+  /// terminal-marked to delegate to.
+  ///
+  /// The stop is nonetheless already **recorded** when that `Err` arrives: the boundary is latched
+  /// inside the crate's terminal predicate, ahead of the diagnostic ever being offered to the
+  /// emitter, precisely so that the emitter's answer cannot decide whether the input remembers its
+  /// own stop. This reads that record.
+  ///
+  /// # It is a reading of NOW, which is what makes it right across the recovery path
+  ///
+  /// It takes no baseline and witnesses no event. It answers *"will a scan from here yield the
+  /// stop rather than a token?"*, and the two facts it reads are the two the scanner itself
+  /// refuses on:
+  ///
+  /// - [`TokenBudgetTally::refused_an_item`](crate::input::TokenBudgetTally::refused_an_item) — the
+  ///   input-layer budget's recorded refusal. No [`Checkpoint`](crate::input::Checkpoint) carries
+  ///   it, no re-key clears it and no `token_budget_mut` exists, so once an item has been refused
+  ///   it is refused for the life of the input;
+  /// - the **poison boundary**, positionally, at the committed cursor — the lexer's own limit trip,
+  ///   which lives in `L::State` and therefore travels with the regime that produced it.
+  ///
+  /// Reading the boundary *live* rather than against a baseline is the whole of why this can be
+  /// published where the session's scanner-trip counter cannot.
+  /// [`set_state`](Self::set_state) / [`state_mut`](Self::state_mut) drop the boundary, and
+  /// **dropping it is the documented limit-recovery path** — swap in a fresh or bigger-budget state
+  /// and scanning resumes past the old boundary. A monotone counter is never cleared by either, so
+  /// a loop that recovers exactly as documented reads the rest of the document and a counter-based
+  /// verdict still answers "truncated": measured at eight tokens under a scan budget of three,
+  /// recovered with `set_state`, all eight consumed and the witness still `true`. This reading goes
+  /// `false` the moment the regime that owned the stop dies, because there is nothing left to read.
+  ///
+  /// For the same reason it needs no rollback proof at any nesting depth. A witness that *compares*
+  /// a rollbackable cell across an attempt compares a restored value against what it was restored
+  /// to; this one is not a comparison. A [`Checkpoint`](crate::input::Checkpoint) that puts the
+  /// boundary back puts back a live stop, and this then reports a live stop — which is what the
+  /// next scan will do.
+  ///
+  /// # What a `false` does not promise
+  ///
+  /// Two residues, named rather than implied, and both are **bounded by real progress** rather than
+  /// by a caller's discipline:
+  ///
+  /// - **the cursor rewound behind a live boundary.** An element may latch a trip, open an
+  ///   [`attempt`](Self::attempt), consume the cached pre-trip tokens and decline; the restore
+  ///   rewinds the cursor behind the boundary while the latch survives. Every positional witness
+  ///   reads clean there. Lexing *strictly before* the frontier still proceeds, so the loop that
+  ///   carries on re-parses a prefix that really is there and re-reaches the stop — it does not
+  ///   loop over a spent scanner;
+  /// - **a met ceiling with the one-shot probe unspent.** A budget of `N` over a document of `N`
+  ///   items has met its ceiling and refused nothing, and *"would an item be refused?"* is not
+  ///   *"is there an item?"* — only running the lexer separates them, which is what the probe is
+  ///   for. Until it has run, this reads `false`; the entry that spends it records the refusal and
+  ///   this reads `true` from then on. Answering `true` at the met ceiling instead would report a
+  ///   fully-parsed document as truncated, which is the defect the probe exists to avoid.
+  ///
+  /// Costs a `bool` load, and — only if that is `false` — one `Offset::Ord` comparison against a
+  /// latch that is `None` on every input that has never tripped.
+  #[inline(always)]
+  pub fn at_scanner_stop(&self) -> bool {
+    // The durable half first: a `bool` on a crate-owned struct, false on every input that never
+    // configured a token budget, and true forever once one has refused. The positional half is
+    // asked only when it is not already settled, and it is the one that costs consumer code
+    // (`Offset::Ord`, through `reached_boundary`).
+    self.token_budget.refused_an_item() || self.reached_boundary(self.cursor().as_inner())
+  }
+
   /// Snapshots the terminal-stop latch for an attempt-relative absence witness.
   ///
   /// The latch is not monotone: a trip raises it (keeping the most-poisoned, smallest boundary), a
@@ -998,33 +1100,40 @@ where
   /// `skip_then_retry` would inherit. That is a design round, not a visibility change, so the pair
   /// stays crate-internal until it has had one.
   ///
-  /// # What a consumer can answer today, and what it cannot
+  /// # What a consumer reads instead, and why it is not this
   ///
-  /// [`try_expect_or_stop`](Self::try_expect_or_stop) covers **the declining exits**, and only
-  /// those. Its contract is that a terminal stop is an error and never a decline, and it reads the
-  /// *live* boundary, so it is right where this counter is wrong: the same `set_state` recovery
-  /// that leaves the counter poisoned correctly stops it reporting a stop. Measured on the fixture
-  /// above — the truncated run raises the terminal end-of-input error with no input-side witness
-  /// anywhere, the widened control reads all eight, and the recovered run reads all eight too.
-  /// `tokora/tests/root_loop_trip_witness.rs`'s section 3 is those cells.
+  /// [`at_scanner_stop`](Self::at_scanner_stop) is the public scanner verdict, and it is a reading
+  /// of **now** rather than a comparison against a baseline: the input-layer budget's recorded
+  /// refusal, or the poison boundary at the committed cursor. That is what lets it be published
+  /// where this pair cannot be. It goes clean across the `set_state` recovery, because the boundary
+  /// dies with the regime that owned it and there is nothing left to read — where this counter,
+  /// being monotone, keeps answering `true` over a document the recovery finished. Planting the
+  /// counter reading in its place reds
+  /// `a_documented_widening_leaves_the_witness_reporting_a_finished_document`, at `Err(Eot)` for an
+  /// `Ok(7)`: a fully recovered document reported as truncated.
   ///
-  /// **It is not a replacement for this pair, and must not be described as one.** A *rejecting*
-  /// (fail-fast) emitter reports a lexer-resource trip by returning the value its
-  /// `From<<L::Token as Token>::Error>` builds, and `scan_with(..)?` propagates that value from
-  /// **inside** `try_expect_or_stop`, before the call can reach the arm that raises a terminal
-  /// stop. The caller therefore receives an ordinary grammar error over an exhausted scanner, with
-  /// nothing on it to read — and no care in the grammar's
-  /// [`MaybeTerminal`](crate::error::MaybeTerminal) can repair that, because nothing on the path
-  /// is terminal-marked to delegate to. Calling `try_expect_or_stop` does not help, because the
-  /// unmarked error originated inside that call. This is the same fact the twin's own
-  /// documentation states from the other side: this witness *answers where the error value
-  /// cannot*.
+  /// It answers the **rejecting-emitter** path this pair exists for, and answers it without a
+  /// baseline. A rejecting (fail-fast) emitter reports a lexer-resource trip by returning the value
+  /// its `From<<L::Token as Token>::Error>` builds, and `scan_with(..)?` propagates that value from
+  /// **inside** [`try_expect_or_stop`](Self::try_expect_or_stop), before the call can reach the arm
+  /// that raises a terminal stop; no care in the grammar's
+  /// [`MaybeTerminal`](crate::error::MaybeTerminal) repairs that, because nothing on the path is
+  /// terminal-marked to delegate to. The **boundary is latched anyway** — inside the crate's
+  /// terminal predicate, ahead of the diagnostic ever being offered to the emitter — so the stop is
+  /// on record when the rejection arrives, and the live reading finds it.
+  /// `tokora/tests/root_loop_trip_witness.rs` section 4 is the measurement, including the growth
+  /// the reading removes: without it a re-keying root loop files one diagnostic per remaining
+  /// token, at three document lengths.
   ///
-  /// So: **no public witness answers the rejecting-emitter path today.** That gap is real, it is
-  /// older than this pair's visibility — the pair has been crate-internal throughout — and closing
-  /// it is the design round above, not a visibility change. `tokora/tests/root_loop_trip_witness.rs`
-  /// section 4 pins it as a defect, beside the control that shows an accepting emitter marks the
-  /// same stop.
+  /// [`try_expect_or_stop`](Self::try_expect_or_stop) still covers **the declining exits** and is
+  /// still the primitive to build a decline on: its contract is that a terminal stop is an error
+  /// and never a decline, and it reads the same live boundary. What it cannot do is speak on the
+  /// path where the emitter's `Err` overtakes it, which is why the verdict above exists beside it.
+  ///
+  /// None of that changes this pair's own answer or its visibility. An **attempt-relative** verdict
+  /// is a different question from a live one — this one is what a *driver* judging one element or
+  /// one speculative parse needs, where the live reading is what a *root loop* holding an `Err`
+  /// needs — and the `set_state` false positive above is the reason it stays where it is.
   ///
   /// Costs one `u64` load per attempt — one machine word on a 64-bit target, two on a 32-bit one
   /// — and no scan, no lookahead fill and no token commit reads it. Unlike its descent twin this
@@ -1047,6 +1156,13 @@ where
   /// `From<<L::Token as Token>::Error>` builds, and nothing on that path constructs an
   /// [`UnexpectedEnd`](crate::error::UnexpectedEnd) for
   /// [`into_terminal`](crate::error::UnexpectedEnd::into_terminal) to mark.
+  ///
+  /// It is not the only thing that answers there any more, and it is not the public one:
+  /// [`at_scanner_stop`](Self::at_scanner_stop) reads the same fact **live** — no baseline, no
+  /// placement — which is what makes it publishable where this is not. The two are different
+  /// questions, not two spellings of one: this is *did a trip happen inside the attempt I am
+  /// judging*, which is what a driver needs; that is *is the scanner stopped here now*, which is
+  /// what a root loop holding an `Err` needs.
   ///
   /// **Attempt-relative, not session-absolute**, and a **count** rather than a flag — the same two
   /// disciplines [`tripped_during_attempt`](Self::tripped_during_attempt) documents at length, for

--- a/tokora/src/input/input_ref/try_expect.rs
+++ b/tokora/src/input/input_ref/try_expect.rs
@@ -302,6 +302,23 @@ where
   /// itself). This is the primitive an attempt/decline caller should build on
   /// when a decline commits it to a different parse — see the `try_*` delimited
   /// shapes.
+  ///
+  /// # The one exit this cannot mark, and what reads it
+  ///
+  /// The parenthesis above is a gap, not a footnote. A **rejecting** (fail-fast)
+  /// [`Emitter`](crate::Emitter) reports the trip by *returning* the value its
+  /// `From<<L::Token as Token>::Error>` builds — that `Err` **is** the report — and the scan
+  /// propagates it before this body can reach the arm that raises the terminal end-of-input.
+  /// The caller then holds an ordinary-looking grammar error over an exhausted scanner, and no
+  /// delegation in its [`MaybeTerminal`](crate::error::MaybeTerminal) recovers the fact, because
+  /// nothing on that path is terminal-marked.
+  ///
+  /// The stop is on record anyway — the boundary is latched inside the crate's terminal predicate,
+  /// ahead of the diagnostic ever being offered to the emitter — so
+  /// [`at_scanner_stop`](Self::at_scanner_stop) answers there. A root loop deciding *"does this
+  /// failure end the document"* reads it beside
+  /// [`is_terminal`](crate::error::MaybeTerminal::is_terminal); every other caller of this method
+  /// can keep reading the error value alone.
   #[inline]
   pub fn try_expect_or_stop<F>(
     &mut self,

--- a/tokora/src/input/lineage.rs
+++ b/tokora/src/input/lineage.rs
@@ -117,6 +117,7 @@
 //! | `emitted_error_end` (dedup watermark) | `Input` | lineage memo | pure-copy the saved value |
 //! | `front_reported_end` (front-report watermark) | `Input` | lineage memo | pure-copy the saved value — beside the emitter rewind, so the witness and the report it names move as one |
 //! | `poison_boundary` (sticky terminal frontier) | `Input` | lineage memo | pure-copy the saved value |
+//! | `regime_seq` (the id source those names come from) | `Input` | monotone session fact | **nothing** — a restored source would reissue a name, and two regimes sharing one name is exactly what an id must not allow |
 //! | `regime` (the installed lexer regime's name) | `Input` | lineage memo | pure-copy the saved value — a restore that puts a `State` back puts its name back with it, which is what lets a reader compare two regimes that `State`'s own bounds cannot |
 //! | [`cache_pushes`](Lineage::cache_pushes) | `Lineage` | lineage memo | pure-copy the saved value — the copy is what makes nested restores compose; see below |
 //! | [`live_ckpts`](Lineage) | `Lineage` | lineage memo | pop through the restored id |
@@ -199,6 +200,14 @@ pub(crate) fn census<'inp, L, Ctx, Lang, Cmpl>(
     //   from inside a scan, whose predicates take `&Token` and never `&mut InputRef`, so the
     //   generation cannot move across the pair that rewind restores.
     regime: _,
+    // — MONOTONE SESSION FACT: restore does NOT touch it, and must not — the same class, and the
+    //   same argument, as `next_ckp_id` below. It is the SOURCE the cell above is allocated from,
+    //   and a source a restore rewound would reissue a name two different regimes then share:
+    //   save at `g`, install B, roll back, install C, and a reader comparing names calls B and C
+    //   the same regime. Climbs only, at `install_rekey`; stops at `REGIME_EXHAUSTED`, which the
+    //   reading excludes from equality so an exhausted allocator forces "changed" rather than
+    //   "same".
+    regime_seq: _,
     // — CONTROL-STACK FACT: restore does NOT touch it, and must not. Depth is a property of the
     //   live frames, not of input progress: a save and the restore returning to it happen at the
     //   same depth by construction, so nothing observable changes across the pair; and an unwind
@@ -289,6 +298,9 @@ pub(crate) fn census<'inp, L, Ctx, Lang, Cmpl>(
     // — lineage memo (borrowed): pure-copied by a restore, bumped by `install_rekey`. Same class
     //   as the `Input` field above it.
     regime: _,
+    // — MONOTONE SESSION FACT (borrowed): the id source, climbed by `install_rekey`, never lowered
+    //   and never restored. Same class as the `Input` field above it.
+    regime_seq: _,
     // — CONTROL-STACK FACT (borrowed): raised by `descend`, lowered by the `Descent` guard's
     //   drop, never restored. Same class as the `Input` field above it.
     recursion: _,

--- a/tokora/src/input/lineage.rs
+++ b/tokora/src/input/lineage.rs
@@ -117,6 +117,7 @@
 //! | `emitted_error_end` (dedup watermark) | `Input` | lineage memo | pure-copy the saved value |
 //! | `front_reported_end` (front-report watermark) | `Input` | lineage memo | pure-copy the saved value — beside the emitter rewind, so the witness and the report it names move as one |
 //! | `poison_boundary` (sticky terminal frontier) | `Input` | lineage memo | pure-copy the saved value |
+//! | `regime` (the installed lexer regime's name) | `Input` | lineage memo | pure-copy the saved value — a restore that puts a `State` back puts its name back with it, which is what lets a reader compare two regimes that `State`'s own bounds cannot |
 //! | [`cache_pushes`](Lineage::cache_pushes) | `Lineage` | lineage memo | pure-copy the saved value — the copy is what makes nested restores compose; see below |
 //! | [`live_ckpts`](Lineage) | `Lineage` | lineage memo | pop through the restored id |
 //! | [`pinned`](Lineage) | `Lineage` | lineage memo | nothing (a restore does not change which guards are live) |
@@ -184,6 +185,20 @@ pub(crate) fn census<'inp, L, Ctx, Lang, Cmpl>(
     //   witnesses. A witness that did not would be unable to see a rollback at all.
     front_reported_end: _,
     poison_boundary: _,
+    // — lineage memo: restore PURE-COPIES the saved value, and it is in the same group as the
+    //   boundary above for one reason — it is that boundary's regime's NAME. `Lexer`'s determinism
+    //   clause makes a scan a function of source, offset and `State`, and `State` is bounded
+    //   `Debug + Clone`, so nothing can compare two of them; this counts the one class of event
+    //   that REPLACES a regime rather than advancing it (`install_rekey`, the sole bump site,
+    //   reached only from `set_state` and `state_mut`). A restore that puts a `State` back must
+    //   put its name back with it, or a rolled-back surgery would leave the saved regime wearing a
+    //   post-surgery generation. Equal generation plus equal committed offset therefore implies an
+    //   equal `State` — the other two writers of `*state` are a commit, which moves the offset,
+    //   and a restore, which carries its own saved generation — and that pair is what
+    //   `InputRef::scanner_outcome` tests. Not in `ThroughEntry`: no surgery door is reachable
+    //   from inside a scan, whose predicates take `&Token` and never `&mut InputRef`, so the
+    //   generation cannot move across the pair that rewind restores.
+    regime: _,
     // — CONTROL-STACK FACT: restore does NOT touch it, and must not. Depth is a property of the
     //   live frames, not of input progress: a save and the restore returning to it happen at the
     //   same depth by construction, so nothing observable changes across the pair; and an unwind
@@ -271,6 +286,9 @@ pub(crate) fn census<'inp, L, Ctx, Lang, Cmpl>(
     emitted_error_end: _,
     front_reported_end: _,
     poison_boundary: _,
+    // — lineage memo (borrowed): pure-copied by a restore, bumped by `install_rekey`. Same class
+    //   as the `Input` field above it.
+    regime: _,
     // — CONTROL-STACK FACT (borrowed): raised by `descend`, lowered by the `Descent` guard's
     //   drop, never restored. Same class as the `Input` field above it.
     recursion: _,

--- a/tokora/src/input/mod.rs
+++ b/tokora/src/input/mod.rs
@@ -285,7 +285,7 @@ pub(crate) const TRIP_COUNTER_EXHAUSTED: u64 = u64::MAX;
 pub(crate) use input_ref::Session;
 pub use input_ref::{
   Balance, Commit, DelimClass, Descent, DropPolicy, Hole, InputRef, ResourceTripBaseline, Rollback,
-  ScannerTripBaseline, Transaction,
+  ScannerAttempt, ScannerOutcome, ScannerTripBaseline, Transaction,
 };
 pub(crate) use lineage::Lineage;
 pub use session::{Budget, PartialSession, RedriveFromBase, ReplayMode, SessionRefusal};

--- a/tokora/src/input/mod.rs
+++ b/tokora/src/input/mod.rs
@@ -692,6 +692,13 @@ where
   /// but through [`scanner_trips`](Self::scanner_trips), *not* through this cell, and the
   /// difference is the whole reason that cell exists.
   ///
+  /// A **root loop** outside this crate asks a different question and gets this cell as half the
+  /// answer. [`InputRef::at_scanner_stop`] reads it positionally, at the committed cursor, together
+  /// with the token budget's recorded refusal beside it — not against a baseline, which is what
+  /// makes the rollback argument below irrelevant to it and what lets it be published where the
+  /// counter cannot be. A restore that puts this field back puts back a live stop, and that reading
+  /// then reports a live stop, which is what the next scan will do.
+  ///
   /// This one is **inside the rollback set**, and a witness inside it cannot answer a question
   /// asked from outside it. A speculating attempt restores this field on `Err`, so a snapshot taken
   /// before the attempt and compared after it compares a restored value against the value it was

--- a/tokora/src/input/mod.rs
+++ b/tokora/src/input/mod.rs
@@ -282,6 +282,40 @@ pub(crate) use input_ref::CloseStatus;
 /// target, and two executed workload shapes — and the whole table, with the decision it supports,
 /// is on [`InputRef::trip_snapshot`](InputRef::trip_snapshot).
 pub(crate) const TRIP_COUNTER_EXHAUSTED: u64 = u64::MAX;
+
+/// The value the regime-id allocator stops at, and the one id that is equal to **nothing**.
+///
+/// Its siblings above saturate into a value that keeps answering the *conservative* question
+/// correctly — a trip counter pinned at the ceiling still reads "tripped". An id cannot do that,
+/// because the reading it feeds is an **equality**, and a saturating id compares *equal* across a
+/// re-key: the very shape a regime id exists to tell apart, silently answering
+/// [`ScannerOutcome::Stalled`](crate::input::ScannerOutcome::Stalled) — *repeating reproduces the
+/// trip* — over an input whose regime the caller has just replaced. That is a false **stop**, the
+/// harmful direction.
+///
+/// So exhaustion is handled rather than saturated into: this sentinel is excluded from equality by
+/// [`InputRef::scanner_outcome`](crate::InputRef::scanner_outcome)'s comparison, so once the
+/// allocator reaches it every regime reads as *changed*. A parse that re-keys 2^64 times then
+/// stops being able to report a stall and reports a re-key instead, which costs it the guard and
+/// keeps it correct.
+pub(crate) const REGIME_EXHAUSTED: u64 = u64::MAX;
+
+/// Whether two regime ids name the **same** regime.
+///
+/// Equality, minus the one id that names nothing. [`REGIME_EXHAUSTED`] is what the allocator hands
+/// out once it can no longer climb, so two regimes really can wear it at once; excluding it here is
+/// how exhaustion degrades. Every comparison against it is `false`, so
+/// [`InputRef::scanner_outcome`] answers
+/// [`ScannerOutcome::ReKeyed`](crate::input::ScannerOutcome::ReKeyed) and never
+/// [`ScannerOutcome::Stalled`](crate::input::ScannerOutcome::Stalled). A parse that has re-keyed
+/// 2^64 times loses the guard; it does not gain a false stop.
+///
+/// A free function rather than a method because the property is about two numbers and nothing
+/// else, and that is what makes exhaustion testable without a 2^64-step parse.
+#[inline(always)]
+pub(crate) const fn same_regime(a: u64, b: u64) -> bool {
+  a == b && a != REGIME_EXHAUSTED
+}
 pub(crate) use input_ref::Session;
 pub use input_ref::{
   Balance, Commit, DelimClass, Descent, DropPolicy, Hole, InputRef, ResourceTripBaseline, Rollback,
@@ -732,25 +766,47 @@ where
   /// **Three writers of `*state`, and only one of them lands here.** A *commit* threads the lexer's
   /// own post-token state forward and advances the committed span with it; a *restore* installs a
   /// checkpoint's saved pair; a *surgery* ([`InputRef::set_state`], [`InputRef::state_mut`])
-  /// replaces the regime outright through `install_rekey`, which is the sole bump site. So
-  /// **equal generation and equal committed offset together imply an equal `State`**: a commit
-  /// would have moved the offset, and a restore carries the generation of the regime it puts back.
-  /// That pair is what [`InputRef::scanner_outcome`] tests, and it is why it can say a repeat
-  /// reproduces a trip without running one.
+  /// replaces the regime outright through `install_rekey`, which is the sole allocation site. So
+  /// **equal id and equal committed offset together imply an equal `State`**: a commit would have
+  /// moved the offset, and a restore carries the id of the regime it puts back. That pair is what
+  /// [`InputRef::scanner_outcome`] tests, and it is why it can say a repeat reproduces a trip
+  /// without running one.
+  ///
+  /// **That is a claim about values, so a census of assignment sites is not enough to make it.**
+  /// It also needs there to be no public path to the *live* `State` at all — a `State` may hold
+  /// interior mutability, and a `&L::State` handed to safe code is a way to change what a scan
+  /// sees without touching any of the three writers. [`InputRef::state`] therefore returns an
+  /// owned clone, and so does [`Checkpoint::state`]. The remaining shape is a `Clone` that
+  /// **shares** its interior mutability, which is the determinism clause's own named violation.
   ///
   /// **A lineage memo, not a session fact**: a [`Checkpoint`] carries it and a restore pure-copies
   /// it back, exactly like the `poison_boundary` above — because it describes the same thing that
   /// boundary does, the regime that produced it, and a restore that puts back a regime must put
-  /// back its name. Saturating, like the trip counters, and for the same reason: an equality test
-  /// needs consecutive values to differ, and at the ceiling every regime compares equal, which is
-  /// the conservative direction (a stall reads as a re-key, so a loop carries on rather than
-  /// stopping early).
+  /// back its name. The **source** it is allocated from is the opposite class and sits directly
+  /// below; the two must not be confused, and deriving one from the other is the defect that
+  /// split them.
   ///
   /// Not in `ThroughEntry`. The sync family's positional rewind restores a `State` it captured
   /// inside one scan call, and no surgery door is reachable from there — the predicates it hands
   /// out take `&Token`, never `&mut InputRef` — so the generation cannot have moved across the
   /// pair it rewinds.
   regime: u64,
+  /// The **allocator** the regime ids above come from: monotone, and **outside the rollback set**.
+  ///
+  /// The distinction between this and the cell above is the whole of what makes a regime id an
+  /// identity rather than a depth counter. Deriving the next id from the *current* — checkpointed
+  /// — value is not injective, and the counterexample is public: save at `g`, install regime B
+  /// (`g + 1`), roll back to `g`, install regime C (`g + 1` again). B and C are different regimes
+  /// wearing one name, and a reader comparing names calls them the same. The same shape as the
+  /// checkpoint ids in [`Lineage`](super::Lineage), which are allocated from a monotone source
+  /// for the identical reason — *a reissued id could collide*.
+  ///
+  /// So this only ever climbs, a restore never touches it, and it is what `install_rekey` reads.
+  /// At `REGIME_EXHAUSTED` it stops climbing and every id from then on
+  /// is that sentinel, which no comparison treats as equal to anything — including itself. An
+  /// exhausted allocator therefore forces *"the regime changed"*, never *"the regime is the
+  /// same"*: the safe direction, because the unsafe one is a false stall.
+  regime_seq: u64,
   /// The **recursion budget** this parse descends against: live descent depth plus the limit it
   /// may not exceed, configured at [`with_state_and_context`](Self::with_state_and_context) from
   /// [`InputContext::with_recursion_limiter`] and defaulting to
@@ -1155,6 +1211,8 @@ where
       poison_boundary: None,
       // Generation zero: the regime the caller handed in, before any surgery has replaced it.
       regime: 0,
+      // …and the allocator agrees with it, so the first surgery hands out 1.
+      regime_seq: 0,
       // The caller's budget, moved in as given. Every constructor of `RecursionLimiter` starts
       // at depth 0, so this is depth 0 for every context the crate or a caller can build without
       // deliberately walking one deeper first — and a deliberately-deep one is a caller stating
@@ -1321,6 +1379,9 @@ where
       // The regime generation, borrowed beside the boundary it shares a restore group with: a
       // surgery through this handle replaces the regime for the session, not for the handle.
       regime: &mut self.regime,
+      // The allocator, borrowed for the reason the trip counters are: an id it hands out is a fact
+      // about the session, so it must outlive the handle that asked for one.
+      regime_seq: &mut self.regime_seq,
       // The recursion budget, borrowed like the ground-truth cells above rather than snapshotted
       // like `finality`: a handle's frames raise and lower it, and the value must outlive them.
       recursion: &mut self.recursion,

--- a/tokora/src/input/mod.rs
+++ b/tokora/src/input/mod.rs
@@ -243,7 +243,6 @@ pub use cursor::Cursor;
 #[cfg(all(test, feature = "logos_0_16", feature = "std", feature = "combinators"))]
 pub(crate) use input_ref::ClosePayload;
 pub(crate) use input_ref::CloseStatus;
-pub(crate) use input_ref::ScannerTripBaseline;
 
 /// The value both trip counters stop at, and the reading that means "**at least** this many".
 ///
@@ -286,7 +285,7 @@ pub(crate) const TRIP_COUNTER_EXHAUSTED: u64 = u64::MAX;
 pub(crate) use input_ref::Session;
 pub use input_ref::{
   Balance, Commit, DelimClass, Descent, DropPolicy, Hole, InputRef, ResourceTripBaseline, Rollback,
-  Transaction,
+  ScannerTripBaseline, Transaction,
 };
 pub(crate) use lineage::Lineage;
 pub use session::{Budget, PartialSession, RedriveFromBase, ReplayMode, SessionRefusal};

--- a/tokora/src/input/mod.rs
+++ b/tokora/src/input/mod.rs
@@ -721,6 +721,36 @@ where
   /// [the law](crate::input#terminal-beats-incomplete-and-they-never-substitute) for why the ranking
   /// is total, and what an attacker could do without it.
   poison_boundary: Option<L::Offset>,
+  /// The identity of the **lexer regime** installed now — a generation stamped on every state
+  /// surgery, and the third determinism input made comparable.
+  ///
+  /// [`Lexer`](crate::Lexer)'s determinism clause says a scan is decided by source, offset and
+  /// [`State`](crate::state::State). The first two are readable; the third is not — `State` is
+  /// bounded `Debug + Clone` and nothing more, so no handle can compare two of them. This counts
+  /// the one class of event that replaces a regime rather than advancing it.
+  ///
+  /// **Three writers of `*state`, and only one of them lands here.** A *commit* threads the lexer's
+  /// own post-token state forward and advances the committed span with it; a *restore* installs a
+  /// checkpoint's saved pair; a *surgery* ([`InputRef::set_state`], [`InputRef::state_mut`])
+  /// replaces the regime outright through `install_rekey`, which is the sole bump site. So
+  /// **equal generation and equal committed offset together imply an equal `State`**: a commit
+  /// would have moved the offset, and a restore carries the generation of the regime it puts back.
+  /// That pair is what [`InputRef::scanner_outcome`] tests, and it is why it can say a repeat
+  /// reproduces a trip without running one.
+  ///
+  /// **A lineage memo, not a session fact**: a [`Checkpoint`] carries it and a restore pure-copies
+  /// it back, exactly like the `poison_boundary` above — because it describes the same thing that
+  /// boundary does, the regime that produced it, and a restore that puts back a regime must put
+  /// back its name. Saturating, like the trip counters, and for the same reason: an equality test
+  /// needs consecutive values to differ, and at the ceiling every regime compares equal, which is
+  /// the conservative direction (a stall reads as a re-key, so a loop carries on rather than
+  /// stopping early).
+  ///
+  /// Not in `ThroughEntry`. The sync family's positional rewind restores a `State` it captured
+  /// inside one scan call, and no surgery door is reachable from there — the predicates it hands
+  /// out take `&Token`, never `&mut InputRef` — so the generation cannot have moved across the
+  /// pair it rewinds.
+  regime: u64,
   /// The **recursion budget** this parse descends against: live descent depth plus the limit it
   /// may not exceed, configured at [`with_state_and_context`](Self::with_state_and_context) from
   /// [`InputContext::with_recursion_limiter`] and defaulting to
@@ -1123,6 +1153,8 @@ where
       emitted_error_end: L::Offset::default(),
       front_reported_end: None,
       poison_boundary: None,
+      // Generation zero: the regime the caller handed in, before any surgery has replaced it.
+      regime: 0,
       // The caller's budget, moved in as given. Every constructor of `RecursionLimiter` starts
       // at depth 0, so this is depth 0 for every context the crate or a caller can build without
       // deliberately walking one deeper first — and a deliberately-deep one is a caller stating
@@ -1286,6 +1318,9 @@ where
       emitted_error_end: &mut self.emitted_error_end,
       front_reported_end: &mut self.front_reported_end,
       poison_boundary: &mut self.poison_boundary,
+      // The regime generation, borrowed beside the boundary it shares a restore group with: a
+      // surgery through this handle replaces the regime for the session, not for the handle.
+      regime: &mut self.regime,
       // The recursion budget, borrowed like the ground-truth cells above rather than snapshotted
       // like `finality`: a handle's frames raise and lower it, and the value must outlive them.
       recursion: &mut self.recursion,

--- a/tokora/src/input/tests.rs
+++ b/tokora/src/input/tests.rs
@@ -110,3 +110,33 @@ fn input_as_ref_borrows_the_bound_emitter() {
   let input_ref = input.as_ref();
   let _ = input_ref;
 }
+
+/// The regime-id allocator's exhaustion forces *"the regime changed"*, never *"the regime is the
+/// same"* — the safe direction, because the unsafe one is a false stall.
+///
+/// `REGIME_EXHAUSTED` is the id `install_rekey` hands out once the allocator can no longer climb,
+/// so two different regimes really can wear it at once. Saturating into an ordinary value instead
+/// would make a re-key at the ceiling compare **equal**, and `InputRef::scanner_outcome` would
+/// answer `ScannerOutcome::Stalled` — *repeating reproduces the trip* — over an input whose regime
+/// the caller has just replaced. This pins the exclusion that stops it, which no parse could reach
+/// by re-keying.
+#[test]
+fn an_exhausted_regime_id_is_equal_to_nothing_including_itself() {
+  use super::{REGIME_EXHAUSTED, same_regime};
+
+  assert!(
+    same_regime(0, 0),
+    "the initial regime is the same as itself"
+  );
+  assert!(same_regime(7, 7), "an ordinary id is the same as itself");
+  assert!(!same_regime(7, 8), "different ids are different regimes");
+  assert!(
+    !same_regime(REGIME_EXHAUSTED, REGIME_EXHAUSTED),
+    "an exhausted allocator names every regime alike, so its id may never carry an equality — \
+     answering `true` here is exactly the false `Stalled` the sentinel exists to prevent"
+  );
+  assert!(
+    !same_regime(REGIME_EXHAUSTED, 7) && !same_regime(7, REGIME_EXHAUSTED),
+    "and it is not the same as any ordinary id either, in both argument orders"
+  );
+}

--- a/tokora/src/input/token_budget.rs
+++ b/tokora/src/input/token_budget.rs
@@ -407,7 +407,10 @@ impl TokenBudgetTally {
   ///   in-crate reader of terminality uses and what this deliberately is not. In band, on the paths
   ///   that do not unwind, the signal a caller already has is the terminal-marked
   ///   [`UnexpectedEot`](crate::error::UnexpectedEot) the `*_or_stop` family raises, read through
-  ///   [`MaybeTerminal::is_terminal`](crate::error::MaybeTerminal);
+  ///   [`MaybeTerminal::is_terminal`](crate::error::MaybeTerminal) — and, where a *rejecting*
+  ///   emitter's `Err` overtakes that carrier,
+  ///   [`InputRef::at_scanner_stop`](crate::InputRef::at_scanner_stop), which reads this bit as
+  ///   one of its two halves so a caller does not have to combine them;
   /// - **it does not survive a [`PartialSession`](super::PartialSession) redrive.** A redrive
   ///   builds a fresh `Input`, and an input's tally is constructed from the attempt context's
   ///   [`TokenBudget`] and from nothing else — so it is at zero. Nothing a caller can hold carries

--- a/tokora/src/parse_state/mod.rs
+++ b/tokora/src/parse_state/mod.rs
@@ -240,9 +240,13 @@ where
     self.inp.cst_start_at(mark, kind);
   }
 
-  /// Returns the state of the lexer.
+  /// Returns the state of the lexer, **by value**.
+  ///
+  /// Forwards [`InputRef::state`](crate::InputRef::state), which hands out a clone so that no
+  /// public path reaches the live regime without going through a door that re-keys. See it for
+  /// the whole argument.
   #[inline(always)]
-  pub const fn state(&self) -> &L::State {
+  pub fn state(&self) -> L::State {
     self.inp.state()
   }
 

--- a/tokora/src/parser/many/mod.rs
+++ b/tokora/src/parser/many/mod.rs
@@ -377,7 +377,7 @@ pub(super) fn file_element_failure<'inp, 'closure, L, Ctx, Lang: ?Sized, Cmpl>(
   inp: &mut InputRef<'inp, 'closure, L, Ctx, Lang, Cmpl>,
   err: <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error,
   since: &Cursor<'inp, 'closure, L>,
-  scans: ScannerTripBaseline,
+  scans: ScannerTripBaseline<'closure>,
   trips: ResourceTripBaseline<'closure>,
 ) -> Result<(), <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
 where
@@ -520,7 +520,7 @@ where
 pub(super) fn absence_after_element<'inp, 'closure, L, Ctx, Lang: ?Sized, Cmpl>(
   inp: &InputRef<'inp, 'closure, L, Ctx, Lang, Cmpl>,
   latch: &Option<L::Offset>,
-  scans: ScannerTripBaseline,
+  scans: ScannerTripBaseline<'closure>,
   trips: ResourceTripBaseline<'closure>,
 ) -> Result<(), <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
 where

--- a/tokora/src/parser/recovery_gate.rs
+++ b/tokora/src/parser/recovery_gate.rs
@@ -219,7 +219,7 @@ fn judge<'inp, 'closure, L, O, Ctx, Lang: ?Sized, Cmpl, F>(
   f: F,
   latch: &Option<L::Offset>,
   trips: ResourceTripBaseline<'closure>,
-  scans: ScannerTripBaseline,
+  scans: ScannerTripBaseline<'closure>,
 ) -> Result<O, (Failure<'inp, L, Ctx, Lang>, bool)>
 where
   L: Lexer<'inp>,

--- a/tokora/tests/boost.rs
+++ b/tokora/tests/boost.rs
@@ -339,7 +339,9 @@ fn state_and_state_mut_accessible() {
     Ctx: ParseContext<'inp, TestLexer<'inp>>,
     Ctx::Emitter: Emitter<'inp, TestLexer<'inp>, Error = ()>,
   {
-    let _s = inp.state();
+    // `state()` hands back an owned clone now, and this lexer's state is `()` — so a binding here
+    // would be a unit binding. The call itself is what this cell is about.
+    inp.state();
     let _sm = inp.state_mut();
     Ok(())
   }

--- a/tokora/tests/expect.rs
+++ b/tokora/tests/expect.rs
@@ -279,7 +279,8 @@ fn parse_state_accessors_via_map() {
         // Exercise all parse_state accessors
         let _span = ps.span();
         let _emitter = ps.emitter_ref();
-        let _state = ps.state();
+        // An owned clone now, and this lexer's state is `()`; the call is the subject here.
+        ps.state();
         let _state_mut = ps.state_mut();
         let _slice = ps.slice();
         tok

--- a/tokora/tests/forwarding_discrimination.rs
+++ b/tokora/tests/forwarding_discrimination.rs
@@ -1772,14 +1772,14 @@ fn state_state_and_state_mut() {
       probe_token
         .map_with(move |(), mut state: ProbeSt<'_, '_, '_>| {
           assert_eq!(
-            *state.state(),
+            state.state(),
             ENTRY,
             "`ParseState::state` must read the parse's own lexer state, which this parse was \
              entered with"
           );
           *state.state_mut() = WRITTEN;
           assert_eq!(
-            *state.state(),
+            state.state(),
             WRITTEN,
             "`ParseState::state_mut` must hand back the same lexer state `state` reads — a \
              write through the mutable door is invisible through the shared one only if the two \

--- a/tokora/tests/root_loop_trip_witness.rs
+++ b/tokora/tests/root_loop_trip_witness.rs
@@ -1,19 +1,21 @@
 #![cfg(all(feature = "std", feature = "logos_0_16"))]
 
-//! The four **trip-witness** methods, used the way a consumer outside this crate uses them.
+//! The input-side **terminality readings**, used the way a consumer outside this crate uses them.
 //!
 //! `InputRef::trip_snapshot` / `tripped_during_attempt` and their scanner twins
 //! `scanner_trip_snapshot` / `scanner_tripped_during_attempt` were crate-private for as long as the
-//! only sites judging an attempt were this crate's own. They are public now because a consumer
-//! acquired the defect they exist for: a **hand-written document-root loop** that catches a failed
-//! definition and has to decide whether that failure ends the document.
+//! only sites judging an attempt were this crate's own. The descent pair is public now because a
+//! consumer acquired the defect they exist for: a **hand-written document-root loop** that catches
+//! a failed definition and has to decide whether that failure ends the document. The scanner pair
+//! is still crate-internal, and the public scanner verdict is `InputRef::at_scanner_stop` — a
+//! reading of the live stop rather than a baseline-and-compare, for the reason section 4 measures.
 //!
 //! Every other suite that touches these counters drives them through a *combinator* —
 //! `tokora/tests/collection_resource_trip.rs` through the collection drivers,
 //! `tokora/tests/collection_terminal_stop.rs` through the same four families under a scanner
-//! limiter. None of them proves what publishing the methods is for, which is that a loop this crate
-//! did not write can take the baseline and read the verdict. That is what this file drives, and it
-//! drives it from `tokora/tests/`, so nothing here can reach a `pub(crate)` item.
+//! limiter. None of them proves what publishing these readings is for, which is that a loop this
+//! crate did not write can judge its own failure. That is what this file drives, and it drives it
+//! from `tokora/tests/`, so nothing here can reach a `pub(crate)` item.
 //!
 //! # The shape, and the amplification it prevents
 //!
@@ -61,25 +63,31 @@
 //! invocation. Those are compile-fail doctests on `InputRef::trip_snapshot`; what survives to be
 //! measured at runtime is placement, which no type can decide for a caller.
 //!
-//! # The scanner half, and why this file does not use the scanner counter — sections 3 and 4
+//! # The scanner half, and why it is not a counter — sections 3 and 4
 //!
 //! `try_expect` folds a terminal scanner stop into the same `Ok(None)` it uses for a genuine end of
 //! input, so a root loop reaches its "the document ended" arm holding **no error**. The obvious
-//! answer is the input-side scanner counter, and it is the wrong one: `set_state` re-keys the
-//! forward-scanning facts and dropping the poison boundary there is the crate's *documented*
-//! limit-recovery path, while the counter is monotone and never cleared. A loop that recovers that
-//! way reads the whole document and the counter still says truncated. That pair is therefore
-//! crate-internal, and `InputRef::scanner_trip_snapshot` records the measurement.
+//! answer is the input-side scanner *counter*, and it is the wrong one: `set_state` / `state_mut`
+//! re-key the forward-scanning facts and dropping the poison boundary there is the crate's
+//! *documented* limit-recovery path, while the counter is monotone and never cleared. A loop that
+//! recovers that way reads the whole document and the counter still says truncated. That pair is
+//! therefore crate-internal, and `InputRef::scanner_trip_snapshot` records the measurement.
 //!
 //! [`InputRef::try_expect_or_stop`] is what a consumer reaches for **on the declining exits**, and
 //! section 3 is the three cells that show it right in all three of those positions: truncated,
-//! untruncated, and recovered. It is **not** a replacement for the input-side witness, and section
-//! 4 is why: a *rejecting* emitter's trip is built and propagated from inside that very call,
-//! before it can raise a terminal stop, so the caller gets an ordinary-looking error over an
-//! exhausted scanner and no delegation in its `MaybeTerminal` can recover the fact. **No public
-//! witness answers that path today.** Section 4 pins it as a defect rather than a feature; the
-//! visibility of the scanner pair has never changed it in either direction.
+//! untruncated, and recovered.
 //!
+//! It is not the whole answer, and section 4 is the exit it cannot reach: a *rejecting* emitter's
+//! trip is built and propagated from inside that very call, before it can raise a terminal stop, so
+//! the caller gets an ordinary-looking error over an exhausted scanner and no delegation in its
+//! `MaybeTerminal` can recover the fact. [`InputRef::at_scanner_stop`] is what a root loop reads
+//! there — the **live** stop, at the committed cursor, taking no baseline. Section 4 measures both
+//! directions of it: without the reading a re-keying root loop files one diagnostic per remaining
+//! token at three document lengths, and with it the *documented* recovery still finishes the
+//! document — the row a monotone counter answers wrongly, and the reason the counter pair is not
+//! what was published.
+//!
+//! [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
 //! [`InputRef::try_expect_or_stop`]: tokora::InputRef::try_expect_or_stop
 
 mod common;
@@ -91,6 +99,7 @@ use tokora::{
   Emitter, InputRef, Parse, ParseContext, Parser, ParserContext, Token as TokenTrait,
   emitter::{Fatal, Ignored, Silent},
   error::MaybeTerminal,
+  input::TokenBudget,
   lexer::LogosLexer,
   logos::{self, Logos},
   state::{State, recursion_tracker::RecursionLimiter},
@@ -818,14 +827,175 @@ fn a_documented_state_recovery_leaves_or_stop_reporting_a_finished_document() {
   );
 }
 
-// ── Section 4: the exit no public witness answers, and it is not this branch's ────
+// ── Section 4: the exit the error value cannot answer, and the witness that does ────
 
-/// A **rejecting** emitter hands a root loop a scanner stop with nothing on it to read.
+/// A document of `units` numbers, so a report count can be measured as a *growth* rather than as
+/// one number.
+fn s_document(units: usize) -> String {
+  (1..=units)
+    .map(|n| n.to_string())
+    .collect::<Vec<_>>()
+    .join(" ")
+}
+
+/// The brake. The defect the cells below measure is an unbounded report stream, and a fixture that
+/// hangs reports nothing — so the loop stops itself and the *count* is what fails the assertion.
+const S_REPORT_CAP: usize = 256;
+
+/// The root loop a context-sensitive grammar writes: an ordinary failure is met by **re-keying the
+/// lexer regime** and retrying, which is [`InputRef::state_mut`]'s documented effect — the token
+/// cache is dropped and the poison boundary with it.
 ///
-/// **This cell pins a known tokora defect, deliberately.** It is not an endorsement and it is not
-/// a regression: the witness that would answer it, `InputRef::scanner_tripped_during_attempt`, is
-/// crate-internal and was crate-internal before this suite existed. When the gap is closed this
-/// cell must change; that is what it is for.
+/// `witness` is the whole variable. With it, the loop asks the input whether the scanner has
+/// stopped before it decides the failure was ordinary; without it, the error value is all it has.
+///
+/// The re-key carries the **same** limiter — same shared counter, same limit. That is not a
+/// contrived recovery: [`InputRef::state_mut`] hands out `&mut L::State` for a mode switch, and a
+/// grammar that switches lexing modes on a syntax error has no reason to touch a resource tally it
+/// did not know was spent. Widening the budget is the *other* recovery, and it is
+/// [`s_root_widening`].
+///
+/// [`InputRef::state_mut`]: tokora::InputRef::state_mut
+fn s_root_rekeying<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
+  witness: bool,
+) -> Result<usize, SErr>
+where
+  Ctx: ParseContext<'inp, SLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
+{
+  let mut parsed = 0usize;
+  loop {
+    match inp.try_expect_or_stop(|_| true) {
+      Ok(Some(_)) => parsed += 1,
+      Ok(None) => return Ok(parsed),
+      Err(e) => {
+        // The root loop's one decision: does this failure end the document?
+        if e.is_terminal() || (witness && inp.at_scanner_stop()) {
+          return Err(e);
+        }
+        note_report();
+        if reports() >= S_REPORT_CAP {
+          return Ok(parsed);
+        }
+        // An ordinary syntax error, as far as this loop can tell: re-key and carry on. The
+        // boundary goes with the regime, so the next turn re-lexes against a tally that is still
+        // spent.
+        inp.state_mut();
+      }
+    }
+  }
+}
+
+/// [`s_root_rekeying`] reading the witness. A plain `fn` item, not a closure: the parser entry
+/// point is higher-ranked in `'inp`, and only a `fn` item generalises there without annotation.
+fn s_root_rekeying_witnessed<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
+) -> Result<usize, SErr>
+where
+  Ctx: ParseContext<'inp, SLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
+{
+  s_root_rekeying(inp, true)
+}
+
+/// [`s_root_rekeying`] reading only the error value — the loop that has nothing to read.
+fn s_root_rekeying_unwitnessed<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
+) -> Result<usize, SErr>
+where
+  Ctx: ParseContext<'inp, SLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
+{
+  s_root_rekeying(inp, false)
+}
+
+/// The same loop, recovering the way the limit-recovery path is *documented*: swap in a state whose
+/// budget is not spent.
+///
+/// The witness is read on every failure after the widening, and it must **not** fire — the recovery
+/// is complete and the document is finished, not truncated. This is the row a monotone trip counter
+/// gets wrong.
+fn s_root_widening<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
+) -> Result<usize, SErr>
+where
+  Ctx: ParseContext<'inp, SLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
+{
+  let mut parsed = 0usize;
+  let mut widened = false;
+  loop {
+    match inp.try_expect_or_stop(|_| true) {
+      Ok(Some(_)) => parsed += 1,
+      // The end of the document, and the loop asks the witness whether it is a *truncated* one.
+      // This is where a monotone trip counter answers wrongly and the live reading does not: the
+      // counter still carries the trip the widening recovered from.
+      Ok(None) => {
+        return if inp.at_scanner_stop() {
+          Err(SErr::Eot)
+        } else {
+          Ok(parsed)
+        };
+      }
+      Err(e) => {
+        if widened {
+          if e.is_terminal() || inp.at_scanner_stop() {
+            return Err(e);
+          }
+          note_report();
+          return Ok(parsed);
+        }
+        inp.set_state(ScanLimiter::with_limit(S_ROOMY));
+        widened = true;
+      }
+    }
+  }
+}
+
+/// Reads the witness on the far side of a re-key, and hands the reading back as the parse's output.
+///
+/// Two budgets stop a scanner and they decay differently. The **lexer's** limit lives in `L::State`
+/// and the boundary it latches is a per-regime memo, so a re-key really does recover it. The
+/// **input's** [`TokenBudget`] refusal is recorded on the input's own tally, which no
+/// [`Checkpoint`] carries, no re-key touches and no mutator lowers. A witness that read only the
+/// boundary would answer clean on the far side of a re-key over an input that is stopped for good.
+///
+/// [`TokenBudget`]: tokora::input::TokenBudget
+/// [`Checkpoint`]: tokora::input::Checkpoint
+fn s_probe_after_rekey<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
+) -> Result<bool, SErr>
+where
+  Ctx: ParseContext<'inp, SLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
+{
+  loop {
+    match inp.try_expect_or_stop(|_| true) {
+      Ok(Some(_)) => {}
+      Ok(None) => return Ok(inp.at_scanner_stop()),
+      Err(_) => {
+        inp.state_mut();
+        return Ok(inp.at_scanner_stop());
+      }
+    }
+  }
+}
+
+/// Section 4's driver: the verdict, and how many items the lexer actually scanned, under the
+/// **rejecting** emitter. `s_drive!`'s twin, and a macro for the same reason.
+macro_rules! s_drive_fatal {
+  ($limit:expr, $root:ident, $src:expr) => {{
+    let limiter = ScanLimiter::with_limit($limit);
+    let scanned = limiter.counter();
+    let ctx: ParserContext<'_, SLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+    let out = Parser::with_parser_and_context($root, ctx).parse_str_with_state($src, limiter);
+    (out, scanned.get())
+  }};
+}
+
+/// A **rejecting** emitter hands a root loop a scanner stop with nothing on the error value to
+/// read — and [`InputRef::at_scanner_stop`] is what the loop reads instead.
 ///
 /// A rejecting (fail-fast) emitter reports a lexer-resource trip by **returning** the value its
 /// `From<<L::Token as Token>::Error>` builds — that `Err` is the report, not a refusal to make one
@@ -833,13 +1003,16 @@ fn a_documented_state_recovery_leaves_or_stop_reporting_a_finished_document() {
 /// call can reach the arm that raises a terminal end-of-input. So the caller receives an ordinary
 /// grammar error over an exhausted scanner, and no care in the grammar's `MaybeTerminal` can fix
 /// it: [`SErr`] delegates as carefully as a grammar can and still answers `false`, because there is
-/// nothing terminal-marked anywhere on that path to delegate to.
+/// nothing terminal-marked anywhere on that path to delegate to. **That half is unchanged, and this
+/// cell still measures it** — closing al8n/tokora#311 put nothing on the value.
 ///
-/// A root loop that reads only the error value can therefore resynchronise against the same spent
-/// budget, or accept a truncated document. Section 3's cells are all the **accepting** emitter,
-/// where the same stop arrives as a terminal `Eot` — which is why "use `try_expect_or_stop`" is a
-/// statement about *those* exits and not a replacement for the input-side witness.
+/// What it changed is that the loop can read the stop off the *input*. The boundary is latched
+/// inside the crate's terminal predicate, ahead of the diagnostic ever being offered to the
+/// emitter, so it is already on record when the rejection arrives. The two emitters therefore now
+/// agree about whether the document ended, which they did not before: the accepting one says so
+/// through the error value, the rejecting one through the input.
 ///
+/// [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
 /// [`InputRef::try_expect_or_stop`]: tokora::InputRef::try_expect_or_stop
 #[test]
 fn a_rejecting_emitter_hands_the_root_loop_an_unmarked_scanner_stop() {
@@ -862,18 +1035,192 @@ fn a_rejecting_emitter_hands_the_root_loop_an_unmarked_scanner_stop() {
   );
   assert!(
     !rejecting.unwrap_err().is_terminal(),
-    "and it is UNMARKED. This is the gap: a document-root loop reading the error value sees an \
-     ordinary failure over a spent scanner budget, and the input-side witness that would say \
-     otherwise is crate-internal"
+    "and it is still UNMARKED: nothing on that path constructs a terminal carrier for \
+     `MaybeTerminal` to delegate to, so the fix could not be on the value"
   );
 
   // The control: the identical fixture under an ACCEPTING emitter, where the stop is marked. The
-  // two differ only in the emitter, which is what makes the gap a property of the channel.
+  // two differ only in the emitter, which is what made the gap a property of the channel.
   let (accepting, _) = s_drive!(S_TIGHT, s_root_or_stop, S_SRC);
   assert_eq!(
     accepting,
     Err(SErr::Eot),
     "accepting emitter, same source, same budget: the stop is terminal-marked and readable"
+  );
+
+  // And the reading that is the same on both channels: the loop asks the INPUT.
+  reset();
+  let (witnessed, scanned) = s_drive_fatal!(S_TIGHT, s_root_rekeying_witnessed, S_SRC);
+  assert!(scanned > S_TIGHT, "the witnessed run must trip too");
+  assert_eq!(
+    witnessed,
+    Err(SErr::Limit),
+    "the witnessed loop ends the document holding the unmarked value, because `at_scanner_stop` \
+     answered where `is_terminal` could not"
+  );
+  assert_eq!(
+    reports(),
+    0,
+    "one stop is one stop: nothing was filed as an ordinary syntax error"
+  );
+}
+
+/// Without the witness the same loop turns one spent budget into one diagnostic **per remaining
+/// token**, and the count grows with the document.
+///
+/// This is the amplification shape of al8n/smear#169, reached here through the *other* public
+/// contract: the loop reads the unmarked value, concludes "ordinary syntax error", re-keys — which
+/// drops the poison boundary, because that is what a re-key does — and retries against a tally that
+/// is still spent. The crate's own [`InputRef::try_expect_or_stop`] gate cannot stop it, since the
+/// re-key removes the very latch that gate reads.
+///
+/// Three lengths, so what is pinned is the growth and not one number.
+///
+/// [`InputRef::try_expect_or_stop`]: tokora::InputRef::try_expect_or_stop
+#[test]
+fn without_the_witness_a_re_keying_root_loop_files_one_report_per_remaining_token() {
+  for units in [4usize, 8, 16] {
+    let src = s_document(units);
+
+    reset();
+    let (unwitnessed, scanned) = s_drive_fatal!(S_TIGHT, s_root_rekeying_unwitnessed, &src);
+    assert!(
+      scanned > S_TIGHT,
+      "units={units}: the fixture must trip: scanned {scanned}, limit {S_TIGHT}"
+    );
+    assert_eq!(
+      reports(),
+      units - S_TIGHT,
+      "units={units}: one spent budget filed {} diagnostics — the growth the witness removes. \
+       Verdict was {unwitnessed:?}",
+      units - S_TIGHT
+    );
+    assert_eq!(
+      unwitnessed,
+      Ok(S_TIGHT),
+      "units={units}: and the run it finally reports is the truncated one — everything the \
+       re-keys crossed was consumed by the trips that ate it"
+    );
+
+    reset();
+    let (witnessed, scanned) = s_drive_fatal!(S_TIGHT, s_root_rekeying_witnessed, &src);
+    assert!(
+      scanned > S_TIGHT,
+      "units={units}: the witnessed run must trip too"
+    );
+    assert_eq!(
+      witnessed,
+      Err(SErr::Limit),
+      "units={units}: the witnessed loop ends the document at the stop"
+    );
+    assert_eq!(
+      reports(),
+      0,
+      "units={units}: and files nothing, at every length"
+    );
+  }
+}
+
+/// Non-vacuity for the pair above: with a budget nothing reaches, the two loops agree.
+///
+/// Without this cell, "the witnessed loop files nothing" is satisfiable by a loop that does nothing
+/// at all.
+#[test]
+fn with_scan_budget_to_spare_the_witness_costs_the_parse_nothing() {
+  for units in [4usize, 8, 16] {
+    let src = s_document(units);
+
+    reset();
+    let (out, scanned) = s_drive_fatal!(S_ROOMY, s_root_rekeying_unwitnessed, &src);
+    assert!(
+      scanned <= S_ROOMY,
+      "units={units}: the control must not trip: scanned {scanned}"
+    );
+    assert_eq!(out, Ok(units), "units={units}: the whole document");
+    assert_eq!(reports(), 0, "units={units}: nothing filed");
+
+    reset();
+    let (out, scanned) = s_drive_fatal!(S_ROOMY, s_root_rekeying_witnessed, &src);
+    assert!(
+      scanned <= S_ROOMY,
+      "units={units}: the witnessed control must not trip either: scanned {scanned}"
+    );
+    assert_eq!(
+      out,
+      Ok(units),
+      "units={units}: the whole document, with the witness read at every failure — and there are \
+       none"
+    );
+    assert_eq!(reports(), 0, "units={units}: nothing filed");
+  }
+}
+
+/// The row a **monotone** trip counter gets wrong, and this witness does not: a documented recovery
+/// finishes the document, and the witness says so.
+///
+/// `set_state` drops the poison boundary — that *is* the documented limit-recovery path — while the
+/// session's scanner-trip counter is monotone and never cleared. Measured on this exact fixture,
+/// a counter-based verdict answers `true` here over a fully recovered parse; the live reading
+/// answers `false`, because the regime that owned the stop is gone.
+#[test]
+fn a_documented_widening_leaves_the_witness_reporting_a_finished_document() {
+  reset();
+  let (out, scanned) = s_drive_fatal!(S_TIGHT, s_root_widening, S_SRC);
+  assert!(
+    scanned > S_TIGHT,
+    "the fixture must actually trip before recovering: scanned {scanned}, limit {S_TIGHT}"
+  );
+  assert_eq!(
+    out,
+    Ok(S_UNITS - 1),
+    "the recovery is documented and complete, so the document is finished and not truncated. One \
+     token short of the source because the trip that provoked the recovery consumed the token it \
+     tripped on — that loss is the trip's, not the witness's"
+  );
+  assert_eq!(
+    reports(),
+    0,
+    "no failure after the widening: the loop reached a genuine end of input, and the witness — \
+     read on every one of those turns — never fired"
+  );
+}
+
+/// The **other** budget the witness answers for: the input-layer [`TokenBudget`], whose refusal no
+/// re-key can clear.
+///
+/// The pair is the measurement. Same probe, same re-key, and the two stops answer differently on
+/// the far side of it because they are recorded in different places — which is why the witness
+/// reads both and not just the boundary.
+///
+/// [`TokenBudget`]: tokora::input::TokenBudget
+#[test]
+fn a_token_budget_refusal_outlives_the_re_key_that_clears_a_lexer_trip() {
+  const BUDGET: usize = 3;
+  let src = s_document(S_UNITS);
+
+  // The lexer's own limit: the boundary is a per-regime memo, so the re-key really recovers it.
+  let (lexer_side, scanned) = s_drive_fatal!(S_TIGHT, s_probe_after_rekey, &src);
+  assert!(
+    scanned > S_TIGHT,
+    "the lexer-side cell must actually trip: scanned {scanned}, limit {S_TIGHT}"
+  );
+  assert_eq!(
+    lexer_side,
+    Ok(false),
+    "a re-key drops the poison boundary — the documented limit-recovery path — so the witness \
+     reads clean on the far side of it"
+  );
+
+  // The input's own budget: recorded on the tally, which the re-key does not touch.
+  let ctx: ParserContext<'_, SLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let ctx = ctx.with_token_budget(TokenBudget::with_limitation(BUDGET));
+  let budget_side = Parser::with_parser_and_context(s_probe_after_rekey, ctx)
+    .parse_str_with_state(&src, ScanLimiter::with_limit(S_ROOMY));
+  assert_eq!(
+    budget_side,
+    Ok(true),
+    "the token budget's refusal is not a per-regime memo: no `Checkpoint` carries it, no re-key \
+     touches it and no mutator lowers it, so the witness still reads stopped"
   );
 }
 

--- a/tokora/tests/root_loop_trip_witness.rs
+++ b/tokora/tests/root_loop_trip_witness.rs
@@ -104,9 +104,17 @@
 //! shape that is. A trip inside a speculative wrapper is restored away together with the tally
 //! that took it, so every live reading of the input is correctly clean while the caller holds the
 //! trip-derived error at the position the attempt began — a loop guarded on a boolean retries the
-//! identical scan for ever. `ScannerOutcome::Stalled` is that state named: a trip, no stop in
-//! force, and no committed progress. It needs no scan, because the fact that separates a futile
-//! retry from a real recovery is progress, not the scanner's current regime.
+//! identical scan for ever.
+//!
+//! The outcome partitions that by the `Lexer` determinism clause's own three inputs. `Stalled`
+//! means all three are unchanged — source, an offset **equal** to the capture's, and the same
+//! lexer regime — so a repeat reproduces the trip. Each way that can fail has its own arm rather
+//! than being folded in: `ReKeyed` when the documented `set_state`/`state_mut` recovery replaced
+//! the regime without moving the offset, `Rewound` when a rollback landed below the capture,
+//! `Progressed` when the parse committed past it. The capture is **affine** — one capture judges
+//! one attempt — because a reusable one recreates the very retry the arm exists to close, and
+//! `InputRef::judge_scanner` binds capture, work and verdict into a single turn so neither
+//! placement exists to get wrong.
 //!
 //! Its lexer is deliberately **not** the earlier sections': `SLexer`'s tally lives behind an
 //! `Rc<Cell<_>>`, which the `Lexer` determinism clause names as a contract violation — *"a shared
@@ -1418,7 +1426,7 @@ where
 fn after_rollback<'inp, 'closure, L, Ctx>(
   inp: &mut InputRef<'inp, 'closure, L, Ctx>,
   since: ScannerTripBaseline<'closure>,
-  attempt: &ScannerAttempt<'inp, 'closure, L>,
+  attempt: ScannerAttempt<'inp, 'closure, L>,
 ) -> AcrossRollback
 where
   L: tokora::Lexer<'inp>,
@@ -1457,7 +1465,7 @@ macro_rules! probe_bodies {
       let scan = inp.scanner_trip_snapshot();
       let attempt = inp.scanner_attempt();
       let _ = inp.try_attempt(drain_recording);
-      Ok(after_rollback(inp, scan, &attempt))
+      Ok(after_rollback(inp, scan, attempt))
     }
 
     /// `attempt_parse`: the same rollback, reached through the three-way vocabulary.
@@ -1472,7 +1480,7 @@ macro_rules! probe_bodies {
       let scan = inp.scanner_trip_snapshot();
       let attempt = inp.scanner_attempt();
       let _ = inp.attempt_parse(|inp| drain_recording(inp).map(ParseAttempt::Accept));
-      Ok(after_rollback(inp, scan, &attempt))
+      Ok(after_rollback(inp, scan, attempt))
     }
 
     /// A rollback-on-drop [`Transaction`]: no verb at all, just the guard going out of scope.
@@ -1492,7 +1500,7 @@ macro_rules! probe_bodies {
         let mut txn = inp.begin();
         let _ = drain_recording(&mut txn);
       }
-      Ok(after_rollback(inp, scan, &attempt))
+      Ok(after_rollback(inp, scan, attempt))
     }
   };
 }
@@ -1819,7 +1827,7 @@ fn the_stall_outcome_ends_a_speculating_loop_the_boolean_cannot() {
         Err(e) => {
           let done = if match_outcome {
             matches!(
-              inp.scanner_outcome(&attempt),
+              inp.scanner_outcome(attempt),
               ScannerOutcome::Stopped | ScannerOutcome::Stalled
             )
           } else {
@@ -1925,7 +1933,7 @@ fn a_recovery_answering_the_stall_makes_progress_and_the_next_attempt_says_so() 
         Ok(true) => parsed += 1,
         Ok(false) => return Ok((parsed, seen)),
         Err(e) => {
-          let outcome = inp.scanner_outcome(&attempt);
+          let outcome = inp.scanner_outcome(attempt);
           seen.push(outcome);
           match outcome {
             // The documented limit recovery, taken in answer to the stall.
@@ -2017,4 +2025,239 @@ fn a_shared_counter_is_the_named_contract_violation_and_this_is_its_consequence(
        divergence the determinism clause exists to keep out of the supported surface"
     );
   }
+}
+
+/// The documented recovery, taken **inside** the judged attempt: a trip, then `set_state`, and no
+/// committed progress between the capture and the reading.
+///
+/// The offset is unmoved, so a predicate testing only *"did the committed end advance"* answers
+/// `Stalled` here — and `Stalled` is a claim that repeating the attempt reproduces the trip, which
+/// is false: the third determinism input was replaced and a retry under the fresh regime succeeds.
+/// [`ScannerOutcome::ReKeyed`] is that transition with a name.
+///
+/// The control below it is the same probe without the recovery, which must still be `Stalled` — so
+/// what the pair pins is the `set_state`, not the shape of the probe.
+///
+/// [`ScannerOutcome::ReKeyed`]: tokora::input::ScannerOutcome::ReKeyed
+#[test]
+fn a_documented_recovery_inside_the_attempt_is_a_re_key_and_not_a_stall() {
+  fn probe<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>,
+    recover: bool,
+  ) -> Result<ScannerOutcome, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    // Consume up to the ceiling, so the capture below sits exactly where the next scan trips and
+    // nothing is committed between it and the reading.
+    for _ in 0..S_TIGHT {
+      let _ = inp.try_expect_or_stop(|_| true)?;
+    }
+    let attempt = inp.scanner_attempt();
+    // The judged production speculates: it trips, and its rollback takes the latch and the
+    // position back to exactly where the capture was taken. That is the shape in which a stall is
+    // even possible — with the latch standing the answer is `Stopped` and the position never
+    // arises.
+    let _ = inp.try_attempt(|inp| {
+      let _ = inp.try_expect_or_stop(|_| true);
+      Err::<(), SErr>(SErr::Ordinary)
+    });
+    if recover {
+      // The documented limit-recovery path: a regime whose budget is not spent. It replaces the
+      // state, and it moves the committed end by nothing at all.
+      inp.set_state(TokenLimiter::with_limitation(1_000));
+    }
+    Ok(inp.scanner_outcome(attempt))
+  }
+
+  fn recovering<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>,
+  ) -> Result<ScannerOutcome, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    probe(inp, true)
+  }
+
+  fn plain<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>,
+  ) -> Result<ScannerOutcome, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    probe(inp, false)
+  }
+
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let recovered = Parser::with_parser_and_context(recovering, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
+  assert_eq!(
+    recovered,
+    Ok(ScannerOutcome::ReKeyed),
+    "the committed end did not move, and reporting that as a stall would reject a parse the fresh \
+     regime can finish — the regime generation is what tells the two apart"
+  );
+
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let stalled = Parser::with_parser_and_context(plain, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
+  assert_eq!(
+    stalled,
+    Ok(ScannerOutcome::Stalled),
+    "the identical probe without the recovery: the rollback took the latch and the position back \
+     to the capture and moved no regime, so all three determinism inputs are unmoved and \
+     repeating it reproduces the trip"
+  );
+}
+
+/// A rollback that lands **below** the capture is neither a stall nor progress.
+///
+/// The transaction opens before the capture, so its rollback carries the committed end past the
+/// position the capture describes. A predicate testing *"did the end advance"* folds that into
+/// [`ScannerOutcome::Stalled`] and claims a repetition the capture cannot support — it describes a
+/// position the input has left. Testing **equality** puts it in its own arm.
+///
+/// [`ScannerOutcome::Stalled`]: tokora::input::ScannerOutcome::Stalled
+#[test]
+fn a_rollback_below_the_capture_is_a_rewind_and_not_a_stall() {
+  fn probe<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>,
+  ) -> Result<ScannerOutcome, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    let attempt = {
+      // The guard's base is HERE, before anything below it runs.
+      let mut txn = inp.begin();
+      // Consume up to the ceiling inside the transaction, so the capture sits above the base.
+      for _ in 0..S_TIGHT {
+        let _ = txn.try_expect_or_stop(|_| true)?;
+      }
+      let attempt = txn.scanner_attempt();
+      // Trips, and commits nothing.
+      let _ = txn.try_expect_or_stop(|_| true);
+      attempt
+      // Dropped without deciding: rolls back to the base, which is below the capture.
+    };
+    Ok(inp.scanner_outcome(attempt))
+  }
+
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let out = Parser::with_parser_and_context(probe, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
+  assert_eq!(
+    out,
+    Ok(ScannerOutcome::Rewound),
+    "the trip is still counted — the counter is outside the rollback set — but the committed end \
+     is below the capture, so the capture describes a position the input has left"
+  );
+}
+
+/// [`InputRef::judge_scanner`] binds capture, judged work and verdict into one turn, and the loop
+/// written with it ends at the stop having filed nothing — the same result as the hand-placed pair,
+/// with neither placement left to get wrong.
+///
+/// [`InputRef::judge_scanner`]: tokora::InputRef::judge_scanner
+#[test]
+fn the_closure_form_guards_the_same_loop_with_no_placement_to_get_wrong() {
+  fn root<'inp, Ctx>(inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>) -> Result<usize, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    let mut parsed = 0usize;
+    loop {
+      let (outcome, element) = inp.judge_scanner(|inp| {
+        inp.try_attempt(|inp| match inp.try_expect_or_stop(|_| true) {
+          Ok(Some(_)) => Ok(true),
+          Ok(None) => Ok(false),
+          Err(e) => Err(e),
+        })
+      });
+      match element {
+        Ok(true) => parsed += 1,
+        Ok(false) => return Ok(parsed),
+        Err(e) => {
+          if e.is_terminal() || matches!(outcome, ScannerOutcome::Stopped | ScannerOutcome::Stalled)
+          {
+            return Err(e);
+          }
+          note_report();
+          if reports() >= S_REPORT_CAP {
+            return Ok(parsed);
+          }
+        }
+      }
+    }
+  }
+
+  reset();
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let tight = Parser::with_parser_and_context(root, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
+  assert_eq!(tight, Err(SErr::Limit), "ends on the first futile turn");
+  assert_eq!(reports(), 0, "and files nothing");
+
+  reset();
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let roomy = Parser::with_parser_and_context(root, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(1_000));
+  assert_eq!(
+    roomy,
+    Ok(S_UNITS),
+    "and reads the whole document with room to spare"
+  );
+  assert_eq!(reports(), 0, "with nothing to file");
+}
+
+/// A recovery the attempt's own rollback **undoes** is not a recovery, and the regime generation
+/// says so because a [`Checkpoint`] carries it.
+///
+/// This is the objection that sank the original "recovery generation" design: a cell outside the
+/// rollback set counts a `set_state` a rollback undid as a recovery, and the loop then carries on
+/// against a regime that is spent again. Naming the regime inside the restore group answers it —
+/// the restore puts the generation back with the `State` it names, so the capture and the input
+/// agree again and the outcome is [`ScannerOutcome::Stalled`], not
+/// [`ScannerOutcome::ReKeyed`].
+///
+/// [`Checkpoint`]: tokora::input::Checkpoint
+/// [`ScannerOutcome::Stalled`]: tokora::input::ScannerOutcome::Stalled
+/// [`ScannerOutcome::ReKeyed`]: tokora::input::ScannerOutcome::ReKeyed
+#[test]
+fn a_recovery_the_rollback_undoes_is_a_stall_and_not_a_re_key() {
+  fn probe<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>,
+  ) -> Result<ScannerOutcome, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    for _ in 0..S_TIGHT {
+      let _ = inp.try_expect_or_stop(|_| true)?;
+    }
+    let attempt = inp.scanner_attempt();
+    let _ = inp.try_attempt(|inp| {
+      // Trips…
+      let _ = inp.try_expect_or_stop(|_| true);
+      // …and recovers, INSIDE the speculation.
+      inp.set_state(TokenLimiter::with_limitation(1_000));
+      Err::<(), SErr>(SErr::Ordinary)
+    });
+    // The rollback undid the recovery along with everything else the attempt did.
+    Ok(inp.scanner_outcome(attempt))
+  }
+
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let out = Parser::with_parser_and_context(probe, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
+  assert_eq!(
+    out,
+    Ok(ScannerOutcome::Stalled),
+    "the regime the caller installed is gone with the rollback that discarded it, so all three \
+     determinism inputs are back where the capture found them and a repeat reproduces the trip"
+  );
 }

--- a/tokora/tests/root_loop_trip_witness.rs
+++ b/tokora/tests/root_loop_trip_witness.rs
@@ -100,10 +100,13 @@
 //! draining, at the frontier, re-keyed, recovered) is measured under both emitters; rows 1-2 are
 //! the gain and rows 4-5 are why a monotone counter's permanent false positive does not survive.
 //!
-//! What it does **not** close is named and measured too: a trip inside a speculative wrapper is
-//! restored away together with the tally that took it, so both readings correctly say the scanner
-//! can scan again, and a loop that keeps redoing that refundable work is a resource-*placement*
-//! problem whose fix is `TokenBudget` on the input.
+//! Neither boolean is a sufficient **root-loop** guard, and `InputRef::scanner_outcome` is the
+//! shape that is. A trip inside a speculative wrapper is restored away together with the tally
+//! that took it, so every live reading of the input is correctly clean while the caller holds the
+//! trip-derived error at the position the attempt began — a loop guarded on a boolean retries the
+//! identical scan for ever. `ScannerOutcome::Stalled` is that state named: a trip, no stop in
+//! force, and no committed progress. It needs no scan, because the fact that separates a futile
+//! retry from a real recovery is progress, not the scanner's current regime.
 //!
 //! Its lexer is deliberately **not** the earlier sections': `SLexer`'s tally lives behind an
 //! `Rc<Cell<_>>`, which the `Lexer` determinism clause names as a contract violation — *"a shared
@@ -124,7 +127,7 @@ use tokora::{
   Emitter, InputRef, Parse, ParseContext, Parser, ParserContext, Token as TokenTrait,
   emitter::{Fatal, Ignored, Silent},
   error::MaybeTerminal,
-  input::{ScannerTripBaseline, TokenBudget},
+  input::{ScannerAttempt, ScannerOutcome, ScannerTripBaseline, TokenBudget},
   lexer::LogosLexer,
   logos::{self, Logos},
   state::{
@@ -1386,6 +1389,9 @@ struct AcrossRollback {
   /// `scanner_stopped_during_attempt(baseline)` after that same restore, over a baseline taken
   /// **before** the wrapper opened.
   verdict: bool,
+  /// `scanner_outcome(capture)` over a capture taken **before** the wrapper opened — the arm the
+  /// boolean beside it has no room for.
+  outcome: ScannerOutcome,
   /// What the input's own next call answers from the restored state.
   next: NextAnswer,
 }
@@ -1412,6 +1418,7 @@ where
 fn after_rollback<'inp, 'closure, L, Ctx>(
   inp: &mut InputRef<'inp, 'closure, L, Ctx>,
   since: ScannerTripBaseline<'closure>,
+  attempt: &ScannerAttempt<'inp, 'closure, L>,
 ) -> AcrossRollback
 where
   L: tokora::Lexer<'inp>,
@@ -1420,6 +1427,7 @@ where
 {
   let after = inp.at_scanner_stop();
   let verdict = inp.scanner_stopped_during_attempt(since);
+  let outcome = inp.scanner_outcome(attempt);
   let next = match inp.try_expect_or_stop(|_| true) {
     Ok(Some(_)) => NextAnswer::Token,
     Ok(None) => NextAnswer::EndOfInput,
@@ -1429,6 +1437,7 @@ where
     inside: inside(),
     after,
     verdict,
+    outcome,
     next,
   }
 }
@@ -1446,8 +1455,9 @@ macro_rules! probe_bodies {
     {
       note_inside(false);
       let scan = inp.scanner_trip_snapshot();
+      let attempt = inp.scanner_attempt();
       let _ = inp.try_attempt(drain_recording);
-      Ok(after_rollback(inp, scan))
+      Ok(after_rollback(inp, scan, &attempt))
     }
 
     /// `attempt_parse`: the same rollback, reached through the three-way vocabulary.
@@ -1460,8 +1470,9 @@ macro_rules! probe_bodies {
     {
       note_inside(false);
       let scan = inp.scanner_trip_snapshot();
+      let attempt = inp.scanner_attempt();
       let _ = inp.attempt_parse(|inp| drain_recording(inp).map(ParseAttempt::Accept));
-      Ok(after_rollback(inp, scan))
+      Ok(after_rollback(inp, scan, &attempt))
     }
 
     /// A rollback-on-drop [`Transaction`]: no verb at all, just the guard going out of scope.
@@ -1476,11 +1487,12 @@ macro_rules! probe_bodies {
     {
       note_inside(false);
       let scan = inp.scanner_trip_snapshot();
+      let attempt = inp.scanner_attempt();
       {
         let mut txn = inp.begin();
         let _ = drain_recording(&mut txn);
       }
-      Ok(after_rollback(inp, scan))
+      Ok(after_rollback(inp, scan, &attempt))
     }
   };
 }
@@ -1578,10 +1590,12 @@ fn every_speculative_wrapper_restores_a_checkpoint_that_predates_the_trip() {
         inside: true,
         after: false,
         verdict: false,
+        outcome: ScannerOutcome::Stalled,
         next: NextAnswer::Token,
       }),
       "{name}: the stop is on record where the failure is produced and gone on the far side of \
-       the restore — and the restore refunded the tally, so the scanner really does scan again"
+       the restore — the restore refunded the tally, so every live reading is correctly clean, and \
+       `Stalled` is the only thing that says the retry would repeat it"
     );
   }
 }
@@ -1609,6 +1623,7 @@ fn an_input_side_bound_outlives_every_one_of_the_three_rollbacks() {
         inside: true,
         after: true,
         verdict: true,
+        outcome: ScannerOutcome::Stopped,
         next: NextAnswer::Stopped,
       }),
       "{name}: the refusal is recorded on the input's own tally, which no rollback reaches, so \
@@ -1756,29 +1771,35 @@ fn a_baseline_taken_after_the_trip_does_not_charge_this_attempt_with_it() {
   );
 }
 
-/// The case **neither** reading closes, measured rather than left implicit: a root loop whose
-/// element parses inside a `try_attempt` over a bound that lives in the lexer state.
+/// The case the boolean cannot close and the outcome does: a root loop whose element parses inside
+/// a `try_attempt` over a bound that lives in the lexer state.
 ///
-/// Every turn trips and rolls back, and the restore reinstates the tally the checkpoint saved —
-/// the refund [`TokenLimiter`] documents as *"the correct answer"* for a bound on the committed
-/// stream. Both readings answer `false` and both are **right**: after each restore the scanner
-/// really can scan again. The loop nonetheless never advances, because it keeps redoing refundable
-/// work.
+/// Every turn trips and rolls back, and the restore reinstates the tally the checkpoint saved — the
+/// refund [`TokenLimiter`] documents as *"the correct answer"* for a bound on the committed stream.
+/// So every **live** reading of the input is correctly clean, the caller still holds the
+/// trip-derived error, and the cursor and state are exactly where the attempt began. A loop guarded
+/// on [`InputRef::scanner_stopped_during_attempt`] retries the identical scan and only the
+/// fixture's brake ends it.
 ///
-/// That is a resource-**placement** problem and not a witness problem, and `TokenLimiter`'s own
-/// documentation names the fix: *"the wrong semantics for a bound on work performed, because work
-/// an attempt performed and then rolled back was still performed. For that, use `TokenBudget`"*.
-/// The control is the identical loop with the bound moved onto the input, where no rollback reaches
-/// it — and there the verdict ends it at the refusal.
+/// [`ScannerOutcome::Stalled`] is that state with a name: a trip, no stop in force, and **no
+/// committed progress**. It needs no scan and no regime probe — the trip event is outside the
+/// rollback set and the committed position is observable — and by the [`Lexer`] determinism clause
+/// (source, offset and `State` decide everything a scan sees) none of the three moved, so the
+/// retry reproduces the trip.
 ///
-/// Distinguishing the two would require the verdict to run a scan of its own, and the layer's
-/// `RESUME_CENSUS` refuses a third `Lexer::lex` site outside the budget-authorized one. See the
-/// method's own *"What it does not answer"* section.
+/// This is the supported placement, not a violating lexer: `CLexer` holds the crate's own
+/// [`TokenLimiter`] **by value**, which is exactly what the determinism clause requires.
 ///
+/// [`InputRef::scanner_stopped_during_attempt`]: tokora::InputRef::scanner_stopped_during_attempt
+/// [`Lexer`]: tokora::Lexer
+/// [`ScannerOutcome::Stalled`]: tokora::input::ScannerOutcome::Stalled
 /// [`TokenLimiter`]: tokora::state::token_tracker::TokenLimiter
 #[test]
-fn a_state_side_bound_under_speculation_is_refunded_and_neither_reading_closes_it() {
-  fn root<'inp, Ctx>(inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>) -> Result<usize, SErr>
+fn the_stall_outcome_ends_a_speculating_loop_the_boolean_cannot() {
+  fn root<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>,
+    match_outcome: bool,
+  ) -> Result<usize, SErr>
   where
     Ctx: ParseContext<'inp, CLexer<'inp>>,
     Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
@@ -1786,6 +1807,7 @@ fn a_state_side_bound_under_speculation_is_refunded_and_neither_reading_closes_i
     let mut parsed = 0usize;
     let scan = inp.scanner_trip_snapshot();
     loop {
+      let attempt = inp.scanner_attempt();
       let element = inp.try_attempt(|inp| match inp.try_expect_or_stop(|_| true) {
         Ok(Some(_)) => Ok(true),
         Ok(None) => Ok(false),
@@ -1795,7 +1817,15 @@ fn a_state_side_bound_under_speculation_is_refunded_and_neither_reading_closes_i
         Ok(true) => parsed += 1,
         Ok(false) => return Ok(parsed),
         Err(e) => {
-          if e.is_terminal() || inp.at_scanner_stop() || inp.scanner_stopped_during_attempt(scan) {
+          let done = if match_outcome {
+            matches!(
+              inp.scanner_outcome(&attempt),
+              ScannerOutcome::Stopped | ScannerOutcome::Stalled
+            )
+          } else {
+            inp.at_scanner_stop() || inp.scanner_stopped_during_attempt(scan)
+          };
+          if e.is_terminal() || done {
             return Err(e);
           }
           note_report();
@@ -1807,33 +1837,135 @@ fn a_state_side_bound_under_speculation_is_refunded_and_neither_reading_closes_i
     }
   }
 
+  fn root_boolean<'inp, Ctx>(inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>) -> Result<usize, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    root(inp, false)
+  }
+
+  fn root_outcome<'inp, Ctx>(inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>) -> Result<usize, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    root(inp, true)
+  }
+
   reset();
   let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
-  let state_side = Parser::with_parser_and_context(root, ctx)
+  let boolean = Parser::with_parser_and_context(root_boolean, ctx)
     .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
   assert_eq!(
     reports(),
     S_REPORT_CAP,
-    "both readings are read on every turn and both are right that the restored input can scan; \
-     the loop still never advances. Verdict was {state_side:?}"
+    "both booleans are read on every turn and both are right that the restored input can scan; \
+     the loop still never advances. Verdict was {boolean:?}"
   );
   assert_eq!(
-    state_side,
+    boolean,
     Ok(S_TIGHT),
     "and it parsed exactly the pre-trip prefix — no turn after the first stop advanced the cursor"
   );
 
   reset();
   let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
-  let ctx = ctx.with_token_budget(TokenBudget::with_limitation(S_TIGHT));
-  let input_side = Parser::with_parser_and_context(root, ctx)
-    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(1_000));
+  let outcome = Parser::with_parser_and_context(root_outcome, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
   assert_eq!(
-    input_side,
-    Err(SErr::Eot),
-    "the identical loop over a bound no rollback reaches ends at the refusal"
+    outcome,
+    Err(SErr::Limit),
+    "the same loop matching the outcome ends on the first futile turn"
   );
   assert_eq!(reports(), 0, "and files nothing");
+
+  // Non-vacuity: with a budget nothing reaches, the outcome-guarded loop reads the whole document.
+  reset();
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let roomy = Parser::with_parser_and_context(root_outcome, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(1_000));
+  assert_eq!(
+    roomy,
+    Ok(S_UNITS),
+    "the whole document, with the outcome matched on every turn — so the arm above is a verdict \
+     about the trip and not a loop that stops at once"
+  );
+  assert_eq!(reports(), 0, "and there were no failures to file");
+}
+
+/// [`ScannerOutcome::Stalled`] is a fact about one attempt, so it cannot be permanent: a loop that
+/// answers it by installing a fresh regime makes progress, and the next attempt says so.
+///
+/// This is the row that would go wrong if the arm were derived from the monotone counter alone —
+/// the permanent false positive that kept the raw event crate-internal. The recovering loop reads
+/// the whole document and files exactly one report, for the one turn that really did stall.
+///
+/// [`ScannerOutcome::Stalled`]: tokora::input::ScannerOutcome::Stalled
+#[test]
+fn a_recovery_answering_the_stall_makes_progress_and_the_next_attempt_says_so() {
+  fn root<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>,
+  ) -> Result<(usize, Vec<ScannerOutcome>), SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    let mut parsed = 0usize;
+    let mut seen = Vec::new();
+    let mut recovered = false;
+    loop {
+      let attempt = inp.scanner_attempt();
+      let element = inp.try_attempt(|inp| match inp.try_expect_or_stop(|_| true) {
+        Ok(Some(_)) => Ok(true),
+        Ok(None) => Ok(false),
+        Err(e) => Err(e),
+      });
+      match element {
+        Ok(true) => parsed += 1,
+        Ok(false) => return Ok((parsed, seen)),
+        Err(e) => {
+          let outcome = inp.scanner_outcome(&attempt);
+          seen.push(outcome);
+          match outcome {
+            // The documented limit recovery, taken in answer to the stall.
+            ScannerOutcome::Stalled if !recovered => {
+              recovered = true;
+              inp.set_state(TokenLimiter::with_limitation(1_000));
+              note_report();
+            }
+            ScannerOutcome::Stopped | ScannerOutcome::Stalled => return Err(e),
+            _ => note_report(),
+          }
+          if reports() >= S_REPORT_CAP {
+            return Ok((parsed, seen));
+          }
+        }
+      }
+    }
+  }
+
+  reset();
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let out = Parser::with_parser_and_context(root, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
+  let (parsed, seen) = out.expect("the recovery finishes the document");
+  assert_eq!(
+    seen,
+    vec![ScannerOutcome::Stalled],
+    "exactly one turn stalled, and after the recovery answered it no later turn did — a monotone \
+     carrier would have answered every one of them"
+  );
+  assert_eq!(
+    parsed, S_UNITS,
+    "the WHOLE document — the wrapper's rollback put back the token the trip consumed, so unlike \
+     section 4's unwrapped recovery this one loses nothing"
+  );
+  assert_eq!(
+    reports(),
+    1,
+    "one report, for the one turn that really did stall"
+  );
 }
 
 /// The [`Lexer`] determinism clause names *"a shared counter"* as a contract violation, and this is
@@ -1876,6 +2008,7 @@ fn a_shared_counter_is_the_named_contract_violation_and_this_is_its_consequence(
         inside: true,
         after: false,
         verdict: false,
+        outcome: ScannerOutcome::Stalled,
         next: NextAnswer::Stopped,
       }),
       "{name}: the restore rewound the latch but could NOT rewind a tally the state only points \

--- a/tokora/tests/root_loop_trip_witness.rs
+++ b/tokora/tests/root_loop_trip_witness.rs
@@ -87,19 +87,30 @@
 //! document — the row a monotone counter answers wrongly, and the reason the counter pair is not
 //! what was published.
 //!
-//! # Where the reading survives a rollback, and where it does not — section 5
+//! # Two readings, and which question each answers — section 5
 //!
-//! `at_scanner_stop` reads what is on record at the committed cursor, and a speculative wrapper —
-//! `try_attempt`, `attempt_parse`, a rollback-on-drop `Transaction` — restores a checkpoint that
-//! **predates** the trip: `None` boundary, original cursor, original lexer state. Section 5 drives
-//! all three, and its point is that the resulting `false` is not one answer to grade. It reads
-//! right or wrong according to where the scanner bound lives, and the three rows differ in nothing
-//! else: a tally the state only points at is still spent (wrong), the crate's own `TokenLimiter`
-//! held by value is refunded by the very same restore (right), and a `TokenBudget` on the input is
-//! untouched by it (right, on both sides). The first two need opposite answers after the same
-//! restore, which is why nothing carried across it can serve both — and the last cell measures
-//! what reading it on the wrong side costs: a loop that files a report per turn and never advances
-//! the cursor at all.
+//! `at_scanner_stop` is **positional**: is a stop on record *at the committed cursor*. Its own
+//! docs name the residue that costs — an element's lookahead can trip, latch the frontier *ahead*
+//! of the cursor and still return `Ok` with a short window, and every positional witness reads
+//! clean there while the stop is live and already diagnosed.
+//!
+//! `InputRef::scanner_stopped_during_attempt` is the **attempt-relative** reading that closes it:
+//! the session's scanner-trip counter, which is outside the rollback set, conjoined with a stop
+//! still being latched — presence, not position. Section 5's five-point table (latched ahead,
+//! draining, at the frontier, re-keyed, recovered) is measured under both emitters; rows 1-2 are
+//! the gain and rows 4-5 are why a monotone counter's permanent false positive does not survive.
+//!
+//! What it does **not** close is named and measured too: a trip inside a speculative wrapper is
+//! restored away together with the tally that took it, so both readings correctly say the scanner
+//! can scan again, and a loop that keeps redoing that refundable work is a resource-*placement*
+//! problem whose fix is `TokenBudget` on the input.
+//!
+//! Its lexer is deliberately **not** the earlier sections': `SLexer`'s tally lives behind an
+//! `Rc<Cell<_>>`, which the `Lexer` determinism clause names as a contract violation — *"a shared
+//! counter"* — and a state a restore cannot rewind cannot decide a question about restores.
+//! Section 5's `CLexer` holds the crate's own `TokenLimiter` by value, which is the placement that
+//! contract requires; the one cell that still drives the shared counter says so in its own name
+//! and carries no argument.
 //!
 //! [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
 //! [`InputRef::try_expect_or_stop`]: tokora::InputRef::try_expect_or_stop
@@ -113,7 +124,7 @@ use tokora::{
   Emitter, InputRef, Parse, ParseContext, Parser, ParserContext, Token as TokenTrait,
   emitter::{Fatal, Ignored, Silent},
   error::MaybeTerminal,
-  input::TokenBudget,
+  input::{ScannerTripBaseline, TokenBudget},
   lexer::LogosLexer,
   logos::{self, Logos},
   state::{
@@ -1282,15 +1293,21 @@ fn the_descent_witness_holds_under_a_rejecting_emitter() {
   );
 }
 
-// ── Section 5: a rollback erases the record, and where the bound lives decides ──
+// ── Section 5: the attempt-relative verdict, and what each reading is for ──────
 
-/// The lexer whose scanner bound is the crate's **own shipped** [`TokenLimiter`], held by value
-/// in the state — the placement that type documents.
+/// The section's lexer, and the one difference from [`SLexer`] that matters: its scanner bound is
+/// the crate's **own shipped** [`TokenLimiter`], held **by value** in the state.
 ///
-/// [`SLexer`]'s limiter is the other shape: an `Rc<Cell<_>>` the state only *points* at, so the
-/// tally is reachable from every clone and no restore returns it. The two lexers are identical in
-/// every other respect, which is what makes the pair below a measurement of the placement alone.
+/// That is the placement the [`Lexer`] contract requires. Its determinism clause is explicit that
+/// limit accounting must derive entirely from source, offset and [`State`], and that nothing may
+/// route through *"state a checkpoint's `State` snapshot cannot capture and a restore therefore
+/// cannot rewind: **a shared counter**, an ambient global, an allocator address"*. `SLexer`'s
+/// `Rc<Cell<_>>` tally is exactly that named violation — it is a useful instrument for the earlier
+/// sections, which never roll back, but it cannot decide a question about restores, and the one
+/// cell below that still drives it says so in its own name.
 ///
+/// [`Lexer`]: tokora::Lexer
+/// [`State`]: tokora::state::State
 /// [`TokenLimiter`]: tokora::state::token_tracker::TokenLimiter
 #[derive(Debug, Clone, PartialEq, Logos)]
 #[logos(crate = logos, extras = TokenLimiter, skip r"[ \t\r\n]+")]
@@ -1329,12 +1346,11 @@ impl TokenTrait<'_> for CTok {
 type CLexer<'a> = LogosLexer<'a, CTok>;
 
 thread_local! {
-  /// [`InputRef::at_scanner_stop`] read **where the failure was produced** — inside the
-  /// speculative wrapper, before it decides.
+  /// [`InputRef::at_scanner_stop`] read **inside** a speculative wrapper, at the failure.
   ///
   /// A thread-local rather than a return value because the reading has to be taken from inside a
-  /// closure whose error type is the grammar's, and the whole point of section 4 is that the
-  /// grammar's error type carries nothing.
+  /// closure whose error type is the grammar's, and section 4's whole point is that the grammar's
+  /// error type carries nothing.
   ///
   /// [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
   static INSIDE: Cell<bool> = const { Cell::new(false) };
@@ -1348,30 +1364,33 @@ fn inside() -> bool {
   INSIDE.with(Cell::get)
 }
 
-/// What the input answers **for itself** on the far side of the rollback — the control that says
-/// whether the reading beside it was right or wrong.
+/// What the input answers **for itself** — the control that says whether the readings beside it
+/// were right or wrong.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NextAnswer {
-  /// A scan from the restored state yielded a token: the stop really is gone.
+  /// A scan from here yielded a token.
   Token,
   /// A genuine end of input.
   EndOfInput,
-  /// The scan tripped again: the stop is still in force.
+  /// The scan refused: the stop is in force.
   Stopped,
 }
 
-/// The three readings a speculative wrapper's rollback is judged by.
+/// The four readings a speculative wrapper's rollback is judged by.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct AcrossRollback {
   /// `at_scanner_stop()` inside the wrapper, at the failure.
   inside: bool,
   /// `at_scanner_stop()` after the wrapper restored its pre-trip checkpoint.
   after: bool,
-  /// What the input's own next call answers from that restored state.
+  /// `scanner_stopped_during_attempt(baseline)` after that same restore, over a baseline taken
+  /// **before** the wrapper opened.
+  verdict: bool,
+  /// What the input's own next call answers from the restored state.
   next: NextAnswer,
 }
 
-/// Consumes until the scanner stops, recording the verdict **where the failure is produced**.
+/// Consumes until the scanner stops, recording the live reading where the failure is produced.
 fn drain_recording<'inp, L, Ctx>(inp: &mut InputRef<'inp, '_, L, Ctx>) -> Result<(), SErr>
 where
   L: tokora::Lexer<'inp>,
@@ -1390,14 +1409,17 @@ where
   }
 }
 
-/// The reading after the wrapper has restored, beside what the input itself does next.
-fn after_rollback<'inp, L, Ctx>(inp: &mut InputRef<'inp, '_, L, Ctx>) -> AcrossRollback
+fn after_rollback<'inp, 'closure, L, Ctx>(
+  inp: &mut InputRef<'inp, 'closure, L, Ctx>,
+  since: ScannerTripBaseline<'closure>,
+) -> AcrossRollback
 where
   L: tokora::Lexer<'inp>,
   Ctx: ParseContext<'inp, L>,
   Ctx::Emitter: Emitter<'inp, L, Error = SErr>,
 {
   let after = inp.at_scanner_stop();
+  let verdict = inp.scanner_stopped_during_attempt(since);
   let next = match inp.try_expect_or_stop(|_| true) {
     Ok(Some(_)) => NextAnswer::Token,
     Ok(None) => NextAnswer::EndOfInput,
@@ -1406,11 +1428,12 @@ where
   AcrossRollback {
     inside: inside(),
     after,
+    verdict,
     next,
   }
 }
 
-/// The three public wrappers the finding names, driven identically.
+/// The three public wrappers the rollback question is asked through, driven identically.
 macro_rules! probe_bodies {
   ($lexer:ident, $try_attempt:ident, $attempt_parse:ident, $transaction:ident) => {
     /// `try_attempt`: the closure's `Err` rolls back and then propagates.
@@ -1422,8 +1445,9 @@ macro_rules! probe_bodies {
       Ctx::Emitter: Emitter<'inp, $lexer<'inp>, Error = SErr>,
     {
       note_inside(false);
+      let scan = inp.scanner_trip_snapshot();
       let _ = inp.try_attempt(drain_recording);
-      Ok(after_rollback(inp))
+      Ok(after_rollback(inp, scan))
     }
 
     /// `attempt_parse`: the same rollback, reached through the three-way vocabulary.
@@ -1435,8 +1459,9 @@ macro_rules! probe_bodies {
       Ctx::Emitter: Emitter<'inp, $lexer<'inp>, Error = SErr>,
     {
       note_inside(false);
+      let scan = inp.scanner_trip_snapshot();
       let _ = inp.attempt_parse(|inp| drain_recording(inp).map(ParseAttempt::Accept));
-      Ok(after_rollback(inp))
+      Ok(after_rollback(inp, scan))
     }
 
     /// A rollback-on-drop [`Transaction`]: no verb at all, just the guard going out of scope.
@@ -1450,33 +1475,21 @@ macro_rules! probe_bodies {
       Ctx::Emitter: Emitter<'inp, $lexer<'inp>, Error = SErr>,
     {
       note_inside(false);
+      let scan = inp.scanner_trip_snapshot();
       {
         let mut txn = inp.begin();
         let _ = drain_recording(&mut txn);
       }
-      Ok(after_rollback(inp))
+      Ok(after_rollback(inp, scan))
     }
   };
 }
 
-probe_bodies!(SLexer, s_try_attempt, s_attempt_parse, s_transaction);
 probe_bodies!(CLexer, c_try_attempt, c_attempt_parse, c_transaction);
+probe_bodies!(SLexer, s_try_attempt, s_attempt_parse, s_transaction);
 
-/// Section 5's driver for the **state-side** bound whose tally is shared out of band.
-macro_rules! shared_state_bound {
-  ($probe:ident) => {{
-    let limiter = ScanLimiter::with_limit(S_TIGHT);
-    let scanned = limiter.counter();
-    let ctx: ParserContext<'_, SLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
-    let out = Parser::with_parser_and_context($probe, ctx).parse_str_with_state(S_SRC, limiter);
-    (out, scanned.get())
-  }};
-}
-
-/// The same bound, held **by value** in the state — the crate's own [`TokenLimiter`].
-///
-/// [`TokenLimiter`]: tokora::state::token_tracker::TokenLimiter
-macro_rules! by_value_state_bound {
+/// The conforming lexer under a spent scan budget and a **rejecting** emitter.
+macro_rules! conforming {
   ($probe:ident) => {{
     let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
     Parser::with_parser_and_context($probe, ctx)
@@ -1484,235 +1497,391 @@ macro_rules! by_value_state_bound {
   }};
 }
 
-/// The bound on the **input** — [`TokenBudget`] — with the lexer's own limit out of reach.
-///
-/// [`TokenBudget`]: tokora::input::TokenBudget
+/// The same conforming lexer with room to spare, and the bound moved onto the **input**.
 macro_rules! input_bound {
   ($probe:ident) => {{
-    let ctx: ParserContext<'_, SLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+    let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
     let ctx = ctx.with_token_budget(TokenBudget::with_limitation(S_TIGHT));
     Parser::with_parser_and_context($probe, ctx)
-      .parse_str_with_state(S_SRC, ScanLimiter::with_limit(S_ROOMY))
+      .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(1_000))
   }};
 }
 
-/// A rollback erases the **record** of a scanner stop, so
-/// [`InputRef::at_scanner_stop`] reads clean on its far side — through all three public
-/// speculative wrappers.
+/// [`InputRef::at_scanner_stop`] is **not** "what the next call would do": a refusal on record is
+/// durable and non-positional, so it reads `true` with a lookahead's tokens still waiting in front
+/// of the cursor — and [`InputRef::try_expect_or_stop`] hands one of those out.
 ///
-/// The wrapper restores the checkpoint it saved *before* the trip: `None` boundary, original
-/// cursor, original state. The reading is a reading of what is on record at the committed cursor,
-/// and after that restore there is no record and the cursor is not at the frontier. So it answers
-/// `false`, where the identical loop **without** the wrapper answers `true` — measured in
-/// [`a_rejecting_emitter_hands_the_root_loop_an_unmarked_scanner_stop`].
-///
-/// `inside` is the same reading taken where the failure is produced, before the wrapper decides.
-/// It is `true` in every row, which is the whole of the contract's answer: the record exists, and
-/// it exists until the rollback discards it along with everything else the attempt did.
+/// The gate drains a cached token *before* it consults either fact. So a loop that treats a `true`
+/// as *"stop draining"* rather than as *"the stream is truncated"* drops tokens that are already
+/// lexed and paid for. This is the cell the method's contract names.
 ///
 /// [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
+/// [`InputRef::try_expect_or_stop`]: tokora::InputRef::try_expect_or_stop
+#[test]
+fn a_refusal_on_record_still_has_cached_tokens_in_front_of_it() {
+  fn probe<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>,
+  ) -> Result<(bool, bool, NextAnswer), SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    // The fill produces two items against a ceiling of two and refuses the third, which latches
+    // the durable one-shot probe while the two it produced sit at the cache front.
+    let filled = inp.peek::<generic_arraydeque::typenum::U4>().is_ok();
+    let stop = inp.at_scanner_stop();
+    let next = match inp.try_expect_or_stop(|_| true) {
+      Ok(Some(_)) => NextAnswer::Token,
+      Ok(None) => NextAnswer::EndOfInput,
+      Err(_) => NextAnswer::Stopped,
+    };
+    Ok((filled, stop, next))
+  }
+
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let ctx = ctx.with_token_budget(TokenBudget::with_limitation(2));
+  let out = Parser::with_parser_and_context(probe, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(1_000));
+
+  assert_eq!(
+    out,
+    Ok((true, true, NextAnswer::Token)),
+    "the fill succeeded with a short window, the refusal is on record — and the very next \
+     `try_expect_or_stop` still serves a cached token, because it drains the front before it \
+     consults the gate"
+  );
+}
+
+/// A rollback erases the **record** of a scanner stop, through all three public speculative
+/// wrappers — and under a conforming limiter that is the **right** answer, because the same
+/// restore gave the budget back.
+///
+/// `TokenLimiter` documents the refund from its own side: *"a rollback reinstalls the state a
+/// checkpoint saved, so the baseline becomes that saved count and everything spent after it is
+/// given back"*, and *"an abandoned speculation's tokens are not in it, so a refund is the correct
+/// answer"*. The fourth column is the proof rather than the claim: a scan from the restored state
+/// really does yield a token. Both readings say `false` and both are right.
+///
+/// `inside` is the live reading taken where the failure is produced, before the wrapper decides.
+/// It is `true` in every row: the record exists, and the rollback discards it along with
+/// everything else the attempt did.
 #[test]
 fn every_speculative_wrapper_restores_a_checkpoint_that_predates_the_trip() {
-  for (name, (out, scanned)) in [
-    ("try_attempt", shared_state_bound!(s_try_attempt)),
-    ("attempt_parse", shared_state_bound!(s_attempt_parse)),
-    ("transaction drop", shared_state_bound!(s_transaction)),
-  ] {
-    assert!(
-      scanned > S_TIGHT,
-      "{name}: the fixture must actually trip the scan budget: scanned {scanned}, limit {S_TIGHT}"
-    );
-    assert_eq!(
-      out,
-      Ok(AcrossRollback {
-        inside: true,
-        after: false,
-        next: NextAnswer::Stopped,
-      }),
-      "{name}: the stop is on record where the failure is produced, gone on the far side of the \
-       rollback, and STILL IN FORCE — the input's own next call trips again over a tally no \
-       restore returned"
-    );
-  }
-}
-
-/// The row above is a false negative **because of where that bound lives**, and this is the
-/// control that says so: the crate's own [`TokenLimiter`], held by value in the state, makes the
-/// identical `false` the **right** answer.
-///
-/// `TokenLimiter` documents it outright — *"a rollback reinstalls the state a checkpoint saved, so
-/// the baseline becomes that saved count and everything spent after it is given back"*, and *"an
-/// abandoned speculation's tokens are not in it, so a refund is the correct answer"*. The refund
-/// is what the third column reads: a scan from the restored state yields a token, so no stop is in
-/// force and `at_scanner_stop` saying so is correct.
-///
-/// The two rows differ in nothing but the tally's placement, and they need **opposite** answers
-/// after the same rollback. That is what no carrier riding the rollback can supply: the fact that
-/// separates them lives in `L::State`, which is precisely the thing a checkpoint restores.
-///
-/// [`TokenLimiter`]: tokora::state::token_tracker::TokenLimiter
-#[test]
-fn a_by_value_state_bound_makes_the_same_false_the_right_answer() {
   for (name, out) in [
-    ("try_attempt", by_value_state_bound!(c_try_attempt)),
-    ("attempt_parse", by_value_state_bound!(c_attempt_parse)),
-    ("transaction drop", by_value_state_bound!(c_transaction)),
+    ("try_attempt", conforming!(c_try_attempt)),
+    ("attempt_parse", conforming!(c_attempt_parse)),
+    ("transaction drop", conforming!(c_transaction)),
   ] {
     assert_eq!(
       out,
       Ok(AcrossRollback {
         inside: true,
         after: false,
+        verdict: false,
         next: NextAnswer::Token,
       }),
-      "{name}: the rollback refunded the tally — which `TokenLimiter` documents as the correct \
-       answer — so the stop really is gone and reading `false` is right"
+      "{name}: the stop is on record where the failure is produced and gone on the far side of \
+       the restore — and the restore refunded the tally, so the scanner really does scan again"
     );
   }
 }
 
-/// And the bound the crate ships for *work performed* — [`TokenBudget`], on the input — survives
-/// every one of the three rollbacks, so the reading survives with it.
+/// The bound the crate ships for **work performed** — [`TokenBudget`], on the input — survives
+/// every one of the three rollbacks, so both readings survive with it.
 ///
-/// No `Checkpoint` carries the input's tally, no re-key touches it and no mutator lowers it. That
-/// is not a property a witness had to be given: it is the placement, and
-/// [`InputRef::at_scanner_stop`] already reads it. A consumer that speculates over a scanner bound
-/// gets a rollback-proof verdict by putting the bound here — which is the same sentence
-/// `TokenLimiter`'s own documentation ends on.
+/// No [`Checkpoint`] carries the input's tally, no re-key touches it and no mutator lowers it.
+/// That is the placement for a bound that must hold across speculation, and it is where
+/// `TokenLimiter`'s own documentation sends a caller who needs one: *"work an attempt performed
+/// and then rolled back was still performed"*.
 ///
 /// [`TokenBudget`]: tokora::input::TokenBudget
-/// [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
+/// [`Checkpoint`]: tokora::input::Checkpoint
 #[test]
 fn an_input_side_bound_outlives_every_one_of_the_three_rollbacks() {
   for (name, out) in [
-    ("try_attempt", input_bound!(s_try_attempt)),
-    ("attempt_parse", input_bound!(s_attempt_parse)),
-    ("transaction drop", input_bound!(s_transaction)),
+    ("try_attempt", input_bound!(c_try_attempt)),
+    ("attempt_parse", input_bound!(c_attempt_parse)),
+    ("transaction drop", input_bound!(c_transaction)),
   ] {
     assert_eq!(
       out,
       Ok(AcrossRollback {
         inside: true,
         after: true,
+        verdict: true,
         next: NextAnswer::Stopped,
       }),
       "{name}: the refusal is recorded on the input's own tally, which no rollback reaches, so \
-       the verdict is the same on both sides of the restore"
+       both readings are the same on both sides of the restore"
     );
   }
 }
 
-/// The root loop of section 4 with its element **speculating**, and the amplification that opens
-/// when the verdict is read on the wrong side of the rollback.
+/// The five points the two readings are asked at, and the two where they differ.
 ///
-/// `read_inside` is the whole variable. Reading where the failure is produced ends the document at
-/// the stop; reading after the wrapper has restored reads clean, so the loop files the failure as
-/// an ordinary syntax error, re-keys, and retries — from a state identical to the one it just
-/// failed in. There is **no progress at all**: the element consumes nothing, so the loop neither
-/// advances nor terminates, and only [`S_REPORT_CAP`] stops the fixture.
+/// [`InputRef::at_scanner_stop`] is the **positional** question — is a stop on record *at the
+/// committed cursor*. [`InputRef::scanner_stopped_during_attempt`] is the **attempt-relative** one
+/// — did a trip happen while this attempt ran, and is a stop still latched.
 ///
-/// That is strictly worse than section 4's unwrapped loop, which files one report per *remaining
-/// token* and does end. It is also the case section 4's named residue did not cover: the residue's
-/// bound was "the region behind the frontier is replayable, so the loop makes real progress and
-/// re-reaches the stop", and a wrapper that rolls back keeps none of what it replayed.
-fn s_root_speculating<'inp, Ctx>(
-  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
-  read_inside: bool,
-) -> Result<usize, SErr>
-where
-  Ctx: ParseContext<'inp, SLexer<'inp>>,
-  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
-{
-  let mut parsed = 0usize;
-  loop {
-    let mut stopped = false;
-    let element = inp.try_attempt(|inp| match inp.try_expect_or_stop(|_| true) {
-      Ok(Some(_)) => Ok(true),
-      Ok(None) => Ok(false),
-      Err(e) => {
-        stopped = inp.at_scanner_stop();
-        Err(e)
-      }
-    });
-    match element {
-      Ok(true) => parsed += 1,
-      Ok(false) => return Ok(parsed),
-      Err(e) => {
-        let verdict = if read_inside {
-          stopped
-        } else {
-          inp.at_scanner_stop()
-        };
-        if e.is_terminal() || verdict {
-          return Err(e);
+/// Rows 1 and 2 are why the second exists, and they are the residue the live reading names and
+/// cannot answer: a **lookahead** trips, latching the frontier *ahead* of the cursor, and returns
+/// `Ok` with a short window. Every positional witness reads clean there while the stop is live and
+/// already diagnosed — including after the cached pre-trip tokens start draining, which is row 2.
+///
+/// Rows 4 and 5 are why it is not a permanent false positive. The monotone counter behind it is
+/// never cleared by anything, and a verdict resting on the counter alone would answer `true` over
+/// a fully recovered parse — the measurement that kept the raw pair crate-internal. Both public
+/// state-surgery doors drop the latch, and the verdict goes with it.
+///
+/// Driven under **both** emitters, because section 4's whole subject is that the rejecting one
+/// carries no terminal marking. The two agree at every point.
+///
+/// [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
+/// [`InputRef::scanner_stopped_during_attempt`]: tokora::InputRef::scanner_stopped_during_attempt
+#[test]
+fn the_attempt_relative_verdict_answers_where_the_positional_reading_is_blind() {
+  fn probe<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>,
+  ) -> Result<Vec<(bool, bool)>, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    let mut rows = Vec::new();
+    let scan = inp.scanner_trip_snapshot();
+
+    // 1 — a lookahead trips and latches AHEAD of the cursor, returning a short window.
+    let _ = inp.peek::<generic_arraydeque::typenum::U4>();
+    rows.push((
+      inp.at_scanner_stop(),
+      inp.scanner_stopped_during_attempt(scan),
+    ));
+
+    // 2 — draining the cached pre-trip tokens does not move the cursor to the frontier.
+    let _ = inp.try_expect_or_stop(|_| true);
+    rows.push((
+      inp.at_scanner_stop(),
+      inp.scanner_stopped_during_attempt(scan),
+    ));
+
+    // 3 — consume up to the stop: the cursor reaches the frontier and both readings see it.
+    while let Ok(Some(_)) = inp.try_expect_or_stop(|_| true) {}
+    rows.push((
+      inp.at_scanner_stop(),
+      inp.scanner_stopped_during_attempt(scan),
+    ));
+
+    // 4 — a bare re-key: a mode switch that leaves the resource tally exactly as it was, and
+    // drops the latch, which is what `state_mut` documents.
+    inp.state_mut();
+    rows.push((
+      inp.at_scanner_stop(),
+      inp.scanner_stopped_during_attempt(scan),
+    ));
+
+    // 5 — the documented limit recovery: a regime whose budget is not spent.
+    inp.set_state(TokenLimiter::with_limitation(1_000));
+    rows.push((
+      inp.at_scanner_stop(),
+      inp.scanner_stopped_during_attempt(scan),
+    ));
+
+    Ok(rows)
+  }
+
+  let expected = vec![
+    // (at_scanner_stop, scanner_stopped_during_attempt)
+    (false, true),  // latched ahead of the cursor: the positional reading is blind
+    (false, true),  // and stays blind while the cached pre-trip tokens drain
+    (true, true),   // cursor at the frontier: both see it
+    (false, false), // re-key drops the latch — the documented recovery door
+    (false, false), // and so does a fresh regime
+  ];
+
+  let ctx: ParserContext<'_, CLexer<'_>, Silent<SErr>> = ParserContext::new(Silent::new());
+  let accepting = Parser::with_parser_and_context(probe, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
+  assert_eq!(
+    accepting,
+    Ok(expected.clone()),
+    "accepting emitter: rows 1-2 are the residue the positional reading names and cannot answer; \
+     rows 4-5 are why the verdict is not a permanent false positive"
+  );
+
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let rejecting = Parser::with_parser_and_context(probe, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
+  assert_eq!(
+    rejecting,
+    Ok(expected),
+    "rejecting emitter: the same five answers. The verdict does not depend on which channel the \
+     trip was reported through, which is the property section 4 is about"
+  );
+}
+
+/// The verdict is **attempt-relative**, not *"is this scanner spent"*: a trip that predates the
+/// baseline does not charge the attempt that took it, even while the regime is still refusing.
+///
+/// This is the placement discipline section 2 measures for the descent baseline, in the one line
+/// that separates this reading from a session-absolute one. `at_scanner_stop` answers `true` here
+/// — a stop really is on record at the cursor — and the verdict answers `false`, because nothing
+/// tripped since the baseline was taken. Dropping the event conjunct makes the two agree, which is
+/// what the method would be if it were only its live half.
+#[test]
+fn a_baseline_taken_after_the_trip_does_not_charge_this_attempt_with_it() {
+  fn probe<'inp, Ctx>(inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>) -> Result<(bool, bool), SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    // Trip, and commit the trip: the regime refuses from here on.
+    while let Ok(Some(_)) = inp.try_expect_or_stop(|_| true) {}
+    // The baseline is taken AFTER it. Nothing has tripped since, and no scan runs before the
+    // verdict is read.
+    let fresh = inp.scanner_trip_snapshot();
+    Ok((
+      inp.at_scanner_stop(),
+      inp.scanner_stopped_during_attempt(fresh),
+    ))
+  }
+
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let out = Parser::with_parser_and_context(probe, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
+  assert_eq!(
+    out,
+    Ok((true, false)),
+    "the stop is on record at the cursor, and it is not this attempt's: a baseline taken after the \
+     trip charges nothing, which is the whole of what makes the reading attempt-relative"
+  );
+}
+
+/// The case **neither** reading closes, measured rather than left implicit: a root loop whose
+/// element parses inside a `try_attempt` over a bound that lives in the lexer state.
+///
+/// Every turn trips and rolls back, and the restore reinstates the tally the checkpoint saved —
+/// the refund [`TokenLimiter`] documents as *"the correct answer"* for a bound on the committed
+/// stream. Both readings answer `false` and both are **right**: after each restore the scanner
+/// really can scan again. The loop nonetheless never advances, because it keeps redoing refundable
+/// work.
+///
+/// That is a resource-**placement** problem and not a witness problem, and `TokenLimiter`'s own
+/// documentation names the fix: *"the wrong semantics for a bound on work performed, because work
+/// an attempt performed and then rolled back was still performed. For that, use `TokenBudget`"*.
+/// The control is the identical loop with the bound moved onto the input, where no rollback reaches
+/// it — and there the verdict ends it at the refusal.
+///
+/// Distinguishing the two would require the verdict to run a scan of its own, and the layer's
+/// `RESUME_CENSUS` refuses a third `Lexer::lex` site outside the budget-authorized one. See the
+/// method's own *"What it does not answer"* section.
+///
+/// [`TokenLimiter`]: tokora::state::token_tracker::TokenLimiter
+#[test]
+fn a_state_side_bound_under_speculation_is_refunded_and_neither_reading_closes_it() {
+  fn root<'inp, Ctx>(inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>) -> Result<usize, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    let mut parsed = 0usize;
+    let scan = inp.scanner_trip_snapshot();
+    loop {
+      let element = inp.try_attempt(|inp| match inp.try_expect_or_stop(|_| true) {
+        Ok(Some(_)) => Ok(true),
+        Ok(None) => Ok(false),
+        Err(e) => Err(e),
+      });
+      match element {
+        Ok(true) => parsed += 1,
+        Ok(false) => return Ok(parsed),
+        Err(e) => {
+          if e.is_terminal() || inp.at_scanner_stop() || inp.scanner_stopped_during_attempt(scan) {
+            return Err(e);
+          }
+          note_report();
+          if reports() >= S_REPORT_CAP {
+            return Ok(parsed);
+          }
         }
-        note_report();
-        if reports() >= S_REPORT_CAP {
-          return Ok(parsed);
-        }
-        inp.state_mut();
       }
     }
   }
-}
 
-fn s_root_speculating_inside<'inp, Ctx>(
-  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
-) -> Result<usize, SErr>
-where
-  Ctx: ParseContext<'inp, SLexer<'inp>>,
-  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
-{
-  s_root_speculating(inp, true)
-}
-
-fn s_root_speculating_after<'inp, Ctx>(
-  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
-) -> Result<usize, SErr>
-where
-  Ctx: ParseContext<'inp, SLexer<'inp>>,
-  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
-{
-  s_root_speculating(inp, false)
-}
-
-/// Reading the verdict on the far side of a rollback costs the loop its termination; reading it
-/// where the failure is produced does not.
-///
-/// The pair is the measurement, and the placement is its only variable — same loop, same wrapper,
-/// same source, same budget.
-#[test]
-fn the_verdict_read_after_the_rollback_leaves_the_loop_without_progress() {
   reset();
-  let (after, scanned) = shared_state_bound!(s_root_speculating_after);
-  assert!(
-    scanned > S_TIGHT,
-    "the fixture must actually trip: scanned {scanned}, limit {S_TIGHT}"
-  );
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let state_side = Parser::with_parser_and_context(root, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
   assert_eq!(
     reports(),
     S_REPORT_CAP,
-    "the loop never stops on its own: every turn rolls back to the state the last one failed in, \
-     so only the fixture's brake ends it. Verdict was {after:?}"
+    "both readings are read on every turn and both are right that the restored input can scan; \
+     the loop still never advances. Verdict was {state_side:?}"
   );
   assert_eq!(
-    after,
+    state_side,
     Ok(S_TIGHT),
-    "and it has parsed exactly what the pre-trip prefix holds — no turn after the first stop \
-     advanced the cursor by a single token"
+    "and it parsed exactly the pre-trip prefix — no turn after the first stop advanced the cursor"
   );
 
   reset();
-  let (inside, scanned) = shared_state_bound!(s_root_speculating_inside);
-  assert!(scanned > S_TIGHT, "the inside-read run must trip too");
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let ctx = ctx.with_token_budget(TokenBudget::with_limitation(S_TIGHT));
+  let input_side = Parser::with_parser_and_context(root, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(1_000));
   assert_eq!(
-    inside,
-    Err(SErr::Limit),
-    "read where the failure is produced, the same loop ends the document at the stop"
+    input_side,
+    Err(SErr::Eot),
+    "the identical loop over a bound no rollback reaches ends at the refusal"
   );
-  assert_eq!(
-    reports(),
-    0,
-    "one stop is one stop: nothing was filed as an ordinary syntax error"
-  );
+  assert_eq!(reports(), 0, "and files nothing");
+}
+
+/// The [`Lexer`] determinism clause names *"a shared counter"* as a contract violation, and this is
+/// what the input layer does with one. **It carries no argument** — it is here so the clause has a
+/// measured consequence rather than only a sentence, and so the instrument the earlier sections use
+/// is labelled for what it is.
+///
+/// [`SLexer`]'s tally lives behind an `Rc<Cell<_>>` that every clone shares, so a restore reinstalls
+/// a state pointing at a tally it cannot rewind. Both readings then describe an input that is not
+/// the one the next scan will see: `at_scanner_stop` says clean, the attempt-relative verdict says
+/// stopped, and the input's own next call refuses. Unspecified-but-bounded, exactly as the
+/// [*Violation posture*] section promises — no panic, no unsoundness, and no replay fidelity.
+///
+/// [`Lexer`]: tokora::Lexer
+/// [*Violation posture*]: tokora::Lexer
+#[test]
+fn a_shared_counter_is_the_named_contract_violation_and_this_is_its_consequence() {
+  macro_rules! violating {
+    ($probe:ident) => {{
+      let limiter = ScanLimiter::with_limit(S_TIGHT);
+      let scanned = limiter.counter();
+      let ctx: ParserContext<'_, SLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+      let out = Parser::with_parser_and_context($probe, ctx).parse_str_with_state(S_SRC, limiter);
+      (out, scanned.get())
+    }};
+  }
+
+  for (name, (out, scanned)) in [
+    ("try_attempt", violating!(s_try_attempt)),
+    ("attempt_parse", violating!(s_attempt_parse)),
+    ("transaction drop", violating!(s_transaction)),
+  ] {
+    assert!(
+      scanned > S_TIGHT,
+      "{name}: the fixture must actually trip: scanned {scanned}, limit {S_TIGHT}"
+    );
+    assert_eq!(
+      out,
+      Ok(AcrossRollback {
+        inside: true,
+        after: false,
+        verdict: false,
+        next: NextAnswer::Stopped,
+      }),
+      "{name}: the restore rewound the latch but could NOT rewind a tally the state only points \
+       at, so the refund the conforming row measures never happened — both readings are clean \
+       over a scanner that refuses the very next call, which is the unspecified-but-bounded \
+       divergence the determinism clause exists to keep out of the supported surface"
+    );
+  }
 }

--- a/tokora/tests/root_loop_trip_witness.rs
+++ b/tokora/tests/root_loop_trip_witness.rs
@@ -1356,6 +1356,78 @@ impl TokenTrait<'_> for CTok {
 
 type CLexer<'a> = LogosLexer<'a, CTok>;
 
+/// A lexing **mode** a grammar flips to change how the region ahead lexes — the ordinary reason a
+/// [`State`] carries interior mutability.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum Mode {
+  #[default]
+  Narrow,
+  Wide,
+}
+
+/// A conforming [`State`] with interior mutability: a by-value [`TokenLimiter`] beside a
+/// `Cell<Mode>`.
+///
+/// It is **not** the determinism clause's named violation — the derived `Clone` deep-copies the
+/// cell, so a clone's mode is independent of the live one and a checkpoint restores what it saved.
+/// That is exactly why it is the right instrument for the accessor: the hole it probes is a public
+/// path to the *live* value, not a shared tally.
+///
+/// [`State`]: tokora::state::State
+/// [`TokenLimiter`]: tokora::state::token_tracker::TokenLimiter
+#[derive(Debug, Clone, Default)]
+struct ModeLimiter {
+  limiter: TokenLimiter,
+  mode: Cell<Mode>,
+}
+
+impl ModeLimiter {
+  fn with_limitation(limit: usize) -> Self {
+    Self {
+      limiter: TokenLimiter::with_limitation(limit),
+      mode: Cell::new(Mode::Narrow),
+    }
+  }
+}
+
+impl State for ModeLimiter {
+  type Error = TokenLimitExceeded;
+
+  fn check(&self) -> Result<(), Self::Error> {
+    self.limiter.check()
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Logos)]
+#[logos(crate = logos, extras = ModeLimiter, skip r"[ \t\r\n]+")]
+enum MTok {
+  #[regex(r"[0-9]+", |lex| { lex.extras.limiter.increase(); lex.slice().parse::<i64>().unwrap_or(0) })]
+  Num(i64),
+}
+
+impl core::fmt::Display for MTok {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    core::fmt::Display::fmt(&self.kind(), f)
+  }
+}
+
+impl TokenTrait<'_> for MTok {
+  type Kind = SKind;
+  type Error = SErr;
+
+  const SCAN_LOOKAHEAD: tokora::ScanLookahead = tokora::ScanLookahead::Unbounded;
+
+  fn kind(&self) -> SKind {
+    SKind::Num
+  }
+
+  fn is_trivia(&self) -> bool {
+    false
+  }
+}
+
+type MLexer<'a> = LogosLexer<'a, MTok>;
+
 thread_local! {
   /// [`InputRef::at_scanner_stop`] read **inside** a speculative wrapper, at the failure.
   ///
@@ -2259,5 +2331,112 @@ fn a_recovery_the_rollback_undoes_is_a_stall_and_not_a_re_key() {
     Ok(ScannerOutcome::Stalled),
     "the regime the caller installed is gone with the rollback that discarded it, so all three \
      determinism inputs are back where the capture found them and a repeat reproduces the trip"
+  );
+}
+
+/// A regime id is **allocated**, never derived from the checkpointed cell — so two different
+/// regimes cannot come to wear one name across a rollback.
+///
+/// The public counterexample, built exactly as it reads: save at `g`, install regime **B**, capture
+/// an attempt and trip inside it, roll back to `g`, then install regime **C**. Deriving the next id
+/// from the current value hands B and C the same name, and at the original offset with the stop
+/// cleared the capture and the input compare equal — [`ScannerOutcome::Stalled`], *"repeating
+/// reproduces the trip"*, over an input whose regime the caller has just replaced twice. Allocating
+/// from a monotone source outside the rollback set is what makes C's name new.
+///
+/// [`ScannerOutcome::Stalled`]: tokora::input::ScannerOutcome::Stalled
+#[test]
+fn a_regime_id_is_not_reused_after_a_rollback_hands_its_predecessor_back() {
+  fn probe<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, CLexer<'inp>, Ctx>,
+  ) -> Result<ScannerOutcome, SErr>
+  where
+    Ctx: ParseContext<'inp, CLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, CLexer<'inp>, Error = SErr>,
+  {
+    for _ in 0..S_TIGHT {
+      let _ = inp.try_expect_or_stop(|_| true)?;
+    }
+    let mut txn = inp.begin_stacked();
+    // Savepoint at generation `g`, with nothing consumed after it — so the rollback below lands
+    // the committed end exactly where the capture takes it.
+    let sp = txn.savepoint();
+    // Regime B: a budget already spent, so the scan below trips under it.
+    txn.set_state(TokenLimiter::with_limitation(0));
+    // The capture sees B's name.
+    let attempt = txn.scanner_attempt();
+    // Trip inside B — the event survives everything below, being outside the rollback set.
+    let _ = txn.try_expect_or_stop(|_| true);
+    // Back to `g`: the checkpointed id comes back, and a DERIVED allocator would hand the same
+    // next name — B's — to whatever is installed after this.
+    txn.rollback_to(sp);
+    // Regime C. Different regime, and it must not inherit B's name.
+    txn.set_state(TokenLimiter::with_limitation(1_000));
+    let outcome = txn.scanner_outcome(attempt);
+    txn.commit();
+    Ok(outcome)
+  }
+
+  let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let out = Parser::with_parser_and_context(probe, ctx)
+    .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT));
+  assert_eq!(
+    out,
+    Ok(ScannerOutcome::ReKeyed),
+    "the regime installed now is not the one the capture saw, and no rollback in between may hand \
+     its name back out"
+  );
+}
+
+/// Interior mutability is a legal [`State`], and there is no public path to the live one.
+///
+/// [`State`] is bounded `Debug + Clone`, so a `Cell<Mode>` a grammar flips to change how the region
+/// ahead lexes is a perfectly valid one. Handed a `&L::State`, safe code could flip it at the same
+/// offset with no writer involved and no id moving, and the reading would answer
+/// [`ScannerOutcome::Stalled`] — *repeating reproduces the trip* — over an input where repeating
+/// now succeeds.
+///
+/// [`InputRef::state`] returns an **owned clone**, so the flip lands on the caller's copy and the
+/// live regime is untouched: the parse really does repeat, and `Stalled` really is right. The cell
+/// measures both halves — that the clone is independent, and that the reading is unmoved by writing
+/// through it.
+///
+/// [`State`]: tokora::state::State
+/// [`InputRef::state`]: tokora::InputRef::state
+/// [`ScannerOutcome::Stalled`]: tokora::input::ScannerOutcome::Stalled
+#[test]
+fn a_cell_flipped_through_the_state_accessor_cannot_reach_the_live_regime() {
+  fn probe<'inp, Ctx>(
+    inp: &mut InputRef<'inp, '_, MLexer<'inp>, Ctx>,
+  ) -> Result<(bool, ScannerOutcome), SErr>
+  where
+    Ctx: ParseContext<'inp, MLexer<'inp>>,
+    Ctx::Emitter: Emitter<'inp, MLexer<'inp>, Error = SErr>,
+  {
+    for _ in 0..S_TIGHT {
+      let _ = inp.try_expect_or_stop(|_| true)?;
+    }
+    let attempt = inp.scanner_attempt();
+    let _ = inp.try_attempt(|inp| {
+      let _ = inp.try_expect_or_stop(|_| true);
+      Err::<(), SErr>(SErr::Ordinary)
+    });
+    // The flip a grammar would make to change how the region ahead lexes — through the read
+    // accessor, with no `state_mut` and no `set_state`.
+    inp.state().mode.set(Mode::Wide);
+    // Did it reach the live regime?
+    let reached = inp.state().mode.get() == Mode::Wide;
+    Ok((reached, inp.scanner_outcome(attempt)))
+  }
+
+  let ctx: ParserContext<'_, MLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+  let out = Parser::with_parser_and_context(probe, ctx)
+    .parse_str_with_state(S_SRC, ModeLimiter::with_limitation(S_TIGHT));
+  assert_eq!(
+    out,
+    Ok((false, ScannerOutcome::Stalled)),
+    "the accessor handed back a clone, so the flip never reached the live regime — and the reading \
+     is right that a repeat reproduces the trip, because nothing about the scan's three inputs \
+     moved"
   );
 }

--- a/tokora/tests/root_loop_trip_witness.rs
+++ b/tokora/tests/root_loop_trip_witness.rs
@@ -87,6 +87,20 @@
 //! document — the row a monotone counter answers wrongly, and the reason the counter pair is not
 //! what was published.
 //!
+//! # Where the reading survives a rollback, and where it does not — section 5
+//!
+//! `at_scanner_stop` reads what is on record at the committed cursor, and a speculative wrapper —
+//! `try_attempt`, `attempt_parse`, a rollback-on-drop `Transaction` — restores a checkpoint that
+//! **predates** the trip: `None` boundary, original cursor, original lexer state. Section 5 drives
+//! all three, and its point is that the resulting `false` is not one answer to grade. It reads
+//! right or wrong according to where the scanner bound lives, and the three rows differ in nothing
+//! else: a tally the state only points at is still spent (wrong), the crate's own `TokenLimiter`
+//! held by value is refunded by the very same restore (right), and a `TokenBudget` on the input is
+//! untouched by it (right, on both sides). The first two need opposite answers after the same
+//! restore, which is why nothing carried across it can serve both — and the last cell measures
+//! what reading it on the wrong side costs: a loop that files a report per turn and never advances
+//! the cursor at all.
+//!
 //! [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
 //! [`InputRef::try_expect_or_stop`]: tokora::InputRef::try_expect_or_stop
 
@@ -102,7 +116,12 @@ use tokora::{
   input::TokenBudget,
   lexer::LogosLexer,
   logos::{self, Logos},
-  state::{State, recursion_tracker::RecursionLimiter},
+  state::{
+    State,
+    recursion_tracker::RecursionLimiter,
+    token_tracker::{TokenLimitExceeded, TokenLimiter},
+  },
+  try_parse_input::ParseAttempt,
 };
 
 use common::{TestLexer, Token};
@@ -1260,5 +1279,440 @@ fn the_descent_witness_holds_under_a_rejecting_emitter() {
     reports(),
     0,
     "nothing is filed, so one refusal is one diagnostic"
+  );
+}
+
+// ── Section 5: a rollback erases the record, and where the bound lives decides ──
+
+/// The lexer whose scanner bound is the crate's **own shipped** [`TokenLimiter`], held by value
+/// in the state — the placement that type documents.
+///
+/// [`SLexer`]'s limiter is the other shape: an `Rc<Cell<_>>` the state only *points* at, so the
+/// tally is reachable from every clone and no restore returns it. The two lexers are identical in
+/// every other respect, which is what makes the pair below a measurement of the placement alone.
+///
+/// [`TokenLimiter`]: tokora::state::token_tracker::TokenLimiter
+#[derive(Debug, Clone, PartialEq, Logos)]
+#[logos(crate = logos, extras = TokenLimiter, skip r"[ \t\r\n]+")]
+enum CTok {
+  #[regex(r"[0-9]+", |lex| { lex.extras.increase(); lex.slice().parse::<i64>().unwrap_or(0) })]
+  Num(i64),
+}
+
+impl core::fmt::Display for CTok {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    core::fmt::Display::fmt(&self.kind(), f)
+  }
+}
+
+impl From<TokenLimitExceeded> for SErr {
+  fn from(_: TokenLimitExceeded) -> Self {
+    SErr::Limit
+  }
+}
+
+impl TokenTrait<'_> for CTok {
+  type Kind = SKind;
+  type Error = SErr;
+
+  const SCAN_LOOKAHEAD: tokora::ScanLookahead = tokora::ScanLookahead::Unbounded;
+
+  fn kind(&self) -> SKind {
+    SKind::Num
+  }
+
+  fn is_trivia(&self) -> bool {
+    false
+  }
+}
+
+type CLexer<'a> = LogosLexer<'a, CTok>;
+
+thread_local! {
+  /// [`InputRef::at_scanner_stop`] read **where the failure was produced** — inside the
+  /// speculative wrapper, before it decides.
+  ///
+  /// A thread-local rather than a return value because the reading has to be taken from inside a
+  /// closure whose error type is the grammar's, and the whole point of section 4 is that the
+  /// grammar's error type carries nothing.
+  ///
+  /// [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
+  static INSIDE: Cell<bool> = const { Cell::new(false) };
+}
+
+fn note_inside(reading: bool) {
+  INSIDE.with(|c| c.set(reading));
+}
+
+fn inside() -> bool {
+  INSIDE.with(Cell::get)
+}
+
+/// What the input answers **for itself** on the far side of the rollback — the control that says
+/// whether the reading beside it was right or wrong.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NextAnswer {
+  /// A scan from the restored state yielded a token: the stop really is gone.
+  Token,
+  /// A genuine end of input.
+  EndOfInput,
+  /// The scan tripped again: the stop is still in force.
+  Stopped,
+}
+
+/// The three readings a speculative wrapper's rollback is judged by.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AcrossRollback {
+  /// `at_scanner_stop()` inside the wrapper, at the failure.
+  inside: bool,
+  /// `at_scanner_stop()` after the wrapper restored its pre-trip checkpoint.
+  after: bool,
+  /// What the input's own next call answers from that restored state.
+  next: NextAnswer,
+}
+
+/// Consumes until the scanner stops, recording the verdict **where the failure is produced**.
+fn drain_recording<'inp, L, Ctx>(inp: &mut InputRef<'inp, '_, L, Ctx>) -> Result<(), SErr>
+where
+  L: tokora::Lexer<'inp>,
+  Ctx: ParseContext<'inp, L>,
+  Ctx::Emitter: Emitter<'inp, L, Error = SErr>,
+{
+  loop {
+    match inp.try_expect_or_stop(|_| true) {
+      Ok(Some(_)) => {}
+      Ok(None) => return Ok(()),
+      Err(e) => {
+        note_inside(inp.at_scanner_stop());
+        return Err(e);
+      }
+    }
+  }
+}
+
+/// The reading after the wrapper has restored, beside what the input itself does next.
+fn after_rollback<'inp, L, Ctx>(inp: &mut InputRef<'inp, '_, L, Ctx>) -> AcrossRollback
+where
+  L: tokora::Lexer<'inp>,
+  Ctx: ParseContext<'inp, L>,
+  Ctx::Emitter: Emitter<'inp, L, Error = SErr>,
+{
+  let after = inp.at_scanner_stop();
+  let next = match inp.try_expect_or_stop(|_| true) {
+    Ok(Some(_)) => NextAnswer::Token,
+    Ok(None) => NextAnswer::EndOfInput,
+    Err(_) => NextAnswer::Stopped,
+  };
+  AcrossRollback {
+    inside: inside(),
+    after,
+    next,
+  }
+}
+
+/// The three public wrappers the finding names, driven identically.
+macro_rules! probe_bodies {
+  ($lexer:ident, $try_attempt:ident, $attempt_parse:ident, $transaction:ident) => {
+    /// `try_attempt`: the closure's `Err` rolls back and then propagates.
+    fn $try_attempt<'inp, Ctx>(
+      inp: &mut InputRef<'inp, '_, $lexer<'inp>, Ctx>,
+    ) -> Result<AcrossRollback, SErr>
+    where
+      Ctx: ParseContext<'inp, $lexer<'inp>>,
+      Ctx::Emitter: Emitter<'inp, $lexer<'inp>, Error = SErr>,
+    {
+      note_inside(false);
+      let _ = inp.try_attempt(drain_recording);
+      Ok(after_rollback(inp))
+    }
+
+    /// `attempt_parse`: the same rollback, reached through the three-way vocabulary.
+    fn $attempt_parse<'inp, Ctx>(
+      inp: &mut InputRef<'inp, '_, $lexer<'inp>, Ctx>,
+    ) -> Result<AcrossRollback, SErr>
+    where
+      Ctx: ParseContext<'inp, $lexer<'inp>>,
+      Ctx::Emitter: Emitter<'inp, $lexer<'inp>, Error = SErr>,
+    {
+      note_inside(false);
+      let _ = inp.attempt_parse(|inp| drain_recording(inp).map(ParseAttempt::Accept));
+      Ok(after_rollback(inp))
+    }
+
+    /// A rollback-on-drop [`Transaction`]: no verb at all, just the guard going out of scope.
+    ///
+    /// [`Transaction`]: tokora::input::Transaction
+    fn $transaction<'inp, Ctx>(
+      inp: &mut InputRef<'inp, '_, $lexer<'inp>, Ctx>,
+    ) -> Result<AcrossRollback, SErr>
+    where
+      Ctx: ParseContext<'inp, $lexer<'inp>>,
+      Ctx::Emitter: Emitter<'inp, $lexer<'inp>, Error = SErr>,
+    {
+      note_inside(false);
+      {
+        let mut txn = inp.begin();
+        let _ = drain_recording(&mut txn);
+      }
+      Ok(after_rollback(inp))
+    }
+  };
+}
+
+probe_bodies!(SLexer, s_try_attempt, s_attempt_parse, s_transaction);
+probe_bodies!(CLexer, c_try_attempt, c_attempt_parse, c_transaction);
+
+/// Section 5's driver for the **state-side** bound whose tally is shared out of band.
+macro_rules! shared_state_bound {
+  ($probe:ident) => {{
+    let limiter = ScanLimiter::with_limit(S_TIGHT);
+    let scanned = limiter.counter();
+    let ctx: ParserContext<'_, SLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+    let out = Parser::with_parser_and_context($probe, ctx).parse_str_with_state(S_SRC, limiter);
+    (out, scanned.get())
+  }};
+}
+
+/// The same bound, held **by value** in the state — the crate's own [`TokenLimiter`].
+///
+/// [`TokenLimiter`]: tokora::state::token_tracker::TokenLimiter
+macro_rules! by_value_state_bound {
+  ($probe:ident) => {{
+    let ctx: ParserContext<'_, CLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+    Parser::with_parser_and_context($probe, ctx)
+      .parse_str_with_state(S_SRC, TokenLimiter::with_limitation(S_TIGHT))
+  }};
+}
+
+/// The bound on the **input** — [`TokenBudget`] — with the lexer's own limit out of reach.
+///
+/// [`TokenBudget`]: tokora::input::TokenBudget
+macro_rules! input_bound {
+  ($probe:ident) => {{
+    let ctx: ParserContext<'_, SLexer<'_>, Fatal<SErr>> = ParserContext::new(Fatal::new());
+    let ctx = ctx.with_token_budget(TokenBudget::with_limitation(S_TIGHT));
+    Parser::with_parser_and_context($probe, ctx)
+      .parse_str_with_state(S_SRC, ScanLimiter::with_limit(S_ROOMY))
+  }};
+}
+
+/// A rollback erases the **record** of a scanner stop, so
+/// [`InputRef::at_scanner_stop`] reads clean on its far side — through all three public
+/// speculative wrappers.
+///
+/// The wrapper restores the checkpoint it saved *before* the trip: `None` boundary, original
+/// cursor, original state. The reading is a reading of what is on record at the committed cursor,
+/// and after that restore there is no record and the cursor is not at the frontier. So it answers
+/// `false`, where the identical loop **without** the wrapper answers `true` — measured in
+/// [`a_rejecting_emitter_hands_the_root_loop_an_unmarked_scanner_stop`].
+///
+/// `inside` is the same reading taken where the failure is produced, before the wrapper decides.
+/// It is `true` in every row, which is the whole of the contract's answer: the record exists, and
+/// it exists until the rollback discards it along with everything else the attempt did.
+///
+/// [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
+#[test]
+fn every_speculative_wrapper_restores_a_checkpoint_that_predates_the_trip() {
+  for (name, (out, scanned)) in [
+    ("try_attempt", shared_state_bound!(s_try_attempt)),
+    ("attempt_parse", shared_state_bound!(s_attempt_parse)),
+    ("transaction drop", shared_state_bound!(s_transaction)),
+  ] {
+    assert!(
+      scanned > S_TIGHT,
+      "{name}: the fixture must actually trip the scan budget: scanned {scanned}, limit {S_TIGHT}"
+    );
+    assert_eq!(
+      out,
+      Ok(AcrossRollback {
+        inside: true,
+        after: false,
+        next: NextAnswer::Stopped,
+      }),
+      "{name}: the stop is on record where the failure is produced, gone on the far side of the \
+       rollback, and STILL IN FORCE — the input's own next call trips again over a tally no \
+       restore returned"
+    );
+  }
+}
+
+/// The row above is a false negative **because of where that bound lives**, and this is the
+/// control that says so: the crate's own [`TokenLimiter`], held by value in the state, makes the
+/// identical `false` the **right** answer.
+///
+/// `TokenLimiter` documents it outright — *"a rollback reinstalls the state a checkpoint saved, so
+/// the baseline becomes that saved count and everything spent after it is given back"*, and *"an
+/// abandoned speculation's tokens are not in it, so a refund is the correct answer"*. The refund
+/// is what the third column reads: a scan from the restored state yields a token, so no stop is in
+/// force and `at_scanner_stop` saying so is correct.
+///
+/// The two rows differ in nothing but the tally's placement, and they need **opposite** answers
+/// after the same rollback. That is what no carrier riding the rollback can supply: the fact that
+/// separates them lives in `L::State`, which is precisely the thing a checkpoint restores.
+///
+/// [`TokenLimiter`]: tokora::state::token_tracker::TokenLimiter
+#[test]
+fn a_by_value_state_bound_makes_the_same_false_the_right_answer() {
+  for (name, out) in [
+    ("try_attempt", by_value_state_bound!(c_try_attempt)),
+    ("attempt_parse", by_value_state_bound!(c_attempt_parse)),
+    ("transaction drop", by_value_state_bound!(c_transaction)),
+  ] {
+    assert_eq!(
+      out,
+      Ok(AcrossRollback {
+        inside: true,
+        after: false,
+        next: NextAnswer::Token,
+      }),
+      "{name}: the rollback refunded the tally — which `TokenLimiter` documents as the correct \
+       answer — so the stop really is gone and reading `false` is right"
+    );
+  }
+}
+
+/// And the bound the crate ships for *work performed* — [`TokenBudget`], on the input — survives
+/// every one of the three rollbacks, so the reading survives with it.
+///
+/// No `Checkpoint` carries the input's tally, no re-key touches it and no mutator lowers it. That
+/// is not a property a witness had to be given: it is the placement, and
+/// [`InputRef::at_scanner_stop`] already reads it. A consumer that speculates over a scanner bound
+/// gets a rollback-proof verdict by putting the bound here — which is the same sentence
+/// `TokenLimiter`'s own documentation ends on.
+///
+/// [`TokenBudget`]: tokora::input::TokenBudget
+/// [`InputRef::at_scanner_stop`]: tokora::InputRef::at_scanner_stop
+#[test]
+fn an_input_side_bound_outlives_every_one_of_the_three_rollbacks() {
+  for (name, out) in [
+    ("try_attempt", input_bound!(s_try_attempt)),
+    ("attempt_parse", input_bound!(s_attempt_parse)),
+    ("transaction drop", input_bound!(s_transaction)),
+  ] {
+    assert_eq!(
+      out,
+      Ok(AcrossRollback {
+        inside: true,
+        after: true,
+        next: NextAnswer::Stopped,
+      }),
+      "{name}: the refusal is recorded on the input's own tally, which no rollback reaches, so \
+       the verdict is the same on both sides of the restore"
+    );
+  }
+}
+
+/// The root loop of section 4 with its element **speculating**, and the amplification that opens
+/// when the verdict is read on the wrong side of the rollback.
+///
+/// `read_inside` is the whole variable. Reading where the failure is produced ends the document at
+/// the stop; reading after the wrapper has restored reads clean, so the loop files the failure as
+/// an ordinary syntax error, re-keys, and retries — from a state identical to the one it just
+/// failed in. There is **no progress at all**: the element consumes nothing, so the loop neither
+/// advances nor terminates, and only [`S_REPORT_CAP`] stops the fixture.
+///
+/// That is strictly worse than section 4's unwrapped loop, which files one report per *remaining
+/// token* and does end. It is also the case section 4's named residue did not cover: the residue's
+/// bound was "the region behind the frontier is replayable, so the loop makes real progress and
+/// re-reaches the stop", and a wrapper that rolls back keeps none of what it replayed.
+fn s_root_speculating<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
+  read_inside: bool,
+) -> Result<usize, SErr>
+where
+  Ctx: ParseContext<'inp, SLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
+{
+  let mut parsed = 0usize;
+  loop {
+    let mut stopped = false;
+    let element = inp.try_attempt(|inp| match inp.try_expect_or_stop(|_| true) {
+      Ok(Some(_)) => Ok(true),
+      Ok(None) => Ok(false),
+      Err(e) => {
+        stopped = inp.at_scanner_stop();
+        Err(e)
+      }
+    });
+    match element {
+      Ok(true) => parsed += 1,
+      Ok(false) => return Ok(parsed),
+      Err(e) => {
+        let verdict = if read_inside {
+          stopped
+        } else {
+          inp.at_scanner_stop()
+        };
+        if e.is_terminal() || verdict {
+          return Err(e);
+        }
+        note_report();
+        if reports() >= S_REPORT_CAP {
+          return Ok(parsed);
+        }
+        inp.state_mut();
+      }
+    }
+  }
+}
+
+fn s_root_speculating_inside<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
+) -> Result<usize, SErr>
+where
+  Ctx: ParseContext<'inp, SLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
+{
+  s_root_speculating(inp, true)
+}
+
+fn s_root_speculating_after<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, SLexer<'inp>, Ctx>,
+) -> Result<usize, SErr>
+where
+  Ctx: ParseContext<'inp, SLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, SLexer<'inp>, Error = SErr>,
+{
+  s_root_speculating(inp, false)
+}
+
+/// Reading the verdict on the far side of a rollback costs the loop its termination; reading it
+/// where the failure is produced does not.
+///
+/// The pair is the measurement, and the placement is its only variable — same loop, same wrapper,
+/// same source, same budget.
+#[test]
+fn the_verdict_read_after_the_rollback_leaves_the_loop_without_progress() {
+  reset();
+  let (after, scanned) = shared_state_bound!(s_root_speculating_after);
+  assert!(
+    scanned > S_TIGHT,
+    "the fixture must actually trip: scanned {scanned}, limit {S_TIGHT}"
+  );
+  assert_eq!(
+    reports(),
+    S_REPORT_CAP,
+    "the loop never stops on its own: every turn rolls back to the state the last one failed in, \
+     so only the fixture's brake ends it. Verdict was {after:?}"
+  );
+  assert_eq!(
+    after,
+    Ok(S_TIGHT),
+    "and it has parsed exactly what the pre-trip prefix holds — no turn after the first stop \
+     advanced the cursor by a single token"
+  );
+
+  reset();
+  let (inside, scanned) = shared_state_bound!(s_root_speculating_inside);
+  assert!(scanned > S_TIGHT, "the inside-read run must trip too");
+  assert_eq!(
+    inside,
+    Err(SErr::Limit),
+    "read where the failure is produced, the same loop ends the document at the stop"
+  );
+  assert_eq!(
+    reports(),
+    0,
+    "one stop is one stop: nothing was filed as an ordinary syntax error"
   );
 }


### PR DESCRIPTION
Closes #311.