### PR TITLE
fix: two types that assume a property they do not enforce — a recovery state with nowhere to live, and a ring's contiguity with nothing to keep it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,8 +101,29 @@ and will red until they do.
   fields of its own owes a status field. The trait's own diagnostics example used to demonstrate
   the sentinel comparison and now reads the state.
 
-  **`is_valid`, `is_error` and `is_missing` are on `RecoveryState`, not on the carriers**, and
-  that is the point rather than a detail. Those three names are ones a downstream crate may
+  **`Ident` keeps its three inherent predicates; the other eighteen carriers answer only through
+  the trait.** That asymmetry is a rule applied to two histories rather than an oversight, and the
+  rule is written beside the methods in `ident.rs`:
+
+  > Do not change resolution for a name that already shipped; do not create a new resolution
+  > hazard for a name that did not.
+
+  `Ident::is_valid` has been inherent since #266, and an inherent method **wins** the pick over an
+  extension trait's — so a downstream crate with its own `is_valid` for `Ident` has been getting
+  tokora's answer. Removing the inherent one does not merely cost them an import: the call still
+  compiles, with no ambiguity, and silently falls through to theirs. It falls the dangerous way,
+  too, since a check that merely accepts a non-empty payload reads `Ident::error(span)`'s
+  `"<error>"` as valid syntax. A draft of this release did remove them, on the argument that the
+  declared channel should not have two spellings; that argument is about how the surface reads,
+  and this one is about existing code changing meaning with nothing to catch it. They are not the
+  same weight.
+
+  **`is_valid`, `is_error` and `is_missing` are on `RecoveryState` for the other eighteen**, which
+  never had the names, and that is the point rather than a detail.
+
+  `IdentList` keeps its three as inherent methods and does **not** implement the trait. They are
+  not the same question either: a list is an aggregate, and `is_error` and `is_missing` can both
+  be true of one at once, which no single `Status` can say. Those three names are ones a downstream crate may
   already have on an extension trait of its own — "this literal's payload parses as a number" —
   and Rust prefers an inherent method over a trait's at an unqualified call site. Shipping them
   inherent would have left `literal.is_valid()` compiling and quietly answering a different
@@ -909,28 +930,6 @@ and will red until they do.
   hashing no longer need anything of it. Four of the six bounds dropped, structural matching
   unchanged — strictly better than 0.9 on every axis, which is why this is not a choice between
   two breaks.
-
-- **`Ident::{is_valid, is_error, is_missing}` move to the `RecoveryState` trait** (#320). They have
-  been inherent `const fn`s since #266. Keeping them there while the other eighteen carriers
-  answered through a trait would have reintroduced exactly the `Ident`-versus-the-rest drift the
-  shared `Status` exists to prevent: the declared semantic channel would have had two spellings,
-  and which one a reader needs would depend on which carrier they held.
-
-  Migration is `use tokora::types::RecoveryState;`, and rustc names it — an unimported trait method
-  is `error[E0599]` with *"items from traits can only be used if the trait is in scope"*. In a
-  const context, where a trait method cannot go at all, it is `ident.status().is_valid()`.
-
-  Two arguments were weighed and rejected. Leaving `Ident` inherent is safe for the upgrade but is
-  the drift above. Deprecated inherent forwarders keep both properties, at the cost of warning on
-  call sites that are not wrong yet and of leaving `Ident` — alone among the nineteen — able to
-  displace a consumer's extension trait for another release. The break is taken instead, in a
-  cycle that is already breaking, because it is loud, mechanical, and prospective: it also means a
-  consumer who adds an `is_valid` of their own *after* upgrading gets ambiguity rather than
-  silence.
-
-  `IdentList` keeps its three as inherent methods and does **not** implement the trait. They are
-  not the same question: a list is an aggregate, and `is_error` and `is_missing` can both be true
-  of one at once, which no single `Status` can say.
 
 - **The recovery carriers stop demanding traits of their language marker** (#320). `Ident`,
   `Keyword`, the seventeen `Lit*` types and `IdentList` derived `Debug`, `Copy`, `Clone`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ and will red until they do.
   `Status` is `#[non_exhaustive]`: a fourth recovery state is admissible later, so a `match` needs
   a wildcard arm and `is_valid()` is deliberately not `!is_error() && !is_missing()`.
 
-- **`types::RecoveryState`, and a `const fn status` on all nineteen recovery carriers**
+- **`types::recovery::RecoveryState` and `types::Status`, over all nineteen recovery carriers**
   (#301). `Keyword` and the seventeen literal carriers implemented `ErrorNode` — so
   `error(span)` and `missing(span)` were public and documented as recovery placeholders — while
   holding no field that could record which of the three states a value was in. The only way to
@@ -872,6 +872,43 @@ and will red until they do.
   `UnclosedEmitter` beside a converting sibling forces `ComposableEmitter` to include one of them:
   the converting one fails `Silent` verbatim, and the bound-free one stops covering the delimited
   driver the bundle exists for.
+
+- **`RecoveryState` lives in `tokora::types::recovery` and is not re-exported into
+  `tokora::types`** (#320). A trait reached through a glob can be rebound by a second glob without
+  an error. Reproduced against `rustc 1.100.0-nightly`, three arrangements behave differently:
+  two globs offering the same **type** name is `error[E0659]`; two globs offering the same method
+  through **differently named** traits is `error[E0034]`; but two globs offering the same **trait
+  name** *compiles*, warns under the warn-by-default `ambiguous_glob_imported_traits`
+  (rust-lang/rust#152822), and resolves to whichever glob was written **first** — so
+  `use tokora::types::*; use their_crate::*;` could silently rebind a consumer's own `is_valid`,
+  in either direction depending on import order.
+
+  Moving the three questions off inherent methods closed that rebind at the type and reopened it
+  at the re-export; naming the module closes it for good. A consumer's glob-imported trait is now
+  unopposed, and one who wants tokora's writes `use tokora::types::recovery::RecoveryState;` —
+  an explicit import, which beats a glob and is a choice rather than an accident.
+
+  **`Status` stays at `tokora::types::Status`**, because a type name collides loudly; it is also
+  available as `types::recovery::Status`. The cost to a consumer who is not colliding with
+  anything is one import line, and only for the trait.
+
+- **The recovery carriers keep `PartialEq`/`Eq` derived, and only the other four are hand-written**
+  (#320). Replacing all six derives dropped the compiler-generated `StructuralPartialEq`, so a
+  `const` of a carrier could no longer appear in a `match` pattern — *"constant of non-structural
+  type"*. That was an unannounced break against 0.9, and it slipped through because the change was
+  verified by **rendering**: `Debug`'s field order, `PartialEq`'s short-circuit order, `Hash`'s
+  bytes. Structural matching is not observable that way; only using a value in a pattern shows it.
+
+  Both properties cannot be had at once, and the split is where the evidence put it. Keeping
+  `PartialEq`/`Eq` derived restores structural matching **only when the marker itself satisfies
+  them**, because a derive still constrains every parameter — verified, not assumed: with the
+  derive restored and a marker carrying no traits at all, the pattern is still rejected.
+
+  So the **residual cost** is stated: comparing or pattern-matching a carrier still needs its
+  language marker to be `PartialEq + Eq`, exactly as 0.9 required. Printing, cloning, copying and
+  hashing no longer need anything of it. Four of the six bounds dropped, structural matching
+  unchanged — strictly better than 0.9 on every axis, which is why this is not a choice between
+  two breaks.
 
 - **`Ident::{is_valid, is_error, is_missing}` move to the `RecoveryState` trait** (#320). They have
   been inherent `const fn`s since #266. Keeping them there while the other eighteen carriers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,11 +112,25 @@ and will red until they do.
   was justified below by exactly this standard — that a change of meaning must not be silent —
   and these methods are the case it would otherwise have excluded.
 
-  `status` stays **inherent** because a trait method cannot be `const fn`:
-  `x.status().is_valid()` is const all the way down, which `x.is_valid()` through a trait can
-  never be. It can win a pick, but not silently — it returns `Status`, a type that did not exist
-  before, so displacing a consumer's own `status()` is a type error rather than a different
-  answer.
+  **`status` is on the trait too, and there is no inherent accessor of any name.** It was briefly
+  inherent, kept there to stay `const fn`, on the reasoning that a return type which did not exist
+  before could not be displaced silently. That reasoning is wrong, and the counterexample is one
+  line: `literal.status().is_valid()` typechecks either way, because `Status` offers `is_valid`
+  too — a differing return type is only loud if the caller *stores* the value. Since `new` marks
+  any caller-supplied payload `Valid`, a literal the consumer's own check would have rejected then
+  passes.
+
+  So the test a name has to survive is not *does the signature differ* but **does the whole call
+  chain still typecheck with a different meaning**, and an inherent accessor of any name fails it
+  whenever the two returned types share a method.
+
+  **The cost is that the recovery state is not readable in a const context**, by any spelling,
+  because a trait method cannot be `const`. Nothing in this crate read it in one, and a parse
+  result is not const-constructible in practice. Two ways to keep it were available and both are
+  worse: a `pub` field is a public *setter*, and `x.status = Status::Valid` would launder a
+  placeholder into valid syntax by assignment — the whole defect this type closes; a receiver-less
+  associated function escapes method syntax but is still displaced in path position, trading a
+  certainty for an improbability, and resting on the class of reasoning that was just wrong.
 
 - **`cst::TreeCheckpoint` — the builder's own checkpoint, carrying the one number `rowan`'s does
   not** (#316). Returned by `SyntaxTreeBuilder::checkpoint` and spent by `start_node_at`; it wraps
@@ -2459,22 +2473,26 @@ and will red until they do.
 
 ### Source-breaking additions that can change behaviour with *no diagnostic at the call site*
 
-**`status` and `with_status` are new inherent names on all nineteen recovery carriers, and
-`Status` and `RecoveryState` are new public names in `tokora::types`** (#320). Both methods can
-win the pick over a consumer's extension item, and **neither can do so silently**: each mentions
-`Status` in its signature — as the return type and as the third parameter — and that type did not
-exist before this release, so no item a consumer already wrote can have the same one. Displacing
-either is a type error at the call site, not a different answer. The fix is UFCS,
-`MyExt::status(&kw)`. The two new type names are a glob exposure: a consumer with
+**`with_status` is a new inherent associated function on all nineteen recovery carriers, and
+`Status` and `RecoveryState` are new public names in `tokora::types`** (#320). `with_status` can
+win the pick over a consumer's extension item and **cannot do so silently** — not because its
+signature differs, which is not sufficient, but because its third parameter is a `Status`, a type
+no code written before this release can produce a value of. Arguments are checked at the call
+rather than chained past, so displacing a consumer's `with_status` is `error[E0308]` there. It is
+also unreachable by method-call syntax, taking no `self`. The fix is UFCS,
+`MyExt::with_status(..)`. The two new type names are a glob exposure: a consumer with
 `use tokora::types::*;` and a `Status` or `RecoveryState` of their own gets an ambiguity at the
 name, resolved by an explicit import or an `as` alias.
 
-*An earlier draft of this release listed `is_valid`, `is_error` and `is_missing` here as new
-inherent methods on `Keyword` and the seventeen `Lit*` types, with UFCS offered as the fix. That
-entry is withdrawn: those three are on `RecoveryState` and were never shipped inherent. A note in
-this section is the right home for a name that fails loudly and the wrong one for a name that
-rebinds in silence, which is what a `&self` predicate returning `bool` does — the review of #320
-made that argument and it is correct.*
+*Two earlier drafts of this release listed more names here, and both are withdrawn.* The first
+listed `is_valid`, `is_error` and `is_missing` as new inherent methods on `Keyword` and the
+seventeen `Lit*` types, offering UFCS as the fix; they are on `RecoveryState` and were never
+shipped inherent. The second listed `status` beside `with_status` on the argument that a new
+return type makes a clash loud; that argument is false, since `literal.status().is_valid()`
+typechecks whichever `status` wins, and there is now no inherent `status` at all. **A note in this
+section is the right home for a name that fails loudly and the wrong one for a name that rebinds
+in silence** — and the test for which is whether the whole call chain still typechecks with a
+different meaning, not whether the signature differs.
 
 **`InputRef::trip_snapshot` and `InputRef::tripped_during_attempt` are new inherent methods on a
 type that already shipped.** An inherent item wins the pick over an extension trait's, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -940,11 +940,18 @@ and will red until they do.
   **no kind is loud on both axes.**
 
   **The placement is not derived from that table.** A draft read it as a budget and chose by
-  counting collidable names; that was the wrong criterion. This release's concern is a *silent
-  semantic change* — code that keeps compiling and means something different, with nothing to tell
-  the consumer. A glob-import name clash is not that: a glob is the consumer's own choice, the
-  clash is its ordinary cost, and it is paid at compile time with a leading `::` as the fix. It is
-  also a rule nothing could follow, since it would mean no public module could ever be added.
+  counting collidable names; that was the wrong criterion. The line this release is drawn on is:
+  **tokora must not silently change what a method on a tokora type means, while a name a consumer's
+  own glob shadows is that glob's cost and `::` is its fix.**
+
+  Those are two axes. `literal.is_valid()` on a `Lit*`, `Ident` or `Keyword` is the first — the
+  consumer holds tokora's type, calls what they believe is their own check, and gets tokora's
+  answer — and every carrier repair in this release is that class. `Status` in `types::*` and the
+  `recovery` module are the second: a path into the consumer's own namespace shadowed by a glob
+  they wrote, in code unrelated to tokora's carriers, with `::` as the remedy in both cases. Note
+  that *loud versus silent* does not sort them — the module clashes loudly and `Status` can clash
+  quietly — which is why the deciding property is whose type the call is on. It is also a rule
+  nothing could follow: no public module or vocabulary type could ever be added again.
 
   **The module keeps the name `recovery`, and the check behind that is dated rather than argued.**
   Against the crates.io API on 2026-08-27: `recovery` 0.1.6, ~16.1k downloads, last updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ and will red until they do.
 
 ### Added
 
-- **`types::recovery::Status`, and `with_status` on all nineteen recovery carriers** (#320). The recovery
+- **`types::Status`, and `with_status` on all nineteen recovery carriers** (#320). The recovery
   state stops being a private field and becomes a value a consumer can hold: it is returned by
   `IntoComponents` (see **Changed (breaking)**) and accepted back by
   `Ident::with_status`, `Keyword::with_status` and each `Lit*::with_status`, which are the inverses
@@ -917,13 +917,14 @@ and will red until they do.
   the converting one fails `Silent` verbatim, and the bound-free one stops covering the delimited
   driver the bundle exists for.
 
-- **The whole recovery API lives in `tokora::types::recovery` and nothing from it is re-exported
-  into `tokora::types`** (#320). Reaching it is
-  `use tokora::types::recovery::{Components, FromComponents, RecoveryState, Status};`.
+- **`RecoveryState`, `FromComponents` and `Components` live in `tokora::types::recovery` and are
+  reached by naming it; `Status` is also re-exported as `tokora::types::Status`** (#320). A glob of
+  `tokora::types::*` therefore gets the status type, and the traits are one import away:
+  `use tokora::types::recovery::{RecoveryState, FromComponents, Components};`.
 
-  Every placement puts *some* new name into a namespace a consumer can already glob, and the kinds
-  do not resolve alike. Measured against `rustc 1.100.0-nightly`, consumer source held fixed, the
-  library gaining one item, **and both sides exposing the item the consumer reaches for**:
+  **A measured table came out of settling this, and it is worth keeping on its own.** With the
+  consumer's source held fixed, the library gaining one item, and — this is the part an earlier
+  attempt got wrong — **both sides exposing the item the consumer reaches for**:
 
   | kind       | vs an extern crate of that name  | vs a second glob            | vs a local def |
   |------------|----------------------------------|-----------------------------|----------------|
@@ -932,26 +933,25 @@ and will red until they do.
   | **trait**  | `E0790`                          | **silent, first glob wins** | local wins     |
   | fn / const | no interaction (value namespace) | `E0659`                     | local wins     |
 
-  Two earlier drafts of this release were built on a wrong row. The first measured `type` against
-  an extern crate as `E0599`, loud, and re-exported `Status` into `types` on that basis. The probe
-  asked the shadowing type for an associated item it did not have, so it could only be loud: with
-  a dependency aliased `Status` exporting `Error`, and tokora's `Status` carrying an `Error`
-  variant with an inherent `is_error()`, `Status::Error.is_error()` compiles on both revisions and
-  **the boolean inverts**. The second draft then moved all four items into `types` to get the
-  module name out of the glob, on that same false premise.
+  The `type` row was first read as `E0599`, loud. That was a probe that could only be loud — it
+  asked the shadowing type for an associated item it did not have. With a dependency aliased
+  `Status` exporting `Error`, and tokora's `Status` carrying an `Error` variant with an inherent
+  `is_error()`, `Status::Error.is_error()` compiles on both revisions and the boolean inverts. So
+  **no kind is loud on both axes.**
 
-  **No kind that can carry this API is loud on both axes**, so the question is not which kind is
-  safe but how few silent names a placement adds. The floor is one — a public trait must live in a
-  module, and every module is either already globbed or a new name in one — and a module reaches
-  it. Re-exporting the four items instead puts four names into `types::*`: `Status` and
-  `Components` silent against an extern crate, `RecoveryState` and `FromComponents` silent against
-  a second glob.
+  **The placement is not derived from that table.** A draft read it as a budget and chose by
+  counting collidable names; that was the wrong criterion. This release's concern is a *silent
+  semantic change* — code that keeps compiling and means something different, with nothing to tell
+  the consumer. A glob-import name clash is not that: a glob is the consumer's own choice, the
+  clash is its ordinary cost, and it is paid at compile time with a leading `::` as the fix. It is
+  also a rule nothing could follow, since it would mean no public module could ever be added.
 
-  **The residual, named as what it is.** A consumer with a dependency named or aliased `recovery`
-  who writes `use tokora::types::*;` has every `recovery::…` path rebound to tokora, with no error
-  and no warning. The only lever left is the module's *name*, and that is **probability, not
-  safety**: no identifier is barred from being a crate alias. It is not pulled, because the gain
-  cannot be quantified and the churn is real.
+  **The module keeps the name `recovery`, and the check behind that is dated rather than argued.**
+  Against the crates.io API on 2026-08-27: `recovery` 0.1.6, ~16.1k downloads, last updated
+  2025-09-14, whose docs instruct `use recovery::Recovery;`. `Recovery` is not one of this module's
+  names, so a consumer of both crates gets `E0432` at their own import line — measured, plus
+  `E0659` where the name is then used — never a redirect. A rename was drafted on the mistake above
+  and withdrawn.
 
 - **The recovery carriers keep `PartialEq`/`Eq` derived, and only the other four are hand-written**
   (#320). Replacing all six derives dropped the compiler-generated `StructuralPartialEq`, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ and will red until they do.
   `Status` is `#[non_exhaustive]`: a fourth recovery state is admissible later, so a `match` needs
   a wildcard arm and `is_valid()` is deliberately not `!is_error() && !is_missing()`.
 
-- **`Keyword::{is_valid, is_error, is_missing}`, and the same three on every `Lit*` type**
+- **`types::RecoveryState`, and a `const fn status` on all nineteen recovery carriers**
   (#301). `Keyword` and the seventeen literal carriers implemented `ErrorNode` — so
   `error(span)` and `missing(span)` were public and documented as recovery placeholders — while
   holding no field that could record which of the three states a value was in. The only way to
@@ -94,13 +94,29 @@ and will red until they do.
   the `"<error>"` / `"<missing>"` sentinel, which is a value a caller can spell by hand and edit
   afterwards through `source_mut` / `data_mut`.
 
-  Each of the eighteen now carries the same private `Status` `Ident` has carried since #266, set
-  by `new` (valid) and by the two `ErrorNode` constructors, and read by these predicates. The
-  rule they are all keeping is stated once, on `ErrorNode` itself, under **Two Shapes of
-  Implementor**: a *payload* type such as `&str` has nowhere to put a state and so its
-  placeholder is a sentinel; a *carrier* type with fields of its own owes a status field. The
-  trait's own diagnostics example used to demonstrate the sentinel comparison and now reads the
-  predicates.
+  Each of the nineteen now carries the same private `Status` `Ident` has carried since #266, set
+  by `new` (valid) and by the two `ErrorNode` constructors. The rule they are all keeping is
+  stated once, on `ErrorNode` itself, under **Two Shapes of Implementor**: a *payload* type such
+  as `&str` has nowhere to put a state and so its placeholder is a sentinel; a *carrier* type with
+  fields of its own owes a status field. The trait's own diagnostics example used to demonstrate
+  the sentinel comparison and now reads the state.
+
+  **`is_valid`, `is_error` and `is_missing` are on `RecoveryState`, not on the carriers**, and
+  that is the point rather than a detail. Those three names are ones a downstream crate may
+  already have on an extension trait of its own — "this literal's payload parses as a number" —
+  and Rust prefers an inherent method over a trait's at an unqualified call site. Shipping them
+  inherent would have left `literal.is_valid()` compiling and quietly answering a different
+  question after an upgrade, with no diagnostic anywhere. On a trait the clash is
+  `error[E0034]: multiple applicable items in scope` naming both candidates, or no change at all
+  for a consumer who does not import ours. Widening `IntoComponents` rather than withdrawing it
+  was justified below by exactly this standard — that a change of meaning must not be silent —
+  and these methods are the case it would otherwise have excluded.
+
+  `status` stays **inherent** because a trait method cannot be `const fn`:
+  `x.status().is_valid()` is const all the way down, which `x.is_valid()` through a trait can
+  never be. It can win a pick, but not silently — it returns `Status`, a type that did not exist
+  before, so displacing a consumer's own `status()` is a type error rather than a different
+  answer.
 
 - **`cst::TreeCheckpoint` — the builder's own checkpoint, carrying the one number `rowan`'s does
   not** (#316). Returned by `SyntaxTreeBuilder::checkpoint` and spent by `start_node_at`; it wraps
@@ -842,6 +858,28 @@ and will red until they do.
   `UnclosedEmitter` beside a converting sibling forces `ComposableEmitter` to include one of them:
   the converting one fails `Silent` verbatim, and the bound-free one stops covering the delimited
   driver the bundle exists for.
+
+- **`Ident::{is_valid, is_error, is_missing}` move to the `RecoveryState` trait** (#320). They have
+  been inherent `const fn`s since #266. Keeping them there while the other eighteen carriers
+  answered through a trait would have reintroduced exactly the `Ident`-versus-the-rest drift the
+  shared `Status` exists to prevent: the declared semantic channel would have had two spellings,
+  and which one a reader needs would depend on which carrier they held.
+
+  Migration is `use tokora::types::RecoveryState;`, and rustc names it — an unimported trait method
+  is `error[E0599]` with *"items from traits can only be used if the trait is in scope"*. In a
+  const context, where a trait method cannot go at all, it is `ident.status().is_valid()`.
+
+  Two arguments were weighed and rejected. Leaving `Ident` inherent is safe for the upgrade but is
+  the drift above. Deprecated inherent forwarders keep both properties, at the cost of warning on
+  call sites that are not wrong yet and of leaving `Ident` — alone among the nineteen — able to
+  displace a consumer's extension trait for another release. The break is taken instead, in a
+  cycle that is already breaking, because it is loud, mechanical, and prospective: it also means a
+  consumer who adds an `is_valid` of their own *after* upgrading gets ambiguity rather than
+  silence.
+
+  `IdentList` keeps its three as inherent methods and does **not** implement the trait. They are
+  not the same question: a list is an aggregate, and `is_error` and `is_missing` can both be true
+  of one at once, which no single `Status` can say.
 
 - **The recovery carriers stop demanding traits of their language marker** (#320). `Ident`,
   `Keyword`, the seventeen `Lit*` types and `IdentList` derived `Debug`, `Copy`, `Clone`,
@@ -2421,19 +2459,22 @@ and will red until they do.
 
 ### Source-breaking additions that can change behaviour with *no diagnostic at the call site*
 
-**`with_status` is a new inherent method on all nineteen recovery carriers, and `Status` is a new
-public name in `tokora::types`** (#320). The same inherent-pick exposure as the predicates below,
-plus a glob exposure: a consumer with `use tokora::types::*;` and a `Status` of their own now has
-an ambiguity at that name. **The fixes are UFCS for the method and an explicit import or alias for
-the name.**
+**`status` and `with_status` are new inherent names on all nineteen recovery carriers, and
+`Status` and `RecoveryState` are new public names in `tokora::types`** (#320). Both methods can
+win the pick over a consumer's extension item, and **neither can do so silently**: each mentions
+`Status` in its signature — as the return type and as the third parameter — and that type did not
+exist before this release, so no item a consumer already wrote can have the same one. Displacing
+either is a type error at the call site, not a different answer. The fix is UFCS,
+`MyExt::status(&kw)`. The two new type names are a glob exposure: a consumer with
+`use tokora::types::*;` and a `Status` or `RecoveryState` of their own gets an ambiguity at the
+name, resolved by an explicit import or an `as` alias.
 
-**`is_valid`, `is_error` and `is_missing` are new inherent methods on `Keyword` and on all
-seventeen `Lit*` types** (#301). An inherent item wins the pick over an extension trait's, so a
-consumer who defined any of those three names on one of these carriers — through a trait of their
-own, taking `&self`, which is the receiver tokora's take — now runs tokora's item at an
-unqualified call site. The names are not incidental: they are the three `Ident` has shipped since
-#266, and the whole point of #301 is that the eighteen carriers answer the same question the same
-way. **The fix is UFCS**, `MyExt::is_error(&kw)`, which pins the item on either revision.
+*An earlier draft of this release listed `is_valid`, `is_error` and `is_missing` here as new
+inherent methods on `Keyword` and the seventeen `Lit*` types, with UFCS offered as the fix. That
+entry is withdrawn: those three are on `RecoveryState` and were never shipped inherent. A note in
+this section is the right home for a name that fails loudly and the wrong one for a name that
+rebinds in silence, which is what a `&self` predicate returning `bool` does — the review of #320
+made that argument and it is correct.*
 
 **`InputRef::trip_snapshot` and `InputRef::tripped_during_attempt` are new inherent methods on a
 type that already shipped.** An inherent item wins the pick over an extension trait's, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -843,6 +843,27 @@ and will red until they do.
   the converting one fails `Silent` verbatim, and the bound-free one stops covering the delimited
   driver the bundle exists for.
 
+- **The recovery carriers stop demanding traits of their language marker** (#320). `Ident`,
+  `Keyword`, the seventeen `Lit*` types and `IdentList` derived `Debug`, `Copy`, `Clone`,
+  `PartialEq`, `Eq` and `Hash`, and a derive constrains **every** type parameter — so each of the
+  six carried a `Lang:` bound that nothing in the body uses, since `PhantomData<T>` implements all
+  six for any `T` unconditionally. `Ident<&str, SimpleSpan, MyLang>` was therefore not printable,
+  copyable, comparable or hashable unless the consumer derived those on the marker too, for a
+  reason that does not exist. `IdentList` demanded it twice over: `S` appears only in
+  `PhantomData<S>` and in the default container type, so `S: Debug` was spurious as well.
+
+  The six are now written out with bounds naming only the parameters the body reads.
+  **Nothing else changes**: `Debug` prints the same fields in declaration order, `PartialEq`
+  short-circuits in the same order, and `Hash` feeds the same bytes, because `PhantomData` hashes
+  nothing. Listed as breaking only because an impl's bounds are part of the surface — every
+  program that compiled before still compiles, and some that did not now do.
+
+  This is filed here rather than as a follow-up because #320's first draft **worked around it in a
+  doctest**, adding `#[derive(Debug, Clone, Copy, PartialEq)]` to a marker to make the example
+  build. Published documentation that teaches a consumer to derive four traits on a marker for a
+  reason that is not real is worse than the bare defect, so the workaround is gone and the example
+  now stands as a consumer would write it — which is also the regression test.
+
 - **`IntoComponents::Components` on all nineteen recovery carriers gains the status:
   `(Span, Payload)` becomes `(Span, Payload, Status)`** (#320). `Ident`, `Keyword` and the
   seventeen `Lit*` types hold a span, a payload and a recovery status, and returned two of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ and will red until they do.
 
 ### Added
 
-- **`types::Status`, and `with_status` on all nineteen recovery carriers** (#320). The recovery
+- **`types::recovery::Status`, and `with_status` on all nineteen recovery carriers** (#320). The recovery
   state stops being a private field and becomes a value a consumer can hold: it is returned by
   `IntoComponents` (see **Changed (breaking)**) and accepted back by
   `Ident::with_status`, `Keyword::with_status` and each `Lit*::with_status`, which are the inverses
@@ -86,7 +86,7 @@ and will red until they do.
   `Status` is `#[non_exhaustive]`: a fourth recovery state is admissible later, so a `match` needs
   a wildcard arm and `is_valid()` is deliberately not `!is_error() && !is_missing()`.
 
-- **`types::FromComponents` — the inverse of `IntoComponents`** (#320).
+- **`types::recovery::FromComponents` — the inverse of `IntoComponents`** (#320).
   `T::from_components(x.into_components())` rebuilds a carrier with its recovery state intact, and
   is the door that closes the laundering: rebuilding through `new` would declare a recovered node
   valid.
@@ -109,7 +109,7 @@ and will red until they do.
   No consumer code depends on the withdrawn spelling: `with_status` is new in this release and
   never shipped, which is why it goes where `Ident`'s predicates came back.
 
-- **`types::RecoveryState` and `types::Status`, over all nineteen recovery carriers**
+- **`types::recovery::{RecoveryState, Status}`, over all nineteen recovery carriers**
   (#301). `Keyword` and the seventeen literal carriers implemented `ErrorNode` — so
   `error(span)` and `missing(span)` were public and documented as recovery placeholders — while
   holding no field that could record which of the three states a value was in. The only way to
@@ -917,53 +917,41 @@ and will red until they do.
   the converting one fails `Silent` verbatim, and the bound-free one stops covering the delimited
   driver the bundle exists for.
 
-- **`RecoveryState`, `FromComponents`, `Status` and `Components` are items of `tokora::types`;
-  there is no `types::recovery` module** (#320). Reaching them is
-  `use tokora::types::{RecoveryState, FromComponents, Status, Components};`.
+- **The whole recovery API lives in `tokora::types::recovery` and nothing from it is re-exported
+  into `tokora::types`** (#320). Reaching it is
+  `use tokora::types::recovery::{Components, FromComponents, RecoveryState, Status};`.
 
-  A draft put them in a `pub mod recovery` so the trait would not be in `types::*`. That put a
-  **module** name there instead, and the kinds do not resolve alike. Measured against
-  `rustc 1.100.0-nightly` over three axes, with the consumer's source fixed and the library
-  gaining one item:
+  Every placement puts *some* new name into a namespace a consumer can already glob, and the kinds
+  do not resolve alike. Measured against `rustc 1.100.0-nightly`, consumer source held fixed, the
+  library gaining one item, **and both sides exposing the item the consumer reaches for**:
 
-  |            | vs an extern crate of that name  | vs a second glob            | vs a local def |
+  | kind       | vs an extern crate of that name  | vs a second glob            | vs a local def |
   |------------|----------------------------------|-----------------------------|----------------|
   | **module** | **silent redirect**              | `E0659`                     | local wins     |
+  | **type**   | **silent redirect**              | `E0659`                     | local wins     |
   | **trait**  | `E0790`                          | **silent, first glob wins** | local wins     |
-  | type       | `E0599`                          | `E0659`                     | local wins     |
   | fn / const | no interaction (value namespace) | `E0659`                     | local wins     |
 
-  So a consumer with a dependency named `recovery` and a `use tokora::types::*;` had **every**
-  `recovery::...` path rebound to tokora — an entire crate path prefix, in code with nothing to do
-  with this API, with no error and no warning. That is gone.
+  Two earlier drafts of this release were built on a wrong row. The first measured `type` against
+  an extern crate as `E0599`, loud, and re-exported `Status` into `types` on that basis. The probe
+  asked the shadowing type for an associated item it did not have, so it could only be loud: with
+  a dependency aliased `Status` exporting `Error`, and tokora's `Status` carrying an `Error`
+  variant with an inherent `is_error()`, `Status::Error.is_error()` compiles on both revisions and
+  **the boolean inverts**. The second draft then moved all four items into `types` to get the
+  module name out of the glob, on that same false premise.
 
-  **The two silent axes cannot both be closed, and this is a choice between residuals.** A public
-  trait has to live in a module; if that module is already globbed the trait name is silent on the
-  second-glob axis, and if it is a new module the module name is silent on the extern-crate axis.
-  There is no third place. The trade was made on blast radius: the module hazard redirects a whole
-  path prefix and is triggered by a dependency name a consumer may not control, while the trait
-  hazard reaches four method names on tokora's own carriers and needs a same-named trait
-  glob-imported from the consumer's own prelude.
+  **No kind that can carry this API is loud on both axes**, so the question is not which kind is
+  safe but how few silent names a placement adds. The floor is one — a public trait must live in a
+  module, and every module is either already globbed or a new name in one — and a module reaches
+  it. Re-exporting the four items instead puts four names into `types::*`: `Status` and
+  `Components` silent against an extern crate, `RecoveryState` and `FromComponents` silent against
+  a second glob.
 
-  **The residual, stated:** a consumer glob-importing both `tokora::types::*` and a prelude of
-  their own containing a trait named `RecoveryState` or `FromComponents` gets
-  `ambiguous_glob_imported_traits` — warn-by-default, rust-lang/rust#152822 — and the first glob
-  wins. It is pinned as a test rather than left as prose, so if that lint becomes the hard error
-  its future-incompatibility note promises, the suite says so. A trait reached through a glob can be rebound by a second glob without
-  an error. Reproduced against `rustc 1.100.0-nightly`, three arrangements behave differently:
-  two globs offering the same **type** name is `error[E0659]`; two globs offering the same method
-  through **differently named** traits is `error[E0034]`; but two globs offering the same **trait
-  name** *compiles*, warns under the warn-by-default `ambiguous_glob_imported_traits`
-  (rust-lang/rust#152822), and resolves to whichever glob was written **first** — so
-  `use tokora::types::*; use their_crate::*;` could silently rebind a consumer's own `is_valid`,
-  in either direction depending on import order.
-
-  Moving the three questions off inherent methods closed that rebind at the type and reopened it
-  at the re-export; naming the module closes it for good. A consumer's glob-imported trait is now
-  unopposed. **That is superseded**: the module it moved into was itself a name in `types::*`, of
-  the one kind that is silent against an extern crate, so the trait came back to `types` as an
-  item. See *there is no `types::recovery` module* above for the measured table and the residual
-  this leaves.
+  **The residual, named as what it is.** A consumer with a dependency named or aliased `recovery`
+  who writes `use tokora::types::*;` has every `recovery::…` path rebound to tokora, with no error
+  and no warning. The only lever left is the module's *name*, and that is **probability, not
+  safety**: no identifier is barred from being a crate alias. It is not pulled, because the gain
+  cannot be quantified and the churn is real.
 
 - **The recovery carriers keep `PartialEq`/`Eq` derived, and only the other four are hand-written**
   (#320). Replacing all six derives dropped the compiler-generated `StructuralPartialEq`, so a
@@ -1005,7 +993,7 @@ and will red until they do.
   now stands as a consumer would write it — which is also the regression test.
 
 - **`IntoComponents::Components` on all nineteen recovery carriers becomes
-  `types::Components { span, payload, status }` — a named struct, not a tuple** (#320). `Ident`, `Keyword` and the
+  `types::recovery::Components { span, payload, status }` — a named struct, not a tuple** (#320). `Ident`, `Keyword` and the
   seventeen `Lit*` types hold a span, a payload and a recovery status, and returned two of the
   three. The trait's own contract is that a decomposition is complete with no information loss,
   and the test of that is whether the output rebuilds the input: it did not, so
@@ -2594,9 +2582,8 @@ and will red until they do.
 **`Status` is a new public name in `tokora::types`** (#320). A consumer with
 `use tokora::types::*;` and a `Status` of their own gets `error[E0659]` at the name, resolved by an
 explicit import or an `as` alias. `RecoveryState` and `FromComponents` are **not** in that
-namespace in an earlier draft; they are back in `types` as items, because the module that held
-them was itself a silently-shadowing name. Both silent axes cannot be closed at once — see
-**Changed (breaking)** for the measured table and the accepted residual.
+namespace — they live in `tokora::types::recovery` and must be named, because a trait behind a
+glob is picked silently where a type is not.
 
 *Three earlier drafts of this release listed more names here, and all are withdrawn.* The third
 listed `with_status` as a new inherent associated function that could not be displaced silently,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1448,6 +1448,22 @@ and will red until they do.
   value; and the eighteen carriers grow one field, so `Keyword<&str, SimpleSpan>` goes from 32 to
   40 bytes — exactly `Ident<&str, SimpleSpan>`'s size, which already paid it.
 
+- **`InvalidHexDigits`'s shared reader can no longer be turned into a truncating one by a method
+  added later** (#280). The type's `Deref`, `DerefMut` and `bump` read `as_slices().0` /
+  `as_mut_slices().0` — the first physical segment of a ring buffer handed out as the whole set,
+  the shape #245 fixed in `IncompleteSyntax`. It was correct, because the only mutation was an
+  append and so the head never left zero, but that was a property of the method list rather than
+  of the type, and two of the three reads went through `Deref`/`DerefMut` and so did not name
+  `as_slices` for a grep to find.
+
+  The two reads whose receiver is exclusive now normalize instead of assuming: `make_contiguous`
+  returns the whole ring by construction, whatever state it is in. The one that cannot — `Deref`
+  takes `&self` by trait definition, and one `&[T]` cannot describe two segments — is backed by
+  containment rather than by a comment: the struct is declared in a private submodule, so its
+  field is unreachable from the rest of the file, and every mutation goes through one funnel that
+  restores contiguity on exit, the unwinding one included. A `pop_front` added next year is a
+  private-field error, not a silent reintroduction.
+
 - **A green tree deep enough to abort in its own destructor can no longer be materialized**
   (#316). The construction half of an uncatchable process abort reachable from safe third-party
   code: `rowan`'s recursive release of a green tree. Both public construction doors are covered —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,29 @@ and will red until they do.
   `Status` is `#[non_exhaustive]`: a fourth recovery state is admissible later, so a `match` needs
   a wildcard arm and `is_valid()` is deliberately not `!is_error() && !is_missing()`.
 
+- **`types::recovery::FromComponents` — the inverse of `IntoComponents`** (#320).
+  `T::from_components(x.into_components())` rebuilds a carrier with its recovery state intact, and
+  is the door that closes the laundering: rebuilding through `new` would declare a recovered node
+  valid.
+
+  It is a **trait** method, and that is a repair rather than a style. The same job was briefly done
+  by a `pub const fn with_status(span, payload, status)` inherent on each of the nineteen carriers,
+  argued loud because its `Status` parameter is a type no pre-upgrade expression can produce.
+  **That is false for a type-directed expression, and it was measured.** An unchanged
+  `unsafe { core::mem::zeroed() }` in that argument position infers as a consumer's own status enum
+  before the upgrade and as `Status` after; both revisions compile, there is no ambiguity, and
+  dispatch moves from the consumer's trait to tokora's inherent function. With `Status::Valid` at
+  discriminant zero, a consumer's zero-valued *rejection* becomes valid syntax.
+  `transmute::<u8, _>(0)` does the same, and `MaybeUninit::uninit().assume_init()` yields whatever
+  the stack held. Bounded routes were measured too and all fail loudly — `Default::default()`,
+  `x.into()`, an associated constant and a bounded generic call each need an impl or a named type
+  `Status` does not provide. The silent routes are exactly the **unbounded** ones.
+
+  A trait method sits where a consumer's inherent item outranks it, its argument is an associated
+  type rather than a bare `Status`, and `recovery` is not glob-re-exported — so it has to be named.
+  No consumer code depends on the withdrawn spelling: `with_status` is new in this release and
+  never shipped, which is why it goes where `Ident`'s predicates came back.
+
 - **`types::recovery::RecoveryState` and `types::Status`, over all nineteen recovery carriers**
   (#301). `Keyword` and the seventeen literal carriers implemented `ErrorNode` — so
   `error(span)` and `missing(span)` were public and documented as recovery placeholders — while
@@ -2509,18 +2532,18 @@ and will red until they do.
 
 ### Source-breaking additions that can change behaviour with *no diagnostic at the call site*
 
-**`with_status` is a new inherent associated function on all nineteen recovery carriers, and
-`Status` and `RecoveryState` are new public names in `tokora::types`** (#320). `with_status` can
-win the pick over a consumer's extension item and **cannot do so silently** — not because its
-signature differs, which is not sufficient, but because its third parameter is a `Status`, a type
-no code written before this release can produce a value of. Arguments are checked at the call
-rather than chained past, so displacing a consumer's `with_status` is `error[E0308]` there. It is
-also unreachable by method-call syntax, taking no `self`. The fix is UFCS,
-`MyExt::with_status(..)`. The two new type names are a glob exposure: a consumer with
-`use tokora::types::*;` and a `Status` or `RecoveryState` of their own gets an ambiguity at the
-name, resolved by an explicit import or an `as` alias.
+**`Status` is a new public name in `tokora::types`** (#320). A consumer with
+`use tokora::types::*;` and a `Status` of their own gets `error[E0659]` at the name, resolved by an
+explicit import or an `as` alias. `RecoveryState` and `FromComponents` are **not** in that
+namespace — they live in `tokora::types::recovery` and must be named, because a trait behind a
+glob is picked silently where a type is not.
 
-*Two earlier drafts of this release listed more names here, and both are withdrawn.* The first
+*Three earlier drafts of this release listed more names here, and all are withdrawn.* The third
+listed `with_status` as a new inherent associated function that could not be displaced silently,
+because its `Status` parameter is a type no pre-upgrade code can produce. That is true only of
+expressions whose type comes from the expression; an `unsafe { zeroed() }` takes its type from the
+**parameter**, compiles on both revisions, and moves dispatch. There is no inherent `with_status`
+any more — see `FromComponents` under **Added**.* The first
 listed `is_valid`, `is_error` and `is_missing` as new inherent methods on `Keyword` and the
 seventeen `Lit*` types, offering UFCS as the fix; they are on `RecoveryState` and were never
 shipped inherent. The second listed `status` beside `with_status` on the argument that a new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -975,8 +975,8 @@ and will red until they do.
   reason that is not real is worse than the bare defect, so the workaround is gone and the example
   now stands as a consumer would write it — which is also the regression test.
 
-- **`IntoComponents::Components` on all nineteen recovery carriers gains the status:
-  `(Span, Payload)` becomes `(Span, Payload, Status)`** (#320). `Ident`, `Keyword` and the
+- **`IntoComponents::Components` on all nineteen recovery carriers becomes
+  `types::recovery::Components { span, payload, status }` — a named struct, not a tuple** (#320). `Ident`, `Keyword` and the
   seventeen `Lit*` types hold a span, a payload and a recovery status, and returned two of the
   three. The trait's own contract is that a decomposition is complete with no information loss,
   and the test of that is whether the output rebuilds the input: it did not, so
@@ -992,13 +992,43 @@ and will red until they do.
   and leaving it would have left `Ident::into_components` returning a 2-tuple beside `Keyword`'s
   3-tuple.
 
-  Migration is a compile error at every site, never a silent change: `let (span, src) = x
-  .into_components();` becomes `let (span, src, status) = …`, and `_` if the status is not wanted.
-  The status is **appended** rather than inserted after the span, against the trait's ordering
-  convention, so that `.0` and `.1` keep their meanings and only destructuring arity breaks.
-  Withdrawing the impls was the alternative and is worse: for an owned payload `into_components`
-  is the only extraction that does not clone, and withdrawal removes a capability where widening
-  completes it.
+  Migration is a compile error at every site: `let (span, src) = x.into_components();` becomes
+  `let Components { span, payload, .. } = …`. Withdrawing the impls was the alternative and is
+  worse: for an owned payload `into_components` is the only extraction that does not clone, and
+  withdrawal removes a capability where completing it is what was needed.
+
+  **A three-tuple was tried first and is not safe**, which is why the shape is a struct. Widening
+  `(Span, Payload)` to `(Span, Payload, Status)` was defended on the grounds that the arity changes
+  and every stale destructuring therefore breaks loudly. One line defeats that:
+
+  ```rust,ignore
+  let (_, .., value) = literal.into_components();
+  value.is_valid()
+  ```
+
+  `..` matches zero elements against a pair and one against a triple, so `value` is the payload
+  before and the status after. Both compile whenever the payload also answers `is_valid`, and
+  since `new` assigns `Status::Valid`, a payload the caller's own check rejects then reports
+  valid. `(.., b)` and `.1` are the same defect in other spellings.
+
+  That was the third exemption of its kind refuted in this release — after *the return type
+  differs* and *the argument type is a `Status`* — and all three failed the same way: each
+  estimated what a consumer could have written, and estimated it too small. So this is not a
+  better-argued exemption but a shape no tuple pattern can match at all. Ten shapes were compiled
+  against both the old pair and the new struct: `(a, b)`, `(_, b)`, `(a, ..)`, `(_, .., b)`,
+  `(.., b)`, a trailing comma, `ref` bindings, a `match` arm, `.0` and `.1`. All ten build against
+  the pair — that is the control — and all ten are refused against the struct, with `E0308` for the
+  patterns and `E0609` for the index accesses. Eight of them are `compile_fail` doctests on
+  `Components` with the codes pinned, and the pinning was itself checked by planting a wrong code.
+
+  It is the better API besides: three positional parts whose third is a status is exactly the
+  shape that made `..` dangerous, and a named field says which is which.
+
+  **The stated residual.** A consumer who never looks inside the value keeps compiling —
+  `format!("{:?}", x.into_components())`, or passing it to a generic sink. What they observe
+  changes; what they can *extract* does not, because every pattern, index and typed argument is
+  now refused. There is no spelling that silently hands back the status where the payload used to
+  be.
 
 - **`CachedToken::state` and `CachedToken::into_components` are crate-internal** (#311). The regime
   a cached token carries is now an opaque payload: carried, cloned and moved, never read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ and will red until they do.
   `Status` is `#[non_exhaustive]`: a fourth recovery state is admissible later, so a `match` needs
   a wildcard arm and `is_valid()` is deliberately not `!is_error() && !is_missing()`.
 
-- **`types::recovery::FromComponents` — the inverse of `IntoComponents`** (#320).
+- **`types::FromComponents` — the inverse of `IntoComponents`** (#320).
   `T::from_components(x.into_components())` rebuilds a carrier with its recovery state intact, and
   is the door that closes the laundering: rebuilding through `new` would declare a recovered node
   valid.
@@ -109,7 +109,7 @@ and will red until they do.
   No consumer code depends on the withdrawn spelling: `with_status` is new in this release and
   never shipped, which is why it goes where `Ident`'s predicates came back.
 
-- **`types::recovery::RecoveryState` and `types::Status`, over all nineteen recovery carriers**
+- **`types::RecoveryState` and `types::Status`, over all nineteen recovery carriers**
   (#301). `Keyword` and the seventeen literal carriers implemented `ErrorNode` — so
   `error(span)` and `missing(span)` were public and documented as recovery placeholders — while
   holding no field that could record which of the three states a value was in. The only way to
@@ -917,8 +917,39 @@ and will red until they do.
   the converting one fails `Silent` verbatim, and the bound-free one stops covering the delimited
   driver the bundle exists for.
 
-- **`RecoveryState` lives in `tokora::types::recovery` and is not re-exported into
-  `tokora::types`** (#320). A trait reached through a glob can be rebound by a second glob without
+- **`RecoveryState`, `FromComponents`, `Status` and `Components` are items of `tokora::types`;
+  there is no `types::recovery` module** (#320). Reaching them is
+  `use tokora::types::{RecoveryState, FromComponents, Status, Components};`.
+
+  A draft put them in a `pub mod recovery` so the trait would not be in `types::*`. That put a
+  **module** name there instead, and the kinds do not resolve alike. Measured against
+  `rustc 1.100.0-nightly` over three axes, with the consumer's source fixed and the library
+  gaining one item:
+
+  |            | vs an extern crate of that name  | vs a second glob            | vs a local def |
+  |------------|----------------------------------|-----------------------------|----------------|
+  | **module** | **silent redirect**              | `E0659`                     | local wins     |
+  | **trait**  | `E0790`                          | **silent, first glob wins** | local wins     |
+  | type       | `E0599`                          | `E0659`                     | local wins     |
+  | fn / const | no interaction (value namespace) | `E0659`                     | local wins     |
+
+  So a consumer with a dependency named `recovery` and a `use tokora::types::*;` had **every**
+  `recovery::...` path rebound to tokora — an entire crate path prefix, in code with nothing to do
+  with this API, with no error and no warning. That is gone.
+
+  **The two silent axes cannot both be closed, and this is a choice between residuals.** A public
+  trait has to live in a module; if that module is already globbed the trait name is silent on the
+  second-glob axis, and if it is a new module the module name is silent on the extern-crate axis.
+  There is no third place. The trade was made on blast radius: the module hazard redirects a whole
+  path prefix and is triggered by a dependency name a consumer may not control, while the trait
+  hazard reaches four method names on tokora's own carriers and needs a same-named trait
+  glob-imported from the consumer's own prelude.
+
+  **The residual, stated:** a consumer glob-importing both `tokora::types::*` and a prelude of
+  their own containing a trait named `RecoveryState` or `FromComponents` gets
+  `ambiguous_glob_imported_traits` — warn-by-default, rust-lang/rust#152822 — and the first glob
+  wins. It is pinned as a test rather than left as prose, so if that lint becomes the hard error
+  its future-incompatibility note promises, the suite says so. A trait reached through a glob can be rebound by a second glob without
   an error. Reproduced against `rustc 1.100.0-nightly`, three arrangements behave differently:
   two globs offering the same **type** name is `error[E0659]`; two globs offering the same method
   through **differently named** traits is `error[E0034]`; but two globs offering the same **trait
@@ -929,12 +960,10 @@ and will red until they do.
 
   Moving the three questions off inherent methods closed that rebind at the type and reopened it
   at the re-export; naming the module closes it for good. A consumer's glob-imported trait is now
-  unopposed, and one who wants tokora's writes `use tokora::types::recovery::RecoveryState;` —
-  an explicit import, which beats a glob and is a choice rather than an accident.
-
-  **`Status` stays at `tokora::types::Status`**, because a type name collides loudly; it is also
-  available as `types::recovery::Status`. The cost to a consumer who is not colliding with
-  anything is one import line, and only for the trait.
+  unopposed. **That is superseded**: the module it moved into was itself a name in `types::*`, of
+  the one kind that is silent against an extern crate, so the trait came back to `types` as an
+  item. See *there is no `types::recovery` module* above for the measured table and the residual
+  this leaves.
 
 - **The recovery carriers keep `PartialEq`/`Eq` derived, and only the other four are hand-written**
   (#320). Replacing all six derives dropped the compiler-generated `StructuralPartialEq`, so a
@@ -976,7 +1005,7 @@ and will red until they do.
   now stands as a consumer would write it — which is also the regression test.
 
 - **`IntoComponents::Components` on all nineteen recovery carriers becomes
-  `types::recovery::Components { span, payload, status }` — a named struct, not a tuple** (#320). `Ident`, `Keyword` and the
+  `types::Components { span, payload, status }` — a named struct, not a tuple** (#320). `Ident`, `Keyword` and the
   seventeen `Lit*` types hold a span, a payload and a recovery status, and returned two of the
   three. The trait's own contract is that a decomposition is complete with no information loss,
   and the test of that is whether the output rebuilds the input: it did not, so
@@ -2565,8 +2594,9 @@ and will red until they do.
 **`Status` is a new public name in `tokora::types`** (#320). A consumer with
 `use tokora::types::*;` and a `Status` of their own gets `error[E0659]` at the name, resolved by an
 explicit import or an `as` alias. `RecoveryState` and `FromComponents` are **not** in that
-namespace — they live in `tokora::types::recovery` and must be named, because a trait behind a
-glob is picked silently where a type is not.
+namespace in an earlier draft; they are back in `types` as items, because the module that held
+them was itself a silently-shadowing name. Both silent axes cannot be closed at once — see
+**Changed (breaking)** for the measured table and the accepted residual.
 
 *Three earlier drafts of this release listed more names here, and all are withdrawn.* The third
 listed `with_status` as a new inherent associated function that could not be displaced silently,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,21 @@ and will red until they do.
 
 ### Added
 
+- **`types::Status`, and `with_status` on all nineteen recovery carriers** (#320). The recovery
+  state stops being a private field and becomes a value a consumer can hold: it is returned by
+  `IntoComponents` (see **Changed (breaking)**) and accepted back by
+  `Ident::with_status`, `Keyword::with_status` and each `Lit*::with_status`, which are the inverses
+  of that decomposition and make a decompose-and-rebuild the identity in all three states.
+
+  `with_status` is also the only constructor that can express a state other than valid over a
+  payload the **caller** chose — `new` always declares the result valid, and `ErrorNode::error` /
+  `ErrorNode::missing` pick the payload themselves — so a dialect with its own placeholder
+  spelling now has a door. Without it a complete decomposition would still have ended in
+  laundering, because the only public way back in forced `Valid`.
+
+  `Status` is `#[non_exhaustive]`: a fourth recovery state is admissible later, so a `match` needs
+  a wildcard arm and `is_valid()` is deliberately not `!is_error() && !is_missing()`.
+
 - **`Keyword::{is_valid, is_error, is_missing}`, and the same three on every `Lit*` type**
   (#301). `Keyword` and the seventeen literal carriers implemented `ErrorNode` — so
   `error(span)` and `missing(span)` were public and documented as recovery placeholders — while
@@ -827,6 +842,31 @@ and will red until they do.
   `UnclosedEmitter` beside a converting sibling forces `ComposableEmitter` to include one of them:
   the converting one fails `Silent` verbatim, and the bound-free one stops covering the delimited
   driver the bundle exists for.
+
+- **`IntoComponents::Components` on all nineteen recovery carriers gains the status:
+  `(Span, Payload)` becomes `(Span, Payload, Status)`** (#320). `Ident`, `Keyword` and the
+  seventeen `Lit*` types hold a span, a payload and a recovery status, and returned two of the
+  three. The trait's own contract is that a decomposition is complete with no information loss,
+  and the test of that is whether the output rebuilds the input: it did not, so
+  `LitDecimal::error(span)` and `LitDecimal::new(span, "<error>")` decomposed **identically**, and
+  anything that took a carrier apart and put it back together through `new` reported a recovery
+  placeholder as valid syntax — the laundering #303 removed from `Ident::map`, reached one door
+  over. `Keyword`'s inherent `into_components`, which wins the pick over the trait's at an
+  unqualified call site, widens with it and the trait impl now delegates to it so the two shapes
+  cannot drift.
+
+  **`Ident` is included even though it predates this**, because it is the model the #266 rule
+  points at and the type this branch held up as correct; a model with the hole teaches the hole,
+  and leaving it would have left `Ident::into_components` returning a 2-tuple beside `Keyword`'s
+  3-tuple.
+
+  Migration is a compile error at every site, never a silent change: `let (span, src) = x
+  .into_components();` becomes `let (span, src, status) = …`, and `_` if the status is not wanted.
+  The status is **appended** rather than inserted after the span, against the trait's ordering
+  convention, so that `.0` and `.1` keep their meanings and only destructuring arity breaks.
+  Withdrawing the impls was the alternative and is worse: for an owned payload `into_components`
+  is the only extraction that does not clone, and withdrawal removes a capability where widening
+  completes it.
 
 - **`CachedToken::state` and `CachedToken::into_components` are crate-internal** (#311). The regime
   a cached token carries is now an opaque payload: carried, cloned and moved, never read.
@@ -2359,6 +2399,12 @@ and will red until they do.
   `increase_both_and_check`'s claimed it decreased recursion (it increases both).
 
 ### Source-breaking additions that can change behaviour with *no diagnostic at the call site*
+
+**`with_status` is a new inherent method on all nineteen recovery carriers, and `Status` is a new
+public name in `tokora::types`** (#320). The same inherent-pick exposure as the predicates below,
+plus a glob exposure: a consumer with `use tokora::types::*;` and a `Status` of their own now has
+an ambiguity at that name. **The fixes are UFCS for the method and an explicit import or alias for
+the name.**
 
 **`is_valid`, `is_error` and `is_missing` are new inherent methods on `Keyword` and on all
 seventeen `Lit*` types** (#301). An inherent item wins the pick over an extension trait's, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,22 @@ and will red until they do.
 
 ### Added
 
+- **`Keyword::{is_valid, is_error, is_missing}`, and the same three on every `Lit*` type**
+  (#301). `Keyword` and the seventeen literal carriers implemented `ErrorNode` — so
+  `error(span)` and `missing(span)` were public and documented as recovery placeholders — while
+  holding no field that could record which of the three states a value was in. The only way to
+  tell a recovered node from one spelled out in the source was to compare its payload against
+  the `"<error>"` / `"<missing>"` sentinel, which is a value a caller can spell by hand and edit
+  afterwards through `source_mut` / `data_mut`.
+
+  Each of the eighteen now carries the same private `Status` `Ident` has carried since #266, set
+  by `new` (valid) and by the two `ErrorNode` constructors, and read by these predicates. The
+  rule they are all keeping is stated once, on `ErrorNode` itself, under **Two Shapes of
+  Implementor**: a *payload* type such as `&str` has nowhere to put a state and so its
+  placeholder is a sentinel; a *carrier* type with fields of its own owes a status field. The
+  trait's own diagnostics example used to demonstrate the sentinel comparison and now reads the
+  predicates.
+
 - **`cst::TreeCheckpoint` — the builder's own checkpoint, carrying the one number `rowan`'s does
   not** (#316). Returned by `SyntaxTreeBuilder::checkpoint` and spent by `start_node_at`; it wraps
   `rowan::Checkpoint` beside the flat child index the depth ledger charges a retro-wrap against.
@@ -1419,6 +1435,19 @@ and will red until they do.
   constructs (`fn from_logos(Self::Logos) -> Self`), and a `&'a T` cannot be built from an owned
   logos token.
 
+- **`From<Keyword> for Ident` carries the recovery status instead of fabricating `Valid`**
+  (#301). `Keyword::<&str>::missing(span).into()` produced an `Ident` reporting `is_valid()`,
+  and an `IdentList` containing that segment then reported itself valid as a whole. The
+  conversion was documented as unfixable at the call site because the information did not exist
+  on the source side; it does now, and it crosses unchanged. `Keyword::map` carries it too, for
+  the reason `Ident::map` does — mapping `&str` to `String` changes how a spelling is stored,
+  not whether there was one.
+
+  **Two behaviours change with no diagnostic.** `Keyword::error(span)` no longer compares equal
+  to `Keyword::new(span, "<error>")`, and hashes differently, because the status is part of the
+  value; and the eighteen carriers grow one field, so `Keyword<&str, SimpleSpan>` goes from 32 to
+  40 bytes — exactly `Ident<&str, SimpleSpan>`'s size, which already paid it.
+
 - **A green tree deep enough to abort in its own destructor can no longer be materialized**
   (#316). The construction half of an uncatchable process abort reachable from safe third-party
   code: `rowan`'s recursive release of a green tree. Both public construction doors are covered —
@@ -2314,6 +2343,14 @@ and will red until they do.
   `increase_both_and_check`'s claimed it decreased recursion (it increases both).
 
 ### Source-breaking additions that can change behaviour with *no diagnostic at the call site*
+
+**`is_valid`, `is_error` and `is_missing` are new inherent methods on `Keyword` and on all
+seventeen `Lit*` types** (#301). An inherent item wins the pick over an extension trait's, so a
+consumer who defined any of those three names on one of these carriers — through a trait of their
+own, taking `&self`, which is the receiver tokora's take — now runs tokora's item at an
+unqualified call site. The names are not incidental: they are the three `Ident` has shipped since
+#266, and the whole point of #301 is that the eighteen carriers answer the same question the same
+way. **The fix is UFCS**, `MyExt::is_error(&kw)`, which pins the item on either revision.
 
 **`InputRef::trip_snapshot` and `InputRef::tripped_during_attempt` are new inherent methods on a
 type that already shipped.** An inherent item wins the pick over an extension trait's, so a

--- a/ci/name_collision/README.md
+++ b/ci/name_collision/README.md
@@ -22,6 +22,8 @@ scope limit below before reading a green run as safety:
 | `silent*` | a SILENT row listed in `disclosed.txt` | no — known, and in the CHANGELOG |
 | `ok*` | both sides agree AND the row is justified in `no_collision.txt` | no |
 | `new-owner` | the base side cannot resolve the row's **owner** and the head side can — the same diff introduces the owner as well as the name | no |
+| `new-owner-err` | the same, where the head side **rejects** the collision (E0034) instead of taking it — a new owner's `loud`, reachable on one side only | no |
+| `new-owner-nc*` | the same, where the **consumer's** item wins an earlier pick so no collision is constructed; justified by pick order in `no_collision.txt` | no |
 | `SILENT` | both compile, neither warns, the witness disagrees, not disclosed | **yes** |
 | `UNPROBED` | for an item row, both sides agree and it is **not** justified in `no_collision.txt`; for a glob row, rustc said nothing about the name at all. The glob form cannot be silenced by `no_collision.txt` | **yes** |
 | `INCONCL` | no before-state: the base side did not compile, its witness was not 1, or the marker was missing/duplicated | **yes** |
@@ -137,6 +139,36 @@ that, with the two witnesses listed above. Note what it does *not* say: nothing 
 consumer written after the release. A two-sided delta harness cannot see that, on either
 side of the line.
 
+**`witness=0` was read as "tokora's new item took the call" when it only ever meant "the
+consumer's item did not."** The two differ whenever the SUBJECT already carries an item of the
+probed name, and the first new trait to hit it was `RecoveryState`: it declares
+`is_valid`/`is_error`/`is_missing`, and `Ident` — the obvious subject, already in the fixture's
+import list — has carried inherent `is_valid`/`is_error`/`is_missing` since long before the base
+ref. An inherent item outranks every trait item at the same step, so three rows compiled, ran,
+reported `witness=0` and scored `new-owner` over a call that went to a method the base ref
+already had. **None of the four witnesses in place disagreed with any of them**, because each of
+the four is about the OWNER being new and none is about the call being tokora's new item.
+
+rustc reported it in the same log the whole time — `unused import: `new_module::RecoveryState``
+— and that is now the fifth witness: a `witness=0` row whose owner's import is reported unused
+is INCONCL, not `new-owner`. It costs the templates one rule, which is written where a subject
+is chosen: **an owner's import may not carry `#[allow(unused_imports)]`**, because a suppressed
+warning is a witness that cannot fire. The subject moved to `Keyword`, which declares no
+inherent item of any probed name, and the reason it had to is recorded in `TRAITS` rather than
+in a commit message.
+
+**A new owner whose item cannot WIN the receiver walk had no verdict at all.** `new-owner`
+required `witness=0` — the silent steal — and that is the one outcome a `&self` trait method
+cannot produce here: the three `trait_method` spellings put the consumer at `self` (one pick
+earlier, consumer wins) or `&self` (the same pick, E0034). Ten of one release's fourteen trait
+rows were therefore filed INCONCL — "a broken probe" — over rustc naming the exact collision
+they were built to find. `new-owner-err` is that outcome given a verdict, on the `glob-err`
+witness moved to the item level; `new-owner-nc*` is the earlier-pick case, justified by pick
+order exactly as `read_frontier/same_pick` already was. Note what neither reaches, and it is in
+the run trailer too: with no `&mut self` spelling there is no consumer that sits at a LATER pick
+than a tokora `&self` item, so on such an owner the SILENT verdict is unreachable by
+construction and a run of `new-owner-err` rows is not evidence that no silent shape exists.
+
 **And it happened again, four owners at once, because the templates are the one part of this
 harness that is not derived.** #168 mints `EmitterView` and `Cst`, gives the pre-existing
 `ParseState` its first inherent items, and adds `commit_lexer_error` to the pre-existing
@@ -218,7 +250,9 @@ positive evidence that the probe actually constructed what it claims:
 | `glob-err` | a head diagnostic naming the subject **and** mentioning ambiguity — a build that fails for an unrelated reason measured nothing |
 | `glob-ok` | an ambiguity diagnostic naming the subject — "both sides compiled" alone cannot distinguish *this toolchain does not reject it* from *no collision was constructed* |
 | `ok*` | agreement plus a written justification in `no_collision.txt`, staleness-checked |
-| `new-owner` | a base-side unresolved-import / cannot-find / failed-to-resolve diagnostic **naming this row's owner**, *and* the absence of the same diagnostic on head — a template that misspells its owner would otherwise report `new-owner` forever while having compiled nowhere |
+| `new-owner` | a base-side unresolved-import / cannot-find / failed-to-resolve diagnostic **naming this row's owner**, *and* the absence of the same diagnostic on head — a template that misspells its owner would otherwise report `new-owner` forever while having compiled nowhere — *and* head must not report that owner's import **unused**: see below |
+| `new-owner-err` | the base-side witness above, plus **three** head-side conditions: an `E0034`, the ambiguity's own label naming this row's **item**, and a candidate note naming this row's **owner**. The third is what says one of the two candidates was tokora's |
+| `new-owner-nc*` | the base-side witness above, plus a completed head run whose witness shows the consumer's item took the call, plus a written pick-order justification in `no_collision.txt`, staleness-checked |
 | `loud` | the base side ran (`witness=1`), and cargo names **the probe crate** as what failed — so the failure is the probe's, not a dependency's. **Attribution to the collision is still not established**: in the inherent-method and associated-function categories it may be the probe's own arity — see below |
 
 The fatal verdicts — `SILENT`, `UNPROBED`, `INCONCL`, `FATAL`, `STALE` — need no witness, because

--- a/ci/name_collision/gen_probe.py
+++ b/ci/name_collision/gen_probe.py
@@ -302,6 +302,45 @@ impl Node<PLang> for ProbeNode {
 '''
 
 
+# ── Reaching an owner that lives in a module the base ref does not have ──────────────────
+#
+# The indirection below is not decoration and must not be flattened to a direct import.
+#
+# `run.sh` grants `new-owner` only on positive evidence: a base-side diagnostic that NAMES this
+# row's owner. Every owner before this one lived in a module the base ref already had, so
+# `use tokora::EmitterView;` failed as `unresolved import \`tokora::EmitterView\`` — the owner in
+# the message. `tokora::diagnostic` is the first WHOLE MODULE a diff has added, and there the
+# same shape reports the module instead: `unresolved import \`tokora::diagnostic\``, with no
+# mention of `Code` anywhere in the output. Measured, all three spellings, on the base ref
+# `c14b936`:
+#
+#   use tokora::diagnostic::Code;   -> E0432 `tokora::diagnostic`      (1 error, no `Code`)
+#   use tokora::diagnostic::*;      -> E0432 `tokora::diagnostic`      (1 error, no `Code`)
+#   impl .. for tokora::diagnostic::Code -> E0433 `diagnostic` in `tokora`  (3, no `Code`)
+#
+# rustc suppresses the follow-on `cannot find type \`Code\`` in all three, which is the right
+# thing for a compiler to do and leaves the harness with no evidence: every row scores INCONCL
+# while the head side is measuring exactly what it should.
+#
+# Re-exporting through a local module splits the one failure into two, and the second one names
+# the owner:
+#
+#   error[E0432]: unresolved import `tokora::diagnostic`
+#   error[E0432]: unresolved import `new_module::Code`
+#
+# The head side resolves both hops and is unchanged. Any future diff adding a module takes this
+# shape; a direct import of a type inside a new module cannot reach `new-owner` at all.
+def new_module_imports(module, *names):
+    """Import `names` from `module` so a base ref lacking `module` names each one when it fails."""
+    tail = names[0] if len(names) == 1 else "{%s}" % ", ".join(names)
+    return (
+        "mod new_module {\n"
+        "  pub use %s::*;\n"
+        "}\n"
+        "use new_module::%s;\n" % (module, tail)
+    )
+
+
 # The subject an `Emitter`-declared row rides.
 #
 # `Silent<PErr>` is the fixture's OWN emitter — `PCtx` is built on it — so this is a type tokora
@@ -384,6 +423,49 @@ pub fn lexer_value() -> PLexer<'static> {
 # for (the fixture's own types, not a convenient one), say in the row's `no_collision.txt` entry
 # WHY the subject satisfies the bound, and never read a green `ok*` on a `&mut`-self row as
 # evidence that the subject was right. `EMITTER_SUBJECT_FIXTURE` above is the worked example.
+
+# ── The subject for `tokora::types::recovery`, and WHY IT IS NOT `Ident` ─────────────────
+#
+# Both traits are implemented for `Ident` and for `Keyword`, and `Ident` is the one already in
+# the shared fixture's import list — so it is the obvious pick and it is the WRONG one, which
+# is a fact rather than a preference. `Ident` has carried inherent `is_valid`, `is_error` and
+# `is_missing` since long before the base ref, and an inherent item outranks every trait item
+# at the same step of the receiver walk. Measured, on the `later_pick_discarded` spelling: the
+# probe compiled, ran, reported `CONSUMER-CALLS: 0` and scored `new-owner` — over a call that
+# went to `Ident`'s OWN pre-existing method, with `RecoveryState` reported unused in the same
+# log. Three false verdicts in one run, in the exact shape this harness exists to refuse.
+#
+# `Keyword` declares no inherent `status`, `is_valid`, `is_error` or `is_missing` — check that
+# before moving this subject, because the check is what the choice rests on — so tokora's trait
+# item is the only candidate of that name on it besides the consumer's. `run.sh`'s fifth witness
+# now REFUSES the `Ident` shape rather than trusting this note, but the note is what tells the
+# next author which way to move when it fires.
+#
+# The import is deliberately NOT wrapped in `#[allow(unused_imports)]`, and that is load-bearing
+# rather than an oversight: `unused import: `new_module::RecoveryState`` IS the fifth witness's
+# evidence, and an allow is a witness that cannot fire. `trait_scope`'s `scope` field carries
+# that allow for its own documented reason, which is why these two traits reach the probe
+# through `fixture` instead.
+RECOVERY_CARRIER = r'''
+use tokora::types::Keyword;
+
+/// A carrier tokora implements both `types::recovery` traits for, and which declares no
+/// inherent item of any probed name. Built directly: `Keyword::new` is public and const, and a
+/// parse would hand the value back through a grammar rather than to the line making the call.
+pub fn recovery_carrier() -> Keyword<&'static str> {
+  Keyword::new(tokora::SimpleSpan::new(0, 1), "probe")
+}
+'''
+
+RECOVERY_STATE_FIXTURE = (
+    new_module_imports("tokora::types::recovery", "RecoveryState") + RECOVERY_CARRIER
+)
+
+FROM_COMPONENTS_FIXTURE = (
+    new_module_imports("tokora::types::recovery", "FromComponents") + RECOVERY_CARRIER
+)
+
+
 TRAITS = {
     "ParseInput": {
         "recvr": "parse_num",
@@ -593,6 +675,55 @@ TRAITS = {
         "self_ty": None,
         "scope": "use tokora::state::recursion_tracker::*;",
         "fixture": None,
+    },
+    # ── `RecoveryState` / `FromComponents` — a NEW trait in a NEW module ────────────────────
+    #
+    # The first owners here that the same diff introduces AND that live in a module the base ref
+    # does not have. Both facts matter and they are answered in different places:
+    #
+    #   * the module is new, so a direct `use tokora::types::recovery::RecoveryState;` fails on
+    #     base as `unresolved import `tokora::types::recovery`` — the MODULE, with the owner
+    #     suppressed — and every row scores INCONCL for want of a diagnostic naming the owner.
+    #     `new_module_imports` splits that into two errors, the second `unresolved import
+    #     `new_module::RecoveryState``. Measured on `a218439`, exactly the `tokora::diagnostic`
+    #     shape that function was written for.
+    #   * the owner is new, so the BASE side cannot compile and no row here can reach `loud`,
+    #     `silent` or `ok*` — those all need a before-state. The three verdicts a new owner can
+    #     reach are `new-owner` (head takes the call), `new-owner-err` (head refuses to choose)
+    #     and `new-owner-nc*` (the consumer wins an earlier pick, justified by pick order).
+    #
+    # Which one each spelling lands on is decided by ONE fact: every item on both traits takes
+    # `&self` or no receiver at all, and the `trait_method` spellings are named for a tokora
+    # method taken BY VALUE. Against `&self` there is no LATER pick for the consumer to sit at —
+    # `same_pick` (`self`) is one pick EARLIER and wins outright; `later_pick_*` (`&self`) is the
+    # SAME pick and rustc refuses to choose. So no spelling here can produce a silent steal, and
+    # that is a property of the receiver kinds rather than of these names. It is the mirror of
+    # `Emitter::commit_lexer_error`, one receiver step over: there tokora's `&mut self` is later
+    # than every consumer spelling, here tokora's `&self` is earlier than or equal to all of them.
+    #
+    # `FromComponents::from_components` takes no receiver, so it is a `trait_assoc_fn` and its
+    # rule is path resolution rather than a walk: the consumer's `impl<T> ConsumerAssoc for T`
+    # and tokora's trait are both applicable to `Keyword` and rustc reports E0034. That is the
+    # `loud` verdict that category's docstring predicts, reached on the one side a new owner has.
+    #
+    # `self_ty` carries the turbofish because the template spells `{ty}::{name}()` and a bare
+    # `Keyword<&'static str>::from_components()` is not a path.
+    "RecoveryState": {
+        "recvr": "recovery_carrier()",
+        # `RecoveryState` declares no receiver-less item, so no `trait_assoc_fn` row can arise
+        # and filling this in "just in case" is how a probe ends up riding a guess.
+        "self_ty": None,
+        # The import is in `fixture`, not here: `trait_scope` wraps `scope` in
+        # `#[allow(unused_imports)]`, and that allow would suppress the fifth witness's evidence.
+        "scope": None,
+        "fixture": RECOVERY_STATE_FIXTURE,
+    },
+    "FromComponents": {
+        # No receiver value: `FromComponents` declares exactly one item and it takes none.
+        "recvr": None,
+        "self_ty": "Keyword::<&'static str>",
+        "scope": None,
+        "fixture": FROM_COMPONENTS_FIXTURE,
     },
 }
 
@@ -949,45 +1080,6 @@ pub fn mini_cst() -> Cst<'static, Mini<'static>, Silent<PErr>> {
   cst
 }
 '''
-
-
-# ── Reaching an owner that lives in a module the base ref does not have ──────────────────
-#
-# The indirection below is not decoration and must not be flattened to a direct import.
-#
-# `run.sh` grants `new-owner` only on positive evidence: a base-side diagnostic that NAMES this
-# row's owner. Every owner before this one lived in a module the base ref already had, so
-# `use tokora::EmitterView;` failed as `unresolved import \`tokora::EmitterView\`` — the owner in
-# the message. `tokora::diagnostic` is the first WHOLE MODULE a diff has added, and there the
-# same shape reports the module instead: `unresolved import \`tokora::diagnostic\``, with no
-# mention of `Code` anywhere in the output. Measured, all three spellings, on the base ref
-# `c14b936`:
-#
-#   use tokora::diagnostic::Code;   -> E0432 `tokora::diagnostic`      (1 error, no `Code`)
-#   use tokora::diagnostic::*;      -> E0432 `tokora::diagnostic`      (1 error, no `Code`)
-#   impl .. for tokora::diagnostic::Code -> E0433 `diagnostic` in `tokora`  (3, no `Code`)
-#
-# rustc suppresses the follow-on `cannot find type \`Code\`` in all three, which is the right
-# thing for a compiler to do and leaves the harness with no evidence: every row scores INCONCL
-# while the head side is measuring exactly what it should.
-#
-# Re-exporting through a local module splits the one failure into two, and the second one names
-# the owner:
-#
-#   error[E0432]: unresolved import `tokora::diagnostic`
-#   error[E0432]: unresolved import `new_module::Code`
-#
-# The head side resolves both hops and is unchanged. Any future diff adding a module takes this
-# shape; a direct import of a type inside a new module cannot reach `new-owner` at all.
-def new_module_imports(module, *names):
-    """Import `names` from `module` so a base ref lacking `module` names each one when it fails."""
-    tail = names[0] if len(names) == 1 else "{%s}" % ", ".join(names)
-    return (
-        "mod new_module {\n"
-        "  pub use %s::*;\n"
-        "}\n"
-        "use new_module::%s;\n" % (module, tail)
-    )
 
 
 # ── Inherent subjects whose OWNER this same diff introduces ──────────────────────────────
@@ -1700,6 +1792,15 @@ def trait_method(name, owner, spelling):
         "increase_both": "",
         "increase_both_and_check": "",
         "increase_and_check": "",
+        # `RecoveryState`'s four. `status` takes `&self` and nothing else; the other three are
+        # DEFAULTED methods on it with the same signature — read `types/recovery.rs` and there
+        # is nothing after `&self` in any of them. The same empty-argument shape `clear`,
+        # `read_frontier` and `take_probe` already ride, not the multi-argument support #225
+        # declines.
+        "status": "",
+        "is_valid": "",
+        "is_error": "",
+        "is_missing": "",
     }.get(name)
     if args is None:
         # The pointer matters more than the refusal. An author who lands here reads "add a

--- a/ci/name_collision/gen_probe.py
+++ b/ci/name_collision/gen_probe.py
@@ -1217,6 +1217,39 @@ INHERENT_SUBJECTS = {
             "with_limitation": ("1_000", "TokenBudget"),
         },
     },
+    # `Status` is minted by the same diff as its three items, so it takes this table's new-owner
+    # shape like every entry above it: the base side cannot name the type at all, and only the
+    # head side's binding has to be right. Its module (`tokora::types`) is NOT new — only the
+    # `Status` name within it is — so a plain `use tokora::types::Status;` already names the
+    # owner in the base-side diagnostic and the `new_module_imports` indirection the
+    # `diagnostic` types need buys nothing here, the same reasoning `Probe`'s entry gives.
+    # `recovery`, the submodule `Status` is re-exported from, is new too, but the owner probed
+    # here is reached through the pre-existing `types` re-export, not through `recovery` itself.
+    #
+    # It is `Copy` and all three items take `self` BY VALUE — not `&self` or `&mut self`, one
+    # step EARLIER than any other receiver kind this table carries. The receiver walk is
+    # therefore stronger than `Code`'s or `Probe`'s (found at the `&T` step): tokora's item is
+    # found at the FIRST candidate, `T` itself, before the generated consumer's `&mut self`
+    # extension method is even a candidate.
+    "Status": {
+        "imports": "use tokora::types::Status;\n",
+        "fixture": "",
+        "ty": "Status",
+        "setup": "",
+        # `Status::Error`, not `::Valid` — the module's own doc header measures exactly this
+        # variant (`Status::Error.is_error()`, "the boolean reads false before and true after"),
+        # so the subject here reproduces the same construction rather than a fresh guess.
+        "build": "  let mut subject: Status = Status::Error;\n",
+        "calls": {
+            "is_valid": ("", "bool"),
+            "is_error": ("", "bool"),
+            "is_missing": ("", "bool"),
+        },
+        # `Status` declares no receiver-less associated function — a consumer does not build one
+        # from a constructor, it is handed back through `RecoveryState::status`. An empty table
+        # rather than an absent key, for the reason `Cst`'s empty `assoc_calls` gives.
+        "assoc_calls": {},
+    },
 }
 
 

--- a/ci/name_collision/no_collision.txt
+++ b/ci/name_collision/no_collision.txt
@@ -404,3 +404,36 @@ increase_both_and_check/later_pick_discarded
 increase_and_check/same_pick
 increase_and_check/later_pick_used
 increase_and_check/later_pick_discarded
+
+# ── `RecoveryState` — the BY-VALUE consumer keeps its call, on a new owner ────────────────
+#
+# tokora's are `fn status(&self) -> Status` and three defaulted `fn is_*(&self) -> bool` on
+# `RecoveryState`. The `trait_method` template's `same_pick` consumer declares `self` BY VALUE,
+# which is the FIRST step of the receiver walk; the subject is `Keyword<&'static str>`, which
+# derefs to nothing, so there is no earlier step for tokora's `&self` item to be found at — it
+# sits at the step-0 autoref, one pick later. The consumer's item claims the call and tokora's
+# is never a candidate. rustc says exactly that in the same log, and the fifth witness reads it:
+# `unused import: `new_module::RecoveryState``.
+#
+# This is `read_frontier/same_pick`'s analysis verbatim, on an owner the same diff introduces.
+# The verdict differs — `new-owner-nc*` rather than `ok*` — only because a new owner has no
+# before-state to agree WITH; the fact being justified is identical and so is this file's job
+# for it.
+#
+# The control is in the same run and it is what says this is the SHAPE and not a broken probe:
+# the `later_pick_*` rows put the consumer at `&self`, the same pick tokora's item sits at, and
+# every one of them scores `new-owner-err` — rustc reporting E0034 and naming both candidates.
+# So the template does construct a collision on this subject the moment the receiver kinds
+# agree. Read these four rows as "the by-value consumer keeps its call", never as "`status`,
+# `is_valid`, `is_error` and `is_missing` cannot be stolen".
+#
+# Why the subject satisfies the bound, since `recvr` is trusted and not verified: `Keyword` is
+# one of the two types tokora implements `RecoveryState` for in product code
+# (`types/keyword.rs`), and it is chosen over `Ident` — the other one — because `Ident` carries
+# PRE-EXISTING inherent `is_valid`/`is_error`/`is_missing`, which take the call and produce a
+# `witness=0` that measures nothing. That was measured, not reasoned; see the subject note in
+# gen_probe.py.
+status/same_pick
+is_valid/same_pick
+is_error/same_pick
+is_missing/same_pick

--- a/ci/name_collision/run.sh
+++ b/ci/name_collision/run.sh
@@ -13,6 +13,10 @@
 #   ok*       both sides AGREE and the row is justified in no_collision.txt     non-fatal
 #   new-owner base cannot resolve the OWNER and head can — the same diff        non-fatal
 #             introduces the owner, so no call site could predate the name
+#   new-owner-err  the same, where head REJECTS the collision (E0034) instead    non-fatal
+#             of taking it — the loud outcome, reachable on one side only
+#   new-owner-nc*  the same, where the CONSUMER's item wins an earlier pick and  non-fatal
+#             no collision is constructed; justified by pick order in no_collision.txt
 #   SILENT    both ran, neither warned, witness differs, not disclosed          FATAL
 #   UNPROBED  both sides agree and it is NOT justified — likely a vacuous probe FATAL
 #   INCONCL   no before-state (base did not run, or the witness was unreadable) FATAL
@@ -204,6 +208,8 @@ loud=0
 okc=0
 incon=0
 newowner=0
+newownererr=0
+newownernc=0
 while IFS=$(printf '\t') read -r cat name owner spelling; do
   [ -n "$cat" ] || continue
   if ! python3 "$HERE/gen_probe.py" "$cat" "$name" "$owner" "$spelling" > "$WORK/probe.rs" 2> "$WORK/gen.err"; then
@@ -503,8 +509,8 @@ while IFS=$(printf '\t') read -r cat name owner spelling; do
     # row onto a subject that does exist, which is the vacuous-probe defect this harness was
     # built after: `Gadget::parse_except` cannot collide with `Ident::parse_except`.
     #
-    # FOUR witnesses, not three — "fine" is again being asserted by an absence and this
-    # file's rule is that each such verdict must produce positive evidence:
+    # FIVE witnesses, and TWO head-side shapes — "fine" is again being asserted by an absence
+    # and this file's rule is that each such verdict must produce positive evidence:
     #
     #   * rustc must SAY, on the base side, that it cannot resolve THIS ROW'S OWNER — an
     #     unresolved import / cannot-find / failed-to-resolve diagnostic naming it. A base build
@@ -534,6 +540,16 @@ while IFS=$(printf '\t') read -r cat name owner spelling; do
     #     actual evidence (`witness=0*`) rather than a denylist of the shapes known to be broken
     #     — a denylist is silent about the next broken shape nobody has named yet.
     #
+    #   * and the head side must not report the OWNER's import UNUSED. See the fifth witness
+    #     below: an inherent item the subject already carried produces `witness=0` exactly as a
+    #     new trait item does, and only rustc's `unused import` separates them.
+    #
+    # And the silent steal is not the only head-side shape that proves a collision. A new owner
+    # whose item cannot WIN the receiver walk loses the call to the consumer or ties with it,
+    # and a tie is E0034 — rustc naming the collision instead of taking it. That is the
+    # `new-owner-err` arm below, and it is why this branch is a case over `$h` rather than a
+    # single test.
+    #
     # What the row then means is narrow and is printed with it: no pre-existing call site can be
     # stolen. It says nothing about a consumer written AFTER the release, which is out of scope
     # for a two-sided delta harness by construction.
@@ -545,25 +561,137 @@ while IFS=$(printf '\t') read -r cat name owner spelling; do
     grep -E "(^|[^A-Za-z0-9_])$owner([^A-Za-z0-9_]|$)" "$WORK/out-head.txt" 2>/dev/null \
       | grep -qE "unresolved import|cannot find|failed to resolve|E0432|E0433|E0412" \
       && head_unresolved=yes
+    # THE FIFTH WITNESS. `witness=0` is CONSUMER-CALLS, so what it establishes is "the
+    # consumer's item did not run" — and for a new owner that is produced by TWO things: the
+    # new item taking the call, which is the verdict, and an item of the same name the SUBJECT
+    # ALREADY CARRIED taking it, which measures nothing. Measured on the branch that found
+    # this: `RecoveryState` is new and declares `is_valid`/`is_error`/`is_missing`, `Ident` has
+    # carried inherent `is_valid`/`is_error`/`is_missing` since before the base ref, and an
+    # inherent item outranks every trait item at the same step. Three rows compiled, ran,
+    # reported `witness=0` and scored `new-owner` over a call that went to a method the base
+    # ref already had. Not one of the four witnesses above disagrees with any of them.
+    #
+    # rustc says it out loud, which is what makes this a check and not a taste: an import that
+    # resolved and was never needed is `unused import`. If the head side reports THIS ROW'S
+    # OWNER unused, tokora's item on that owner was not a candidate, whatever the witness
+    # reads. That is the README's rule — enumerate what else could produce this evidence and
+    # exclude each — applied to `witness=0`: the alternative producer is removed rather than
+    # the witness complicated.
+    #
+    # It bills the generator for one thing and the templates must keep paying it: an owner's
+    # import may NOT carry `#[allow(unused_imports)]`. A suppressed warning is a witness that
+    # cannot fire, and every false green in this file's history was asserted by an absence.
+    owner_unused=""
+    grep -E "(^|[^A-Za-z0-9_])$owner([^A-Za-z0-9_]|$)" "$WORK/out-head.txt" 2>/dev/null \
+      | grep -q "unused import" && owner_unused=yes
+    # The head side's LOUD evidence. `new-owner` took exactly ONE head-side shape as proof that
+    # a collision was constructed — `witness=0`, the silent steal — and a trait method taking
+    # `&self` cannot produce it. The `trait_method` spellings put the consumer's item one pick
+    # EARLIER (`self`, by value) or at the SAME pick (`&self`); there is no LATER pick among
+    # them, so the outcomes are "the consumer wins" and "rustc refuses to choose". The refusal
+    # is E0034, it names the probed item and both candidate impls, and it is strictly stronger
+    # evidence than `witness=0` — the compiler REPORTING the collision rather than taking it.
+    # Classified as bare `no-compile` it scored INCONCL, so ten of one release's fourteen trait
+    # rows were filed "broken probe" over rustc naming the exact collision they were built for.
+    #
+    # The witness is `glob-err`'s, moved from the glob level to the item level — but NOT its
+    # implementation, and the difference is measured rather than assumed. `glob-err` pipes the
+    # name-matching lines into an ambiguity-wording test, i.e. both on ONE line, which is how
+    # E0659 prints: "`X` is ambiguous". E0034 does not: the code is on the header line, the name
+    # is on the label line, and the owner is on a candidate note. Written as one pipe this test
+    # matched nothing and every rejected row stayed INCONCL.
+    #
+    # So it is three conditions over the whole head log, each of them rustc's own words about
+    # THIS row, and all three required:
+    #
+    #   * the error KIND — E0034 / "multiple applicable items in scope";
+    #   * the ambiguity's own label naming this row's ITEM — "multiple `<name>` found";
+    #   * a candidate note naming this row's OWNER — which is the half that proves TOKORA's item
+    #     was one of the two candidates rather than some other pair of the same name.
+    #
+    # Together they exclude what the README's rule asks to be excluded: a head build that broke
+    # elsewhere (no E0034), an ambiguity about a different name (no label), and an ambiguity
+    # between two candidates neither of which is tokora's (no owner note). Cargo naming the probe
+    # crate is already required to reach `no-compile` at all, so a dependency cannot get here.
+    #
+    # If a future rustc rewords any of the three, rows go INCONCL and the gate reds. That is the
+    # right direction for a wording dependency to fail, and it is why this is three tests rather
+    # than one loose one.
+    head_rejected=""
+    if grep -qE "E0034|multiple applicable items in scope" "$WORK/out-head.txt" 2>/dev/null \
+       && grep -qE "multiple \`$name\` found" "$WORK/out-head.txt" 2>/dev/null \
+       && grep -E "candidate #[0-9]+ is defined in an impl of the trait" "$WORK/out-head.txt" \
+            2>/dev/null \
+          | grep -qE "(^|[^A-Za-z0-9_])$owner([^A-Za-z0-9_]|$)"; then
+      head_rejected=yes
+    fi
     if [ -n "$base_unresolved" ] && [ -z "$head_unresolved" ]; then
       case "$h" in
         witness=0*)
-          printf "  new-owner %-40s base=%-12s head=%s   (owner \`%s\` is new)\n" \
-            "$label" "$b" "$h" "$owner"
-          echo "          rustc cannot resolve \`$owner\` on the base ref and can on head, so this"
-          echo "          release introduces the owner as well as the name. There is no consumer"
-          echo "          call site that could predate it and nothing to steal."
-          newowner=$((newowner + 1))
+          if [ -n "$owner_unused" ]; then
+            printf "  INCONCL %-42s base=%-12s head=%s\n" "$label" "$b" "$h"
+            echo "          head reports the import of \`$owner\` UNUSED, so tokora's item on it was"
+            echo "          never a candidate: the call went to an item of this name the SUBJECT"
+            echo "          already carried, which the base ref has too. \`witness=0\` says only that"
+            echo "          the CONSUMER's item did not run, and that is all it says here. Give the"
+            echo "          row a subject carrying no pre-existing item of this name."
+            incon=$((incon + 1))
+            status=2
+          else
+            printf "  new-owner %-40s base=%-12s head=%s   (owner \`%s\` is new)\n" \
+              "$label" "$b" "$h" "$owner"
+            echo "          rustc cannot resolve \`$owner\` on the base ref and can on head, so this"
+            echo "          release introduces the owner as well as the name. There is no consumer"
+            echo "          call site that could predate it and nothing to steal."
+            newowner=$((newowner + 1))
+          fi
           ;;
         witness=*)
-          printf "  INCONCL %-42s base=%-12s head=%s\n" "$label" "$b" "$h"
-          echo "          head completed a run and resolved \`$owner\`, but \`$h\` is"
-          echo "          CONSUMER-CALLS, not existence: a nonzero count means the CONSUMER's"
-          echo "          own item took the call, so tokora's new \`$owner\` item was never a"
-          echo "          candidate this run. This proves the probe compiles, not that a"
-          echo "          collision exists."
-          incon=$((incon + 1))
-          status=2
+          # The consumer's item won the walk. For a PRE-EXISTING owner that is the `ok*` shape
+          # below — agreement, justified in writing by the pick order — and it is the SAME fact
+          # here, stated about one side because a new owner has no second one. It is a claim
+          # about the RECEIVER KINDS these templates declare, not about the name, so it is
+          # justified in the same file and staleness-checked by the same reconciliation.
+          if grep -qxF "$label" "$NOCOLLIDE"; then
+            printf "  new-owner-nc* %-36s base=%-12s head=%s   (earlier pick, justified)\n" \
+              "$label" "$b" "$h"
+            echo "          \`$owner\` is unresolved on base, so no call site predates the name; on"
+            echo "          head the CONSUMER's item claims the call at an EARLIER pick and"
+            echo "          tokora's is never a candidate. No collision is constructed at this"
+            echo "          spelling, and no_collision.txt states the pick order that does it."
+            seen_nocollide="$seen_nocollide $label"
+            newownernc=$((newownernc + 1))
+          else
+            printf "  INCONCL %-42s base=%-12s head=%s\n" "$label" "$b" "$h"
+            echo "          head completed a run and resolved \`$owner\`, but \`$h\` is"
+            echo "          CONSUMER-CALLS, not existence: a nonzero count means the CONSUMER's"
+            echo "          own item took the call, so tokora's new \`$owner\` item was never a"
+            echo "          candidate this run. This proves the probe compiles, not that a"
+            echo "          collision exists. If the receiver kinds make that the only outcome"
+            echo "          this spelling can have, state that pick order in no_collision.txt."
+            incon=$((incon + 1))
+            status=2
+          fi
+          ;;
+        no-compile)
+          if [ -n "$head_rejected" ]; then
+            printf "  new-owner-err %-36s base=%-12s head=%s   (collision rejected)\n" \
+              "$label" "$b" "$h"
+            echo "          rustc cannot resolve \`$owner\` on the base ref, so no consumer call"
+            echo "          site predates the name; on head it names \`$name\` and REFUSES to"
+            echo "          choose between the candidates. The collision is real and reported —"
+            echo "          the disclosed outcome, one side at a time."
+            newownererr=$((newownererr + 1))
+          else
+            printf "  INCONCL %-42s base=%-12s head=%s\n" "$label" "$b" "$h"
+            echo "          the owner \`$owner\` is unresolved on the BASE side and head does not"
+            echo "          repeat that diagnostic — but head failed to build and NO diagnostic"
+            echo "          names \`$name\` ambiguously, so head broke for a reason that is not"
+            echo "          this collision. A broken probe on the side that was supposed to"
+            echo "          prove the owner is new, not a clean result."
+            incon=$((incon + 1))
+            status=2
+          fi
           ;;
         *)
           printf "  INCONCL %-42s base=%-12s head=%s\n" "$label" "$b" "$h"
@@ -629,7 +757,11 @@ while IFS=$(printf '\t') read -r cat name owner spelling; do
   fi
 done < "$WORK/plan.tsv"
 
-echo "name-collision: $total probe(s) — $okc justified-no-collision, $loud loud, $silent silent ($newsilent undisclosed), $newowner owner-introduced-here, $incon inconclusive, $unprobed UNPROBED, $fatal FATAL; globs: $globerr rejected, $globok not-rejected"
+# `owner-introduced-here` is the TOTAL of the three shapes a new owner can reach, with the two
+# that are not silent steals named in the parenthetical — the same convention as
+# `silent (N undisclosed)`, where the bracket is a subset and the remainder is the plain case.
+newownerall=$((newowner + newownererr + newownernc))
+echo "name-collision: $total probe(s) — $okc justified-no-collision, $loud loud, $silent silent ($newsilent undisclosed), $newownerall owner-introduced-here ($newownererr rejected, $newownernc earlier-pick), $incon inconclusive, $unprobed UNPROBED, $fatal FATAL; globs: $globerr rejected, $globok not-rejected"
 
 # A baseline entry that no longer reproduces is stale. Left unchecked it becomes a rubber
 # stamp for a probe that stopped running at all — the failure mode of every allowlist.
@@ -710,6 +842,18 @@ elif [ "$newsilent" -eq 0 ] && [ "$unprobed" -eq 0 ]; then
   echo "name-collision:   * a new-owner row says only that no call site could PREDATE the"
   echo "name-collision:     name. A two-sided delta cannot speak about a consumer written"
   echo "name-collision:     after the release, on either side of that line."
+  echo "name-collision:   * new-owner-err says rustc REFUSED this probe's collision, not that"
+  echo "name-collision:     the name cannot be taken silently. The trait spellings declare"
+  echo "name-collision:     \`self\` and \`&self\`, which against a tokora \`&self\` item are the"
+  echo "name-collision:     EARLIER pick and the SAME pick; the \`&mut self\` consumer that"
+  echo "name-collision:     would sit at a LATER one and lose the call quietly is a shape"
+  echo "name-collision:     these templates do not generate. So on such an owner the silent"
+  echo "name-collision:     new-owner verdict is unreachable BY CONSTRUCTION, and a run of"
+  echo "name-collision:     new-owner-err rows is not evidence that no silent shape exists."
+  echo "name-collision:   * new-owner-nc* is a statement about RECEIVER KINDS, not about the"
+  echo "name-collision:     name: the by-value consumer keeps its call. The same names go"
+  echo "name-collision:     loud the moment the consumer writes \`&self\`, which is what the"
+  echo "name-collision:     new-owner-err rows on those same names report."
   echo "name-collision: This is a regression detector, not a proof of absence."
 fi
 exit "$status"

--- a/tokora/src/error/invalid_hex_digits.rs
+++ b/tokora/src/error/invalid_hex_digits.rs
@@ -29,56 +29,181 @@
 
 use core::ops::AddAssign;
 
-use generic_arraydeque::{ConstArrayLength, GenericArrayDeque, IntoArrayLength, typenum::Const};
+use generic_arraydeque::{GenericArrayDeque, IntoArrayLength, typenum::Const};
 
 use crate::utils::{PositionedChar, human_display::DisplayHuman};
 
-/// A zero-copy container for storing invalid hex digit characters.
+pub use store::InvalidHexDigits;
+
+/// The backing ring, and the only code in the crate that can reach it.
 ///
-/// This structure uses const generics to specify the maximum number of invalid
-/// characters it can hold. When parsing hex escape sequences fails, this container
-/// holds the invalid characters encountered (up to `N`) with their positions,
-/// enabling precise error reporting without heap allocation.
+/// [`InvalidHexDigits`] is declared here rather than in the parent module so that its field is
+/// *unreachable* from the parent: a private field is visible in the module that declares the
+/// struct and in that module's descendants, and the parent module is neither. Every operation
+/// the parent performs on the ring therefore goes through one of the doors below, and the door
+/// that can move the head is the door that restores contiguity.
 ///
-/// # Design
+/// # The property this protects
 ///
-/// The container wraps [`GenericArrayDeque`] which provides stack-based storage optimized
-/// for small sizes. It implements `Deref<Target = [PositionedChar<Char>]>` for
-/// convenient access to the stored characters.
+/// The parent hands out `&[PositionedChar<Char, O>]` through [`Deref`](core::ops::Deref), whose
+/// receiver is `&self` by trait definition. A shared borrow cannot normalize a ring, and one
+/// `&[T]` cannot describe two physical segments, so a shared reader can only return the ring's
+/// first segment — which is the whole set exactly while the head is at zero. Handing out that
+/// first segment as if it were the whole set is the shape tokora#245 fixed in `IncompleteSyntax`
+/// and tokora#280 found latent here.
 ///
-/// # Examples
+/// Today the head is at zero because the only mutation is an append. But that is a property of
+/// a method list, and a method list is not a type: a `pop_front`, `remove`, `rotate_left` or any
+/// other head-moving operation added later would silently turn the shared reader into a
+/// truncating one, three read sites away from the method that caused it, and two of those sites
+/// do not name `as_slices` at all.
 ///
-/// ## For Hex Escapes (N=2)
-///
-/// ```
-/// use tokora::error::InvalidHexDigits;
-/// use tokora::utils::PositionedChar;
-///
-/// // Hex escapes need max 2 digits
-/// let mut digits: InvalidHexDigits<char, 2> = InvalidHexDigits::from_positioned_char(PositionedChar::with_position('G', 12));
-/// digits.push(PositionedChar::with_position('H', 13));
-/// assert_eq!(digits.len(), 2);
-/// ```
-///
-/// ## For Unicode Escapes (N=4)
-///
-/// ```
-/// use tokora::error::InvalidHexDigits;
-/// use tokora::utils::PositionedChar;
-///
-/// // Unicode escapes need max 4 digits
-/// let mut digits: InvalidHexDigits<char, 4> = InvalidHexDigits::from_positioned_char(PositionedChar::with_position('G', 12));
-/// digits.push(PositionedChar::with_position('H', 13));
-/// digits.push(PositionedChar::with_position('I', 14));
-/// digits.push(PositionedChar::with_position('J', 15));
-/// assert_eq!(digits.len(), 4);
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct InvalidHexDigits<Char, const N: usize, O = usize>(
-  GenericArrayDeque<PositionedChar<Char, O>, ConstArrayLength<N>>,
-)
-where
-  Const<N>: IntoArrayLength;
+/// So the head-moving operations are not forbidden here, they are *funnelled*: such a method
+/// cannot be written without `InvalidHexDigits::with_ring`, and `with_ring` re-establishes
+/// contiguity on every exit from the closure, the unwinding one included. A contributor who
+/// reaches for `self.0.pop_front()` in the parent module gets a private-field error rather than
+/// a latent reintroduction of #245.
+mod store {
+  use generic_arraydeque::{
+    ArrayLength, ConstArrayLength, GenericArrayDeque, IntoArrayLength, typenum::Const,
+  };
+
+  use crate::utils::PositionedChar;
+
+  /// A zero-copy container for storing invalid hex digit characters.
+  ///
+  /// This structure uses const generics to specify the maximum number of invalid
+  /// characters it can hold. When parsing hex escape sequences fails, this container
+  /// holds the invalid characters encountered (up to `N`) with their positions,
+  /// enabling precise error reporting without heap allocation.
+  ///
+  /// # Design
+  ///
+  /// The container wraps [`GenericArrayDeque`] which provides stack-based storage optimized
+  /// for small sizes. It implements `Deref<Target = [PositionedChar<Char>]>` for
+  /// convenient access to the stored characters, and that accessor reports **every** stored
+  /// character rather than a physical prefix of them — see the module this type is declared in
+  /// for how the ring is kept in one segment.
+  ///
+  /// # Examples
+  ///
+  /// ## For Hex Escapes (N=2)
+  ///
+  /// ```
+  /// use tokora::error::InvalidHexDigits;
+  /// use tokora::utils::PositionedChar;
+  ///
+  /// // Hex escapes need max 2 digits
+  /// let mut digits: InvalidHexDigits<char, 2> = InvalidHexDigits::from_positioned_char(PositionedChar::with_position('G', 12));
+  /// digits.push(PositionedChar::with_position('H', 13));
+  /// assert_eq!(digits.len(), 2);
+  /// ```
+  ///
+  /// ## For Unicode Escapes (N=4)
+  ///
+  /// ```
+  /// use tokora::error::InvalidHexDigits;
+  /// use tokora::utils::PositionedChar;
+  ///
+  /// // Unicode escapes need max 4 digits
+  /// let mut digits: InvalidHexDigits<char, 4> = InvalidHexDigits::from_positioned_char(PositionedChar::with_position('G', 12));
+  /// digits.push(PositionedChar::with_position('H', 13));
+  /// digits.push(PositionedChar::with_position('I', 14));
+  /// digits.push(PositionedChar::with_position('J', 15));
+  /// assert_eq!(digits.len(), 4);
+  /// ```
+  #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+  pub struct InvalidHexDigits<Char, const N: usize, O = usize>(
+    GenericArrayDeque<PositionedChar<Char, O>, ConstArrayLength<N>>,
+  )
+  where
+    Const<N>: IntoArrayLength;
+
+  /// Restores contiguity when an exclusive borrow of the ring ends, on **every** exit path.
+  ///
+  /// A normalization that only runs where the closure returns normally is not a postcondition:
+  /// an unwind out of a caller-supplied closure — a panicking `retain` predicate, say — would
+  /// leave the ring wrapped and every later shared read silently short. `Drop` is what makes
+  /// the two paths the same path.
+  struct Normalized<'ring, T, N: ArrayLength>(&'ring mut GenericArrayDeque<T, N>);
+
+  impl<T, N: ArrayLength> Drop for Normalized<'_, T, N> {
+    #[inline]
+    fn drop(&mut self) {
+      self.0.make_contiguous();
+    }
+  }
+
+  impl<Char, const N: usize, O> InvalidHexDigits<Char, N, O>
+  where
+    Const<N>: IntoArrayLength,
+  {
+    /// Wraps a ring, contiguous, whatever the caller handed over.
+    #[inline]
+    pub(super) fn from_ring(
+      ring: GenericArrayDeque<PositionedChar<Char, O>, ConstArrayLength<N>>,
+    ) -> Self {
+      let mut this = Self(ring);
+      this.0.make_contiguous();
+      this
+    }
+
+    /// The only exclusive door to the ring, and therefore the only place a future head-moving
+    /// operation can be written.
+    ///
+    /// The closure's argument is higher-ranked, so no borrow of the ring — and in particular no
+    /// borrow of one of its two physical segments — outlives the call.
+    #[inline]
+    pub(super) fn with_ring<R>(
+      &mut self,
+      f: impl FnOnce(&mut GenericArrayDeque<PositionedChar<Char, O>, ConstArrayLength<N>>) -> R,
+    ) -> R {
+      let guard = Normalized(&mut self.0);
+      f(&mut *guard.0)
+    }
+
+    /// Every stored digit, by shared reference.
+    ///
+    /// This is the read that cannot normalize anything, so it is the read that depends on the
+    /// funnel above having done it. The assertion is where that dependency is checked: if an
+    /// insertion or removal path is ever added that leaves the ring wrapped, this accessor is
+    /// the one that would silently report a prefix, so this is where it says so.
+    #[inline]
+    pub(super) fn digits(&self) -> &[PositionedChar<Char, O>] {
+      let (contiguous, wrapped) = self.0.as_slices();
+      debug_assert!(
+        wrapped.is_empty(),
+        "InvalidHexDigits: the digit ring is wrapped, so this accessor is about to report \
+         {} of {} digits — a mutation path bypassed `with_ring`",
+        contiguous.len(),
+        self.0.len(),
+      );
+      contiguous
+    }
+
+    /// Every stored digit, by exclusive reference.
+    ///
+    /// Unlike `digits` this one owes nothing to the funnel: `make_contiguous`
+    /// *is* the normalization, so the slice it returns is the whole ring by construction
+    /// whatever state the ring was in.
+    #[inline]
+    pub(super) fn digits_mut(&mut self) -> &mut [PositionedChar<Char, O>] {
+      self.0.make_contiguous()
+    }
+
+    /// The number of stored digits. A shared read that does not depend on contiguity.
+    #[inline]
+    pub(super) const fn stored(&self) -> usize {
+      self.0.len()
+    }
+
+    /// Whether the ring is at capacity. A shared read that does not depend on contiguity.
+    #[inline]
+    pub(super) const fn saturated(&self) -> bool {
+      self.0.is_full()
+    }
+  }
+}
 
 impl<Char, const N: usize, O> core::fmt::Display for InvalidHexDigits<Char, N, O>
 where
@@ -148,7 +273,7 @@ where
 
     let mut vec = GenericArrayDeque::new();
     vec.push_back(ch);
-    Self(vec)
+    Self::from_ring(vec)
   }
 
   /// Creates a new `InvalidHexDigits` containing a single invalid digit.
@@ -183,7 +308,7 @@ where
   /// assert_eq!(digits.len(), 2);
   /// ```
   pub fn from_array(chars: [PositionedChar<Char, O>; N]) -> Self {
-    Self(GenericArrayDeque::from_array(chars))
+    Self::from_ring(GenericArrayDeque::from_array(chars))
   }
 
   /// Creates a new `InvalidHexDigits` from an iterator.
@@ -210,7 +335,9 @@ where
   where
     I: IntoIterator<Item = PositionedChar<Char, O>>,
   {
-    GenericArrayDeque::try_from_iter(iter).map(Self).ok()
+    GenericArrayDeque::try_from_iter(iter)
+      .map(Self::from_ring)
+      .ok()
   }
 
   /// Pushes an invalid hex digit to the container.
@@ -229,7 +356,7 @@ where
   /// ```
   #[inline]
   pub fn push(&mut self, ch: PositionedChar<Char, O>) -> bool {
-    self.0.push_back(ch).is_none()
+    self.with_ring(|ring| ring.push_back(ch)).is_none()
   }
 
   /// Pushes an invalid hex digit to the container.
@@ -269,7 +396,7 @@ where
   #[inline]
   #[allow(clippy::len_without_is_empty)]
   pub const fn len(&self) -> usize {
-    self.0.len()
+    self.stored()
   }
 
   /// Returns `true` if the container is at maximum capacity.
@@ -287,13 +414,17 @@ where
   /// ```
   #[inline]
   pub const fn is_full(&self) -> bool {
-    self.0.is_full()
+    self.saturated()
   }
 
   /// Bumps the position of all stored characters by `n`.
   ///
   /// This is useful when adjusting error positions after processing or
   /// when combining errors from different parsing contexts.
+  ///
+  /// Reads the whole ring rather than its first physical segment. The receiver is exclusive,
+  /// so this site normalizes instead of assuming — which is what the two reads it replaced
+  /// could not do, and why tokora#280 found them.
   ///
   /// ## Examples
   ///
@@ -312,11 +443,8 @@ where
   where
     O: for<'a> AddAssign<&'a O>,
   {
-    let mut idx = 0;
-    let slice = self.0.as_mut_slices().0;
-    while idx < slice.len() {
-      slice[idx].bump_position(n);
-      idx += 1;
+    for ch in self.digits_mut() {
+      ch.bump_position(n);
     }
     self
   }
@@ -350,7 +478,7 @@ where
 
   #[inline]
   fn deref(&self) -> &Self::Target {
-    self.0.as_slices().0
+    self.digits()
   }
 }
 
@@ -360,6 +488,6 @@ where
 {
   #[inline]
   fn deref_mut(&mut self) -> &mut Self::Target {
-    self.0.as_mut_slices().0
+    self.digits_mut()
   }
 }

--- a/tokora/src/error/mod.rs
+++ b/tokora/src/error/mod.rs
@@ -227,7 +227,7 @@ mod unicode_escape;
 ///
 /// A **carrier** type — one with fields of its own, such as [`Ident`](crate::types::Ident),
 /// [`Keyword`](crate::types::Keyword) or the `Lit*` family — must instead hold the state in a
-/// field and report it through [`RecoveryState`](crate::types::RecoveryState), because a carrier's
+/// field and report it through [`RecoveryState`](crate::types::recovery::RecoveryState), because a carrier's
 /// payload is generic and publicly mutable: a caller can spell `"<error>"` by hand, and can
 /// edit a placeholder's payload afterwards, so comparing the payload against a sentinel answers
 /// *what does this node say* and never *did the parser find one here*. A carrier that

--- a/tokora/src/error/mod.rs
+++ b/tokora/src/error/mod.rs
@@ -203,11 +203,11 @@ mod unicode_escape;
 /// fn report_errors(ast: &Program) {
 ///     for node in ast.nodes() {
 ///         match node {
-///             Node::Identifier(id) if id.0 == "<error>" => {
+///             Node::Identifier(id) if id.is_error() => {
 ///                 eprintln!("error: malformed identifier at {:?}", node.span());
 ///                 eprintln!("help: identifiers cannot start with digits");
 ///             }
-///             Node::Identifier(id) if id.0 == "<missing>" => {
+///             Node::Identifier(id) if id.is_missing() => {
 ///                 eprintln!("error: expected identifier at {:?}", node.span());
 ///                 eprintln!("help: insert a name here");
 ///             }
@@ -219,9 +219,25 @@ mod unicode_escape;
 ///
 /// # Best Practices
 ///
+/// ## Two Shapes of Implementor, and Only One of Them May Use a Sentinel
+///
+/// A **payload** type — `&str`, `&[u8]`, an interned handle — has nowhere to put a recovery
+/// state, so its placeholder *is* a sentinel value: the impls below produce `"<error>"` and
+/// `"<missing>"`. That is the whole of what such an impl can promise.
+///
+/// A **carrier** type — one with fields of its own, such as [`Ident`](crate::types::Ident),
+/// [`Keyword`](crate::types::Keyword) or the `Lit*` family — must instead hold the state in a
+/// field and report it through `is_valid` / `is_error` / `is_missing`, because a carrier's
+/// payload is generic and publicly mutable: a caller can spell `"<error>"` by hand, and can
+/// edit a placeholder's payload afterwards, so comparing the payload against a sentinel answers
+/// *what does this node say* and never *did the parser find one here*. A carrier that
+/// implements this trait with no such field advertises two states it cannot represent — that
+/// was tokora#301, and the constructors below are where the state is set, not merely where a
+/// marker is chosen.
+///
 /// ## Use Consistent Sentinel Values
 ///
-/// Choose recognizable placeholder values that:
+/// For a payload type, choose recognizable placeholder values that:
 /// - Cannot occur in valid source code
 /// - Are easy to detect in downstream passes
 /// - Clearly indicate error vs missing

--- a/tokora/src/error/mod.rs
+++ b/tokora/src/error/mod.rs
@@ -227,7 +227,7 @@ mod unicode_escape;
 ///
 /// A **carrier** type — one with fields of its own, such as [`Ident`](crate::types::Ident),
 /// [`Keyword`](crate::types::Keyword) or the `Lit*` family — must instead hold the state in a
-/// field and report it through `is_valid` / `is_error` / `is_missing`, because a carrier's
+/// field and report it through [`RecoveryState`](crate::types::RecoveryState), because a carrier's
 /// payload is generic and publicly mutable: a caller can spell `"<error>"` by hand, and can
 /// edit a placeholder's payload afterwards, so comparing the payload against a sentinel answers
 /// *what does this node say* and never *did the parser find one here*. A carrier that

--- a/tokora/src/error/mod.rs
+++ b/tokora/src/error/mod.rs
@@ -227,7 +227,7 @@ mod unicode_escape;
 ///
 /// A **carrier** type — one with fields of its own, such as [`Ident`](crate::types::Ident),
 /// [`Keyword`](crate::types::Keyword) or the `Lit*` family — must instead hold the state in a
-/// field and report it through [`RecoveryState`](crate::types::recovery::RecoveryState), because a carrier's
+/// field and report it through [`RecoveryState`](crate::types::RecoveryState), because a carrier's
 /// payload is generic and publicly mutable: a caller can spell `"<error>"` by hand, and can
 /// edit a placeholder's payload afterwards, so comparing the payload against a sentinel answers
 /// *what does this node say* and never *did the parser find one here*. A carrier that

--- a/tokora/src/guide/ref_types_syntax.md
+++ b/tokora/src/guide/ref_types_syntax.md
@@ -142,7 +142,8 @@ impl<S, Span, Lang> Ident<S, Span, Lang> {
 // `unsafe { zeroed() }` infers as the consumer's status before the upgrade and as tokora's
 // after, both compile, and a zero-valued rejection becomes Valid.
 impl FromComponents for Ident<..> { fn from_components(c: Self::Components) -> Self; }
-//                                  // exactly the inverse of into_components
+// Components is a NAMED STRUCT { span, payload, status }, not a 3-tuple: `let (_, .., v) = ..`
+// binds the payload against a pair and the status against a triple, and both compile.
 
 // The recovery state is read through a trait, and ONLY through it — there is no inherent
 // accessor of any name, because an inherent one can be displaced by a consumer's extension
@@ -165,7 +166,7 @@ impl RecoveryState for Ident<..> { fn status(&self) -> Status;
 use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, Keyword}, utils::IntoComponents};
 // `RecoveryState` is NOT in `types::*` — a trait reached through a glob can be rebound by a
 // second glob with only a warning, so it has to be named:
-use tokora::types::recovery::{FromComponents, RecoveryState};
+use tokora::types::recovery::{Components, FromComponents, RecoveryState};
 
 struct MyLang;
 
@@ -187,14 +188,14 @@ assert_eq!(as_ident.source_ref(), &"let");
 // Both destructure via `IntoComponents`, into span, payload AND status. The status is in the
 // tuple because `FromComponents` is the inverse: rebuilding through `new` would declare a
 // recovered node valid, which is the laundering the three-part decomposition exists to prevent.
-let (span, source, status) = ident.into_components();
-let upper = Ident::<&str, SimpleSpan, MyLang>::from_components((span, source, status))
+let Components { span, payload, status } = ident.into_components();
+let upper = Ident::<&str, SimpleSpan, MyLang>::from_components(Components { span, payload, status })
     .map(|s| s.to_uppercase());
 assert_eq!(upper.source_ref(), "MY_VAR");
 assert!(upper.is_valid());
 
-let (span, source, status) = bad.into_components();
-assert!(Ident::<&str, SimpleSpan, MyLang>::from_components((span, source, status)).is_error());
+let parts = bad.into_components();
+assert!(Ident::<&str, SimpleSpan, MyLang>::from_components(parts).is_error());
 ```
 
 Both also have real combinator entry points, not just bare constructors. Once the token type opts

--- a/tokora/src/guide/ref_types_syntax.md
+++ b/tokora/src/guide/ref_types_syntax.md
@@ -134,16 +134,20 @@ impl<S, Span, Lang> Ident<S, Span, Lang> {
     const fn span(&self) -> Span where Span: Copy;        // + span_ref / span_mut
     const fn source(&self) -> S where S: Copy;             // + source_ref / source_mut
     fn bump(&mut self, by: &Span::Offset) -> &mut Self where Span: crate::Span;
-    const fn is_valid/is_error/is_missing(&self) -> bool;  // recovery status (Ident only)
+    const fn with_status(span: Span, source: S, status: Status) -> Self;
+    const fn is_valid/is_error/is_missing(&self) -> bool;  // the recovery status
+    fn bump(&mut self, by: &Span::Offset) -> &mut Self where Span: crate::Span;
     fn map<U>(self, f: impl FnOnce(S) -> U) -> Ident<U, Span, Lang>;
 }
-// Keyword has the same new/span*/source*/map, but no is_valid/is_error/is_missing and no bump —
-// it carries no status of its own, and converts into `Ident` for free via `From`.
+// Keyword has the same new/with_status/span*/source*/map and the same three predicates — it
+// carries the same status, so converting into `Ident` via `From` carries it across rather than
+// declaring the result valid. `bump` is Ident's alone. Every `Lit*` type carries it too.
 ```
 
 ```rust
 use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, Keyword}, utils::IntoComponents};
 
+#[derive(Debug, PartialEq)]
 struct MyLang;
 
 let ident = Ident::<&str, SimpleSpan, MyLang>::new(SimpleSpan::new(5, 11), "my_var");
@@ -161,10 +165,17 @@ let kw = Keyword::<&str, SimpleSpan, MyLang>::new(SimpleSpan::new(0, 3), "let");
 let as_ident: Ident<&str, SimpleSpan, MyLang> = kw.into();
 assert_eq!(as_ident.source_ref(), &"let");
 
-// Both destructure via `IntoComponents`; `.map` transforms the payload in place.
-let (span, source) = ident.into_components();
-let upper = Ident::<&str, SimpleSpan, MyLang>::new(span, source).map(|s| s.to_uppercase());
+// Both destructure via `IntoComponents`, into span, payload AND status. The status is in the
+// tuple because `with_status` is the inverse: rebuilding through `new` would declare a recovered
+// node valid, which is the laundering the three-part decomposition exists to prevent.
+let (span, source, status) = ident.into_components();
+let upper = Ident::<&str, SimpleSpan, MyLang>::with_status(span, source, status)
+    .map(|s| s.to_uppercase());
 assert_eq!(upper.source_ref(), "MY_VAR");
+assert!(upper.is_valid());
+
+let (span, source, status) = bad.into_components();
+assert!(Ident::<&str, SimpleSpan, MyLang>::with_status(span, source, status).is_error());
 ```
 
 Both also have real combinator entry points, not just bare constructors. Once the token type opts
@@ -182,8 +193,8 @@ Keyword::<(), ()>::try_parse(inp) -> Result<ParseAttempt<Keyword<L::Token, L::Sp
 ```
 
 [`IdentList<S, Span = SimpleSpan, Container = Vec<Ident<S, Span>>, Lang: ?Sized = ()>`](crate::types::IdentList)
-aggregates already-parsed identifiers. It has no status of its own — `is_valid`/`is_error`/
-`is_missing` scan the elements on every call:
+aggregates already-parsed identifiers. It stores no status of its own — `is_valid`/`is_error`/
+`is_missing` scan the elements on every call, so the list's answer is its segments':
 
 ```rust
 use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, IdentList}};

--- a/tokora/src/guide/ref_types_syntax.md
+++ b/tokora/src/guide/ref_types_syntax.md
@@ -166,7 +166,7 @@ impl RecoveryState for Ident<..> { fn status(&self) -> Status;
 use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, Keyword}, utils::IntoComponents};
 // `RecoveryState` is NOT in `types::*` — a trait reached through a glob can be rebound by a
 // second glob with only a warning, so it has to be named:
-use tokora::types::recovery::{Components, FromComponents, RecoveryState};
+use tokora::types::{Components, FromComponents, RecoveryState};
 
 struct MyLang;
 

--- a/tokora/src/guide/ref_types_syntax.md
+++ b/tokora/src/guide/ref_types_syntax.md
@@ -131,12 +131,18 @@ Read the parameter's *name*, not just its letter.
 ```text
 impl<S, Span, Lang> Ident<S, Span, Lang> {
     const fn new(span: Span, source: S) -> Self;           // status: Valid
-    const fn with_status(span: Span, source: S, status: Status) -> Self;
     const fn span(&self) -> Span where Span: Copy;         // + span_ref / span_mut
     const fn source(&self) -> S where S: Copy;             // + source_ref / source_mut
     fn bump(&mut self, by: &Span::Offset) -> &mut Self where Span: crate::Span;
     fn map<U>(self, f: impl FnOnce(S) -> U) -> Ident<U, Span, Lang>;
 }
+
+// Construction WITH a chosen status is a trait method too, and for the same reason: an inherent
+// `with_status(.., Status)` captures a type-directed argument — an unchanged
+// `unsafe { zeroed() }` infers as the consumer's status before the upgrade and as tokora's
+// after, both compile, and a zero-valued rejection becomes Valid.
+impl FromComponents for Ident<..> { fn from_components(c: Self::Components) -> Self; }
+//                                  // exactly the inverse of into_components
 
 // The recovery state is read through a trait, and ONLY through it — there is no inherent
 // accessor of any name, because an inherent one can be displaced by a consumer's extension
@@ -159,7 +165,7 @@ impl RecoveryState for Ident<..> { fn status(&self) -> Status;
 use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, Keyword}, utils::IntoComponents};
 // `RecoveryState` is NOT in `types::*` — a trait reached through a glob can be rebound by a
 // second glob with only a warning, so it has to be named:
-use tokora::types::recovery::RecoveryState;
+use tokora::types::recovery::{FromComponents, RecoveryState};
 
 struct MyLang;
 
@@ -179,16 +185,16 @@ let as_ident: Ident<&str, SimpleSpan, MyLang> = kw.into();
 assert_eq!(as_ident.source_ref(), &"let");
 
 // Both destructure via `IntoComponents`, into span, payload AND status. The status is in the
-// tuple because `with_status` is the inverse: rebuilding through `new` would declare a recovered
-// node valid, which is the laundering the three-part decomposition exists to prevent.
+// tuple because `FromComponents` is the inverse: rebuilding through `new` would declare a
+// recovered node valid, which is the laundering the three-part decomposition exists to prevent.
 let (span, source, status) = ident.into_components();
-let upper = Ident::<&str, SimpleSpan, MyLang>::with_status(span, source, status)
+let upper = Ident::<&str, SimpleSpan, MyLang>::from_components((span, source, status))
     .map(|s| s.to_uppercase());
 assert_eq!(upper.source_ref(), "MY_VAR");
 assert!(upper.is_valid());
 
 let (span, source, status) = bad.into_components();
-assert!(Ident::<&str, SimpleSpan, MyLang>::with_status(span, source, status).is_error());
+assert!(Ident::<&str, SimpleSpan, MyLang>::from_components((span, source, status)).is_error());
 ```
 
 Both also have real combinator entry points, not just bare constructors. Once the token type opts

--- a/tokora/src/guide/ref_types_syntax.md
+++ b/tokora/src/guide/ref_types_syntax.md
@@ -130,22 +130,30 @@ Read the parameter's *name*, not just its letter.
 
 ```text
 impl<S, Span, Lang> Ident<S, Span, Lang> {
-    const fn new(span: Span, source: S) -> Self;
-    const fn span(&self) -> Span where Span: Copy;        // + span_ref / span_mut
-    const fn source(&self) -> S where S: Copy;             // + source_ref / source_mut
-    fn bump(&mut self, by: &Span::Offset) -> &mut Self where Span: crate::Span;
+    const fn new(span: Span, source: S) -> Self;           // status: Valid
     const fn with_status(span: Span, source: S, status: Status) -> Self;
-    const fn is_valid/is_error/is_missing(&self) -> bool;  // the recovery status
+    const fn span(&self) -> Span where Span: Copy;         // + span_ref / span_mut
+    const fn source(&self) -> S where S: Copy;             // + source_ref / source_mut
+    const fn status(&self) -> Status;                      // const, so usable in a const context
     fn bump(&mut self, by: &Span::Offset) -> &mut Self where Span: crate::Span;
     fn map<U>(self, f: impl FnOnce(S) -> U) -> Ident<U, Span, Lang>;
 }
-// Keyword has the same new/with_status/span*/source*/map and the same three predicates — it
-// carries the same status, so converting into `Ident` via `From` carries it across rather than
-// declaring the result valid. `bump` is Ident's alone. Every `Lit*` type carries it too.
+
+// The three questions are on a trait, and it has to be imported:
+impl RecoveryState for Ident<..> { fn status(&self) -> Status;
+                                   fn is_valid/is_error/is_missing(&self) -> bool; }
+
+// Keyword and every `Lit*` type carry the same status and the same two doors to it, so
+// converting a Keyword into an Ident via `From` carries the state across rather than declaring
+// the result valid. `bump` is Ident's alone.
+//
+// `IdentList` keeps is_valid/is_error/is_missing as INHERENT methods and does not implement the
+// trait: a list is an aggregate, and is_error and is_missing can both be true of one at once,
+// which no single Status can say.
 ```
 
 ```rust
-use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, Keyword}, utils::IntoComponents};
+use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, Keyword, RecoveryState}, utils::IntoComponents};
 
 struct MyLang;
 

--- a/tokora/src/guide/ref_types_syntax.md
+++ b/tokora/src/guide/ref_types_syntax.md
@@ -147,7 +147,6 @@ impl<S, Span, Lang> Ident<S, Span, Lang> {
 ```rust
 use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, Keyword}, utils::IntoComponents};
 
-#[derive(Debug, PartialEq)]
 struct MyLang;
 
 let ident = Ident::<&str, SimpleSpan, MyLang>::new(SimpleSpan::new(5, 11), "my_var");

--- a/tokora/src/guide/ref_types_syntax.md
+++ b/tokora/src/guide/ref_types_syntax.md
@@ -166,7 +166,7 @@ impl RecoveryState for Ident<..> { fn status(&self) -> Status;
 use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, Keyword}, utils::IntoComponents};
 // `RecoveryState` is NOT in `types::*` — a trait reached through a glob can be rebound by a
 // second glob with only a warning, so it has to be named:
-use tokora::types::{Components, FromComponents, RecoveryState};
+use tokora::types::recovery::{Components, FromComponents, RecoveryState};
 
 struct MyLang;
 

--- a/tokora/src/guide/ref_types_syntax.md
+++ b/tokora/src/guide/ref_types_syntax.md
@@ -156,7 +156,10 @@ impl RecoveryState for Ident<..> { fn status(&self) -> Status;
 ```
 
 ```rust
-use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, Keyword, RecoveryState}, utils::IntoComponents};
+use tokora::{SimpleSpan, error::ErrorNode, types::{Ident, Keyword}, utils::IntoComponents};
+// `RecoveryState` is NOT in `types::*` — a trait reached through a glob can be rebound by a
+// second glob with only a warning, so it has to be named:
+use tokora::types::recovery::RecoveryState;
 
 struct MyLang;
 

--- a/tokora/src/guide/ref_types_syntax.md
+++ b/tokora/src/guide/ref_types_syntax.md
@@ -134,14 +134,17 @@ impl<S, Span, Lang> Ident<S, Span, Lang> {
     const fn with_status(span: Span, source: S, status: Status) -> Self;
     const fn span(&self) -> Span where Span: Copy;         // + span_ref / span_mut
     const fn source(&self) -> S where S: Copy;             // + source_ref / source_mut
-    const fn status(&self) -> Status;                      // const, so usable in a const context
     fn bump(&mut self, by: &Span::Offset) -> &mut Self where Span: crate::Span;
     fn map<U>(self, f: impl FnOnce(S) -> U) -> Ident<U, Span, Lang>;
 }
 
-// The three questions are on a trait, and it has to be imported:
+// The recovery state is read through a trait, and ONLY through it — there is no inherent
+// accessor of any name, because an inherent one can be displaced by a consumer's extension
+// method whenever the two return types share a method (`x.status().is_valid()` typechecks
+// either way). The trait has to be imported, which is what makes a clash loud.
 impl RecoveryState for Ident<..> { fn status(&self) -> Status;
                                    fn is_valid/is_error/is_missing(&self) -> bool; }
+// Cost: none of this is `const` — a trait method cannot be.
 
 // Keyword and every `Lit*` type carry the same status and the same two doors to it, so
 // converting a Keyword into an Ident via `From` carries the state across rather than declaring

--- a/tokora/src/parser/keyword/tests.rs
+++ b/tokora/src/parser/keyword/tests.rs
@@ -8,7 +8,7 @@ use crate::{
   logos::{self, Logos},
   span::Spanned,
   token::Token as TokenTrait,
-  types::recovery::Components,
+  types::Components,
 };
 
 #[derive(Debug, Clone, Logos, PartialEq)]

--- a/tokora/src/parser/keyword/tests.rs
+++ b/tokora/src/parser/keyword/tests.rs
@@ -175,7 +175,7 @@ fn parse_exact_accepts_matching_keyword() {
     Keyword::parse_exact(&"if").parse_input(inp)
   }
   let r = Parser::with_context(ctx()).apply(parse).parse_str("if");
-  let (span, tok) = r.unwrap().into_components();
+  let (span, tok, _) = r.unwrap().into_components();
   assert_eq!(tok, Token::If);
   assert_eq!(span, SimpleSpan::new(0, 2));
 }
@@ -205,7 +205,7 @@ fn parse_accepts_else_keyword() {
     Keyword::parse(inp)
   }
   let r = Parser::with_context(ctx()).apply(parse).parse_str("else");
-  let (span, tok) = r.unwrap().into_components();
+  let (span, tok, _) = r.unwrap().into_components();
   assert_eq!(tok, Token::Else);
   assert_eq!(span, SimpleSpan::new(0, 4));
 }
@@ -245,7 +245,7 @@ fn parse_accepts_any_keyword() {
     Keyword::parse(inp)
   }
   let r = Parser::with_context(ctx()).apply(parse).parse_str("if");
-  let (span, tok) = r.unwrap().into_components();
+  let (span, tok, _) = r.unwrap().into_components();
   assert_eq!(tok, Token::If);
   assert_eq!(span, SimpleSpan::new(0, 2));
 }
@@ -258,7 +258,7 @@ fn parse_sliced_accepts_else_keyword() {
     Keyword::parse_sliced(inp)
   }
   let r = Parser::with_context(ctx()).apply(parse).parse_str("else");
-  let (span, source) = r.unwrap().into_components();
+  let (span, source, _) = r.unwrap().into_components();
   assert_eq!(source, "else");
   assert_eq!(span, SimpleSpan::new(0, 4));
 }
@@ -309,7 +309,7 @@ fn parse_exact_sliced_accepts_matching_keyword_with_span() {
     Keyword::parse_exact_sliced(&"if").parse_input(inp)
   }
   let r = Parser::with_context(ctx()).apply(parse).parse_str("if");
-  let (span, source) = r.unwrap().into_components();
+  let (span, source, _) = r.unwrap().into_components();
   assert_eq!(source, "if");
   assert_eq!(span, SimpleSpan::new(0, 2));
 }

--- a/tokora/src/parser/keyword/tests.rs
+++ b/tokora/src/parser/keyword/tests.rs
@@ -8,7 +8,7 @@ use crate::{
   logos::{self, Logos},
   span::Spanned,
   token::Token as TokenTrait,
-  types::Components,
+  types::recovery::Components,
 };
 
 #[derive(Debug, Clone, Logos, PartialEq)]

--- a/tokora/src/parser/keyword/tests.rs
+++ b/tokora/src/parser/keyword/tests.rs
@@ -8,6 +8,7 @@ use crate::{
   logos::{self, Logos},
   span::Spanned,
   token::Token as TokenTrait,
+  types::recovery::Components,
 };
 
 #[derive(Debug, Clone, Logos, PartialEq)]
@@ -175,7 +176,11 @@ fn parse_exact_accepts_matching_keyword() {
     Keyword::parse_exact(&"if").parse_input(inp)
   }
   let r = Parser::with_context(ctx()).apply(parse).parse_str("if");
-  let (span, tok, _) = r.unwrap().into_components();
+  let Components {
+    span,
+    payload: tok,
+    status: _,
+  } = r.unwrap().into_components();
   assert_eq!(tok, Token::If);
   assert_eq!(span, SimpleSpan::new(0, 2));
 }
@@ -205,7 +210,11 @@ fn parse_accepts_else_keyword() {
     Keyword::parse(inp)
   }
   let r = Parser::with_context(ctx()).apply(parse).parse_str("else");
-  let (span, tok, _) = r.unwrap().into_components();
+  let Components {
+    span,
+    payload: tok,
+    status: _,
+  } = r.unwrap().into_components();
   assert_eq!(tok, Token::Else);
   assert_eq!(span, SimpleSpan::new(0, 4));
 }
@@ -245,7 +254,11 @@ fn parse_accepts_any_keyword() {
     Keyword::parse(inp)
   }
   let r = Parser::with_context(ctx()).apply(parse).parse_str("if");
-  let (span, tok, _) = r.unwrap().into_components();
+  let Components {
+    span,
+    payload: tok,
+    status: _,
+  } = r.unwrap().into_components();
   assert_eq!(tok, Token::If);
   assert_eq!(span, SimpleSpan::new(0, 2));
 }
@@ -258,7 +271,11 @@ fn parse_sliced_accepts_else_keyword() {
     Keyword::parse_sliced(inp)
   }
   let r = Parser::with_context(ctx()).apply(parse).parse_str("else");
-  let (span, source, _) = r.unwrap().into_components();
+  let Components {
+    span,
+    payload: source,
+    status: _,
+  } = r.unwrap().into_components();
   assert_eq!(source, "else");
   assert_eq!(span, SimpleSpan::new(0, 4));
 }
@@ -309,7 +326,11 @@ fn parse_exact_sliced_accepts_matching_keyword_with_span() {
     Keyword::parse_exact_sliced(&"if").parse_input(inp)
   }
   let r = Parser::with_context(ctx()).apply(parse).parse_str("if");
-  let (span, source, _) = r.unwrap().into_components();
+  let Components {
+    span,
+    payload: source,
+    status: _,
+  } = r.unwrap().into_components();
   assert_eq!(source, "if");
   assert_eq!(span, SimpleSpan::new(0, 2));
 }

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -390,20 +390,6 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   pub const fn source_ref(&self) -> &S {
     &self.ident
   }
-
-  /// Returns the recovery state of this identifier.
-  ///
-  /// The three questions — valid, error, missing — are asked through
-  /// [`RecoveryState`](super::RecoveryState), which has to be in scope. They are not inherent
-  /// methods because those names are ones a consumer may already have on an extension trait of
-  /// their own, and an inherent method wins that pick silently; see the trait for the argument.
-  ///
-  /// This accessor is inherent so that the state stays readable in a const context, which a
-  /// trait method cannot be: `x.status().is_valid()` is `const` all the way down.
-  #[inline(always)]
-  pub const fn status(&self) -> Status {
-    self.status
-  }
 }
 
 impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -54,7 +54,7 @@
 //! allowing creation of placeholder identifiers during error recovery:
 //!
 //! ```rust,ignore
-//! use tokora::{error::ErrorNode, types::RecoveryState};
+//! use tokora::{error::ErrorNode, types::recovery::RecoveryState};
 //!
 //! // Create placeholder for malformed identifier
 //! let bad_ident = Ident::<String, SimpleSpan, YulLang>::error(span);
@@ -65,7 +65,7 @@
 
 use core::marker::PhantomData;
 
-use super::Status;
+use super::recovery::Status;
 use crate::{
   error::ErrorNode,
   span::{AsSpan, SimpleSpan},
@@ -122,13 +122,13 @@ use crate::{
 /// ## Extracting Components
 ///
 /// ```rust
-/// # use tokora::{SimpleSpan, types::{Ident, Components}, utils::IntoComponents};
+/// # use tokora::{SimpleSpan, types::{Ident, recovery::Components}, utils::IntoComponents};
 /// # struct MyLang;
 /// # let span = SimpleSpan::new(0, 3);
 /// let ident = Ident::<&str, SimpleSpan, MyLang>::new(span, "foo");
 ///
 /// // Destructure into span, payload and recovery status. A named struct, not a tuple: see
-/// // `types::Components` for the `..` pattern that made a three-tuple unsafe.
+/// // `types::recovery::Components` for the `..` pattern that made a three-tuple unsafe.
 /// let Components { span, payload, status } = ident.into_components();
 /// assert_eq!(payload, "foo");
 /// assert!(status.is_valid());
@@ -254,11 +254,11 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Ident<S, Span, Lang> {
   /// zero-sized language marker, which the rebuild names in its own type.
   ///
   /// The status is here because this trait promises a complete decomposition and because
-  /// [`FromComponents`](super::FromComponents) is the inverse: without it in both, a consumer who took
+  /// [`FromComponents`](super::recovery::FromComponents) is the inverse: without it in both, a consumer who took
   /// a carrier apart and put it back together would have to rebuild through
   /// [`new`](Ident::new), which always declares the result valid — the same laundering tokora#303
   /// removed from [`map`](Ident::map), reached one door over.
-  type Components = super::Components<Span, S>;
+  type Components = super::recovery::Components<Span, S>;
 
   #[inline(always)]
   fn into_components(self) -> Self::Components {
@@ -269,7 +269,7 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Ident<S, Span, Lang> {
       ident,
     } = self;
 
-    super::Components {
+    super::recovery::Components {
       span,
       payload: ident,
       status,
@@ -409,7 +409,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   //
   // `Keyword` and the seventeen `Lit*` types never had the names, so giving them inherent ones
   // would be the opposite defect — the new hazard — and they answer through
-  // [`RecoveryState`](super::RecoveryState) alone. `Ident` implements that trait too,
+  // [`RecoveryState`](super::recovery::RecoveryState) alone. `Ident` implements that trait too,
   // so generic code over carriers sees one uniform channel; these three are exactly its answers.
   //
   // The drift argument that removed them is about how the surface reads. This one is about
@@ -417,7 +417,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
 
   /// Returns `true` is this identifier represents an error identifier.
   ///
-  /// Also available as [`RecoveryState::is_error`](super::RecoveryState::is_error),
+  /// Also available as [`RecoveryState::is_error`](super::recovery::RecoveryState::is_error),
   /// which is the spelling every other carrier uses; this inherent form is `Ident`'s alone and
   /// predates the trait.
   #[inline(always)]
@@ -427,7 +427,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
 
   /// Returns `true` is this identifier represents a missing identifier.
   ///
-  /// Also available as [`RecoveryState::is_missing`](super::RecoveryState::is_missing),
+  /// Also available as [`RecoveryState::is_missing`](super::recovery::RecoveryState::is_missing),
   /// which is the spelling every other carrier uses; this inherent form is `Ident`'s alone and
   /// predates the trait.
   #[inline(always)]
@@ -437,7 +437,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
 
   /// Returns `true` is this identifier is valid (not error or missing).
   ///
-  /// Also available as [`RecoveryState::is_valid`](super::RecoveryState::is_valid),
+  /// Also available as [`RecoveryState::is_valid`](super::recovery::RecoveryState::is_valid),
   /// which is the spelling every other carrier uses; this inherent form is `Ident`'s alone and
   /// predates the trait.
   #[inline(always)]
@@ -475,7 +475,7 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   /// The status-setting constructor, crate-internal.
   ///
   /// Public construction with a chosen status goes through
-  /// [`FromComponents`](super::FromComponents), whose argument is an associated
+  /// [`FromComponents`](super::recovery::FromComponents), whose argument is an associated
   /// type rather than a bare `Status` — see that trait for the type-directed inference
   /// route that made an inherent `with_status` unsafe to ship.
   #[inline(always)]
@@ -549,10 +549,10 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   }
 }
 
-impl<S, Span, Lang: ?Sized> super::FromComponents for Ident<S, Span, Lang> {
+impl<S, Span, Lang: ?Sized> super::recovery::FromComponents for Ident<S, Span, Lang> {
   #[inline(always)]
   fn from_components(components: Self::Components) -> Self {
-    let super::Components {
+    let super::recovery::Components {
       span,
       payload,
       status,
@@ -562,7 +562,7 @@ impl<S, Span, Lang: ?Sized> super::FromComponents for Ident<S, Span, Lang> {
   }
 }
 
-impl<S: ?Sized, Span, Lang: ?Sized> super::RecoveryState for Ident<S, Span, Lang> {
+impl<S: ?Sized, Span, Lang: ?Sized> super::recovery::RecoveryState for Ident<S, Span, Lang> {
   #[inline(always)]
   fn status(&self) -> Status {
     self.status

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -127,9 +127,10 @@ use crate::{
 /// # let span = SimpleSpan::new(0, 3);
 /// let ident = Ident::<&str, SimpleSpan, MyLang>::new(span, "foo");
 ///
-/// // Destructure into span and source
-/// let (span, source) = ident.into_components();
+/// // Destructure into span, source and recovery status
+/// let (span, source, status) = ident.into_components();
 /// assert_eq!(source, "foo");
+/// assert!(status.is_valid());
 /// ```
 ///
 /// ## Mutable Access
@@ -164,11 +165,26 @@ impl<S: ?Sized, Span, Lang: ?Sized> AsSpan<Span> for Ident<S, Span, Lang> {
 }
 
 impl<S, Span, Lang: ?Sized> IntoComponents for Ident<S, Span, Lang> {
-  type Components = (Span, S);
+  /// The span, the source, **and the recovery status** — every field this type holds beyond the
+  /// zero-sized language marker, which the rebuild names in its own type.
+  ///
+  /// The status is here because this trait promises a complete decomposition and because
+  /// [`with_status`](Ident::with_status) is the inverse: without it in both, a consumer who took
+  /// a carrier apart and put it back together would have to rebuild through
+  /// [`new`](Ident::new), which always declares the result valid — the same laundering tokora#303
+  /// removed from [`map`](Ident::map), reached one door over.
+  type Components = (Span, S, Status);
 
   #[inline(always)]
   fn into_components(self) -> Self::Components {
-    (self.span, self.ident)
+    let Self {
+      _lang,
+      status,
+      span,
+      ident,
+    } = self;
+
+    (span, ident, status)
   }
 }
 
@@ -331,8 +347,34 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
     Self::with_status(span, source, Status::Valid)
   }
 
+  /// Creates an identifier with an explicitly given recovery status.
+  ///
+  /// The inverse of [`into_components`](IntoComponents::into_components), and the only
+  /// constructor that can express a state other than valid over a payload the caller chose:
+  /// [`new`](Self::new) always declares the result valid, and
+  /// [`ErrorNode::error`](ErrorNode::error) / [`ErrorNode::missing`](ErrorNode::missing) pick the
+  /// payload themselves. A dialect with its own placeholder spelling needs this one.
+  ///
+  /// # Examples
+  ///
+  /// ```rust
+  /// use tokora::{SimpleSpan, types::{Ident, Status}, utils::IntoComponents};
+  /// # #[derive(Debug, Clone, Copy, PartialEq)]
+  /// # struct MyLang;
+  ///
+  /// let span = SimpleSpan::new(0, 4);
+  /// let recovered = Ident::<&str, SimpleSpan, MyLang>::with_status(span, "name", Status::Missing);
+  ///
+  /// assert!(recovered.is_missing());
+  /// assert_eq!(recovered.source_ref(), &"name");
+  ///
+  /// // Round trip: the three components rebuild the value they came from.
+  /// let (span, source, status) = recovered.into_components();
+  /// let rebuilt = Ident::<&str, SimpleSpan, MyLang>::with_status(span, source, status);
+  /// assert_eq!(rebuilt, recovered);
+  /// ```
   #[inline(always)]
-  pub(super) const fn with_status(span: Span, source: S, status: Status) -> Self {
+  pub const fn with_status(span: Span, source: S, status: Status) -> Self {
     Self {
       span,
       ident: source,

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -253,7 +253,7 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Ident<S, Span, Lang> {
   /// zero-sized language marker, which the rebuild names in its own type.
   ///
   /// The status is here because this trait promises a complete decomposition and because
-  /// [`with_status`](Ident::with_status) is the inverse: without it in both, a consumer who took
+  /// [`FromComponents`](super::recovery::FromComponents) is the inverse: without it in both, a consumer who took
   /// a carrier apart and put it back together would have to rebuild through
   /// [`new`](Ident::new), which always declares the result valid — the same laundering tokora#303
   /// removed from [`map`](Ident::map), reached one door over.
@@ -467,38 +467,14 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
     Self::with_status(span, source, Status::Valid)
   }
 
-  /// Creates an identifier with an explicitly given recovery status.
+  /// The status-setting constructor, crate-internal.
   ///
-  /// The inverse of [`into_components`](IntoComponents::into_components), and the only
-  /// constructor that can express a state other than valid over a payload the caller chose:
-  /// [`new`](Self::new) always declares the result valid, and
-  /// [`ErrorNode::error`](ErrorNode::error) / [`ErrorNode::missing`](ErrorNode::missing) pick the
-  /// payload themselves. A dialect with its own placeholder spelling needs this one.
-  ///
-  /// # Examples
-  ///
-  /// ```rust
-  /// use tokora::{SimpleSpan, types::{Ident, Status}, utils::IntoComponents};
-  /// use tokora::types::recovery::RecoveryState;
-  /// // Comparing carriers needs the marker to be `PartialEq`: `PartialEq`/`Eq` stay derived
-  /// // so a `const` carrier keeps working in a `match` pattern, and a derive constrains
-  /// // every parameter. `Debug`, `Clone`, `Copy` and `Hash` need nothing of it.
-  /// #[derive(PartialEq)]
-  /// struct MyLang;
-  ///
-  /// let span = SimpleSpan::new(0, 4);
-  /// let recovered = Ident::<&str, SimpleSpan, MyLang>::with_status(span, "name", Status::Missing);
-  ///
-  /// assert!(recovered.is_missing());
-  /// assert_eq!(recovered.source_ref(), &"name");
-  ///
-  /// // Round trip: the three components rebuild the value they came from.
-  /// let (span, source, status) = recovered.into_components();
-  /// let rebuilt = Ident::<&str, SimpleSpan, MyLang>::with_status(span, source, status);
-  /// assert_eq!(rebuilt, recovered);
-  /// ```
+  /// Public construction with a chosen status goes through
+  /// [`FromComponents`](super::recovery::FromComponents), whose argument is an associated
+  /// type rather than a bare `Status` — see that trait for the type-directed inference
+  /// route that made an inherent `with_status` unsafe to ship.
   #[inline(always)]
-  pub const fn with_status(span: Span, source: S, status: Status) -> Self {
+  pub(super) const fn with_status(span: Span, source: S, status: Status) -> Self {
     Self {
       span,
       ident: source,
@@ -565,6 +541,15 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
       span,
       ident: f(ident),
     }
+  }
+}
+
+impl<S, Span, Lang: ?Sized> super::recovery::FromComponents for Ident<S, Span, Lang> {
+  #[inline(always)]
+  fn from_components(components: Self::Components) -> Self {
+    let (span, source, status) = components;
+
+    Self::with_status(span, source, status)
   }
 }
 

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -149,12 +149,101 @@ use crate::{
 /// *ident.span_mut() = SimpleSpan::new(10, 18);
 /// assert_eq!(ident.span(), SimpleSpan::new(10, 18));
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Ident<S: ?Sized, Span = SimpleSpan, Lang: ?Sized = ()> {
   _lang: PhantomData<Lang>,
   status: Status,
   span: Span,
   ident: S,
+}
+
+// The six impls below replace a `derive`, and the only thing that changes is the bound list.
+//
+// A derive constrains **every** type parameter, so `#[derive(Debug)]` on a type holding a
+// `PhantomData<Lang>` emitted `Lang: Debug` — a requirement on a marker that is never printed,
+// never compared and never hashed, because `PhantomData<T>` implements all six for any `T`
+// unconditionally. The effect was that `Ident<..., MyLang>` was not `Debug`, `Copy` or
+// comparable unless the consumer derived those on `MyLang` too, for a reason that does not
+// exist. tokora#320 caught it the way such things are caught: a doctest that would not compile
+// until four derives were added to the marker.
+//
+// Rendered output and comparison order are unchanged. `Debug` still prints every field in
+// declaration order including the marker, `PartialEq` still short-circuits in that order, and
+// `Hash` still feeds the same bytes — `PhantomData` hashes nothing, so omitting it is not a
+// change.
+
+impl<S, Span, Lang> ::core::fmt::Debug for Ident<S, Span, Lang>
+where
+  S: ::core::fmt::Debug + ?Sized,
+  Span: ::core::fmt::Debug,
+  Lang: ?Sized,
+{
+  fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+    f.debug_struct("Ident")
+      .field("_lang", &&self._lang)
+      .field("status", &&self.status)
+      .field("span", &&self.span)
+      .field("ident", &&self.ident)
+      .finish()
+  }
+}
+
+impl<S, Span, Lang> ::core::clone::Clone for Ident<S, Span, Lang>
+where
+  S: ::core::clone::Clone,
+  Span: ::core::clone::Clone,
+  Lang: ?Sized,
+{
+  #[inline]
+  fn clone(&self) -> Self {
+    Self {
+      _lang: ::core::marker::PhantomData,
+      status: self.status,
+      span: ::core::clone::Clone::clone(&self.span),
+      ident: ::core::clone::Clone::clone(&self.ident),
+    }
+  }
+}
+
+impl<S, Span, Lang> ::core::marker::Copy for Ident<S, Span, Lang>
+where
+  S: ::core::marker::Copy,
+  Span: ::core::marker::Copy,
+  Lang: ?Sized,
+{
+}
+
+impl<S, Span, Lang> ::core::cmp::PartialEq for Ident<S, Span, Lang>
+where
+  S: ::core::cmp::PartialEq + ?Sized,
+  Span: ::core::cmp::PartialEq,
+  Lang: ?Sized,
+{
+  #[inline]
+  fn eq(&self, other: &Self) -> bool {
+    self.status == other.status && self.span == other.span && self.ident == other.ident
+  }
+}
+
+impl<S, Span, Lang> ::core::cmp::Eq for Ident<S, Span, Lang>
+where
+  S: ::core::cmp::Eq + ?Sized,
+  Span: ::core::cmp::Eq,
+  Lang: ?Sized,
+{
+}
+
+impl<S, Span, Lang> ::core::hash::Hash for Ident<S, Span, Lang>
+where
+  S: ::core::hash::Hash + ?Sized,
+  Span: ::core::hash::Hash,
+  Lang: ?Sized,
+{
+  #[inline]
+  fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
+    ::core::hash::Hash::hash(&self.status, state);
+    ::core::hash::Hash::hash(&self.span, state);
+    ::core::hash::Hash::hash(&self.ident, state);
+  }
 }
 
 impl<S: ?Sized, Span, Lang: ?Sized> AsSpan<Span> for Ident<S, Span, Lang> {
@@ -359,7 +448,6 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   ///
   /// ```rust
   /// use tokora::{SimpleSpan, types::{Ident, Status}, utils::IntoComponents};
-  /// # #[derive(Debug, Clone, Copy, PartialEq)]
   /// # struct MyLang;
   ///
   /// let span = SimpleSpan::new(0, 4);

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -122,14 +122,15 @@ use crate::{
 /// ## Extracting Components
 ///
 /// ```rust
-/// # use tokora::{SimpleSpan, types::Ident, utils::IntoComponents};
+/// # use tokora::{SimpleSpan, types::{Ident, recovery::Components}, utils::IntoComponents};
 /// # struct MyLang;
 /// # let span = SimpleSpan::new(0, 3);
 /// let ident = Ident::<&str, SimpleSpan, MyLang>::new(span, "foo");
 ///
-/// // Destructure into span, source and recovery status
-/// let (span, source, status) = ident.into_components();
-/// assert_eq!(source, "foo");
+/// // Destructure into span, payload and recovery status. A named struct, not a tuple: see
+/// // `types::recovery::Components` for the `..` pattern that made a three-tuple unsafe.
+/// let Components { span, payload, status } = ident.into_components();
+/// assert_eq!(payload, "foo");
 /// assert!(status.is_valid());
 /// ```
 ///
@@ -257,7 +258,7 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Ident<S, Span, Lang> {
   /// a carrier apart and put it back together would have to rebuild through
   /// [`new`](Ident::new), which always declares the result valid — the same laundering tokora#303
   /// removed from [`map`](Ident::map), reached one door over.
-  type Components = (Span, S, Status);
+  type Components = super::recovery::Components<Span, S>;
 
   #[inline(always)]
   fn into_components(self) -> Self::Components {
@@ -268,7 +269,11 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Ident<S, Span, Lang> {
       ident,
     } = self;
 
-    (span, ident, status)
+    super::recovery::Components {
+      span,
+      payload: ident,
+      status,
+    }
   }
 }
 
@@ -547,9 +552,13 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
 impl<S, Span, Lang: ?Sized> super::recovery::FromComponents for Ident<S, Span, Lang> {
   #[inline(always)]
   fn from_components(components: Self::Components) -> Self {
-    let (span, source, status) = components;
+    let super::recovery::Components {
+      span,
+      payload,
+      status,
+    } = components;
 
-    Self::with_status(span, source, status)
+    Self::with_status(span, payload, status)
   }
 }
 

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -65,20 +65,12 @@
 
 use core::marker::PhantomData;
 
+use super::status::Status;
 use crate::{
   error::ErrorNode,
   span::{AsSpan, SimpleSpan},
   utils::IntoComponents,
 };
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[repr(u8)]
-#[non_exhaustive]
-enum Status {
-  Valid,
-  Error,
-  Missing,
-}
 
 /// A language identifier with span tracking.
 ///
@@ -297,19 +289,19 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   /// Returns `true` is this identifier represents an error identifier.
   #[inline(always)]
   pub const fn is_error(&self) -> bool {
-    matches!(self.status, Status::Error)
+    self.status.is_error()
   }
 
   /// Returns `true` is this identifier represents a missing identifier.
   #[inline(always)]
   pub const fn is_missing(&self) -> bool {
-    matches!(self.status, Status::Missing)
+    self.status.is_missing()
   }
 
   /// Returns `true` is this identifier is valid (not error or missing).
   #[inline(always)]
   pub const fn is_valid(&self) -> bool {
-    matches!(self.status, Status::Valid)
+    self.status.is_valid()
   }
 }
 
@@ -340,7 +332,7 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   }
 
   #[inline(always)]
-  const fn with_status(span: Span, source: S, status: Status) -> Self {
+  pub(super) const fn with_status(span: Span, source: S, status: Status) -> Self {
     Self {
       span,
       ident: source,

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -54,7 +54,7 @@
 //! allowing creation of placeholder identifiers during error recovery:
 //!
 //! ```rust,ignore
-//! use tokora::error::ErrorNode;
+//! use tokora::{error::ErrorNode, types::RecoveryState};
 //!
 //! // Create placeholder for malformed identifier
 //! let bad_ident = Ident::<String, SimpleSpan, YulLang>::error(span);
@@ -391,22 +391,18 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
     &self.ident
   }
 
-  /// Returns `true` is this identifier represents an error identifier.
+  /// Returns the recovery state of this identifier.
+  ///
+  /// The three questions — valid, error, missing — are asked through
+  /// [`RecoveryState`](super::RecoveryState), which has to be in scope. They are not inherent
+  /// methods because those names are ones a consumer may already have on an extension trait of
+  /// their own, and an inherent method wins that pick silently; see the trait for the argument.
+  ///
+  /// This accessor is inherent so that the state stays readable in a const context, which a
+  /// trait method cannot be: `x.status().is_valid()` is `const` all the way down.
   #[inline(always)]
-  pub const fn is_error(&self) -> bool {
-    self.status.is_error()
-  }
-
-  /// Returns `true` is this identifier represents a missing identifier.
-  #[inline(always)]
-  pub const fn is_missing(&self) -> bool {
-    self.status.is_missing()
-  }
-
-  /// Returns `true` is this identifier is valid (not error or missing).
-  #[inline(always)]
-  pub const fn is_valid(&self) -> bool {
-    self.status.is_valid()
+  pub const fn status(&self) -> Status {
+    self.status
   }
 }
 
@@ -447,7 +443,7 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   /// # Examples
   ///
   /// ```rust
-  /// use tokora::{SimpleSpan, types::{Ident, Status}, utils::IntoComponents};
+  /// use tokora::{SimpleSpan, types::{Ident, RecoveryState, Status}, utils::IntoComponents};
   /// # struct MyLang;
   ///
   /// let span = SimpleSpan::new(0, 4);
@@ -529,6 +525,13 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
       span,
       ident: f(ident),
     }
+  }
+}
+
+impl<S: ?Sized, Span, Lang: ?Sized> super::RecoveryState for Ident<S, Span, Lang> {
+  #[inline(always)]
+  fn status(&self) -> Status {
+    self.status
   }
 }
 

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -385,6 +385,60 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   pub const fn source_ref(&self) -> &S {
     &self.ident
   }
+
+  // ── Why these three are inherent HERE and on no other carrier ──────────────────────────────
+  //
+  // The rule, stated once because the asymmetry below is the rule applied to two histories
+  // rather than an accident:
+  //
+  //   Do not change resolution for a name that already shipped;
+  //   do not create a new resolution hazard for a name that did not.
+  //
+  // `Ident` shipped these three as inherent `const fn`s in 0.9. Removing them does not merely
+  // cost a consumer an import: an inherent method **wins** the pick over an extension trait's, so
+  // a downstream crate with its own `is_valid` for `Ident` was getting tokora's answer. Take the
+  // inherent one away and that call still compiles, with no ambiguity, and silently falls through
+  // to theirs — and it falls the dangerous way, because a check that merely accepts a non-empty
+  // payload reads `Ident::error(span)`'s `"<error>"` as valid syntax. Removal changes resolution
+  // as surely as addition does, in the direction with no diagnostic.
+  //
+  // `Keyword` and the seventeen `Lit*` types never had the names, so giving them inherent ones
+  // would be the opposite defect — the new hazard — and they answer through
+  // [`RecoveryState`](super::recovery::RecoveryState) alone. `Ident` implements that trait too,
+  // so generic code over carriers sees one uniform channel; these three are exactly its answers.
+  //
+  // The drift argument that removed them is about how the surface reads. This one is about
+  // existing code changing meaning with nothing to catch it. They are not the same weight.
+
+  /// Returns `true` is this identifier represents an error identifier.
+  ///
+  /// Also available as [`RecoveryState::is_error`](super::recovery::RecoveryState::is_error),
+  /// which is the spelling every other carrier uses; this inherent form is `Ident`'s alone and
+  /// predates the trait.
+  #[inline(always)]
+  pub const fn is_error(&self) -> bool {
+    self.status.is_error()
+  }
+
+  /// Returns `true` is this identifier represents a missing identifier.
+  ///
+  /// Also available as [`RecoveryState::is_missing`](super::recovery::RecoveryState::is_missing),
+  /// which is the spelling every other carrier uses; this inherent form is `Ident`'s alone and
+  /// predates the trait.
+  #[inline(always)]
+  pub const fn is_missing(&self) -> bool {
+    self.status.is_missing()
+  }
+
+  /// Returns `true` is this identifier is valid (not error or missing).
+  ///
+  /// Also available as [`RecoveryState::is_valid`](super::recovery::RecoveryState::is_valid),
+  /// which is the spelling every other carrier uses; this inherent form is `Ident`'s alone and
+  /// predates the trait.
+  #[inline(always)]
+  pub const fn is_valid(&self) -> bool {
+    self.status.is_valid()
+  }
 }
 
 impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -54,7 +54,7 @@
 //! allowing creation of placeholder identifiers during error recovery:
 //!
 //! ```rust,ignore
-//! use tokora::{error::ErrorNode, types::RecoveryState};
+//! use tokora::{error::ErrorNode, types::recovery::RecoveryState};
 //!
 //! // Create placeholder for malformed identifier
 //! let bad_ident = Ident::<String, SimpleSpan, YulLang>::error(span);
@@ -65,7 +65,7 @@
 
 use core::marker::PhantomData;
 
-use super::status::Status;
+use super::recovery::Status;
 use crate::{
   error::ErrorNode,
   span::{AsSpan, SimpleSpan},
@@ -149,6 +149,21 @@ use crate::{
 /// *ident.span_mut() = SimpleSpan::new(10, 18);
 /// assert_eq!(ident.span(), SimpleSpan::new(10, 18));
 /// ```
+// `PartialEq` and `Eq` are **derived** while the other four are written out, and that split is
+// the point rather than an inconsistency.
+//
+// A derive constrains every type parameter, which is why `Debug`, `Clone`, `Copy` and `Hash` are
+// hand-written here: none of them reads `Lang`, so none of them should demand anything of it.
+// `PartialEq`/`Eq` cannot join them. The derive is also what emits `StructuralPartialEq`, and
+// without that marker a `const` of this type cannot appear in a `match` pattern — "constant of
+// non-structural type", a property no amount of checking the rendered output can see, because it
+// is not observable except by trying to use a value in a pattern.
+//
+// So the residual is stated rather than hidden: comparing or pattern-matching one of these still
+// needs the language marker to be `PartialEq + Eq`. Printing, cloning, copying and hashing do
+// not. That is four of the six bounds dropped against 0.9, and structural matching kept exactly
+// as 0.9 had it.
+#[derive(PartialEq, Eq)]
 pub struct Ident<S: ?Sized, Span = SimpleSpan, Lang: ?Sized = ()> {
   _lang: PhantomData<Lang>,
   status: Status,
@@ -208,26 +223,6 @@ impl<S, Span, Lang> ::core::marker::Copy for Ident<S, Span, Lang>
 where
   S: ::core::marker::Copy,
   Span: ::core::marker::Copy,
-  Lang: ?Sized,
-{
-}
-
-impl<S, Span, Lang> ::core::cmp::PartialEq for Ident<S, Span, Lang>
-where
-  S: ::core::cmp::PartialEq + ?Sized,
-  Span: ::core::cmp::PartialEq,
-  Lang: ?Sized,
-{
-  #[inline]
-  fn eq(&self, other: &Self) -> bool {
-    self.status == other.status && self.span == other.span && self.ident == other.ident
-  }
-}
-
-impl<S, Span, Lang> ::core::cmp::Eq for Ident<S, Span, Lang>
-where
-  S: ::core::cmp::Eq + ?Sized,
-  Span: ::core::cmp::Eq,
   Lang: ?Sized,
 {
 }
@@ -429,8 +424,13 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   /// # Examples
   ///
   /// ```rust
-  /// use tokora::{SimpleSpan, types::{Ident, RecoveryState, Status}, utils::IntoComponents};
-  /// # struct MyLang;
+  /// use tokora::{SimpleSpan, types::{Ident, Status}, utils::IntoComponents};
+  /// use tokora::types::recovery::RecoveryState;
+  /// // Comparing carriers needs the marker to be `PartialEq`: `PartialEq`/`Eq` stay derived
+  /// // so a `const` carrier keeps working in a `match` pattern, and a derive constrains
+  /// // every parameter. `Debug`, `Clone`, `Copy` and `Hash` need nothing of it.
+  /// #[derive(PartialEq)]
+  /// struct MyLang;
   ///
   /// let span = SimpleSpan::new(0, 4);
   /// let recovered = Ident::<&str, SimpleSpan, MyLang>::with_status(span, "name", Status::Missing);
@@ -514,7 +514,7 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   }
 }
 
-impl<S: ?Sized, Span, Lang: ?Sized> super::RecoveryState for Ident<S, Span, Lang> {
+impl<S: ?Sized, Span, Lang: ?Sized> super::recovery::RecoveryState for Ident<S, Span, Lang> {
   #[inline(always)]
   fn status(&self) -> Status {
     self.status

--- a/tokora/src/types/ident.rs
+++ b/tokora/src/types/ident.rs
@@ -54,7 +54,7 @@
 //! allowing creation of placeholder identifiers during error recovery:
 //!
 //! ```rust,ignore
-//! use tokora::{error::ErrorNode, types::recovery::RecoveryState};
+//! use tokora::{error::ErrorNode, types::RecoveryState};
 //!
 //! // Create placeholder for malformed identifier
 //! let bad_ident = Ident::<String, SimpleSpan, YulLang>::error(span);
@@ -65,7 +65,7 @@
 
 use core::marker::PhantomData;
 
-use super::recovery::Status;
+use super::Status;
 use crate::{
   error::ErrorNode,
   span::{AsSpan, SimpleSpan},
@@ -122,13 +122,13 @@ use crate::{
 /// ## Extracting Components
 ///
 /// ```rust
-/// # use tokora::{SimpleSpan, types::{Ident, recovery::Components}, utils::IntoComponents};
+/// # use tokora::{SimpleSpan, types::{Ident, Components}, utils::IntoComponents};
 /// # struct MyLang;
 /// # let span = SimpleSpan::new(0, 3);
 /// let ident = Ident::<&str, SimpleSpan, MyLang>::new(span, "foo");
 ///
 /// // Destructure into span, payload and recovery status. A named struct, not a tuple: see
-/// // `types::recovery::Components` for the `..` pattern that made a three-tuple unsafe.
+/// // `types::Components` for the `..` pattern that made a three-tuple unsafe.
 /// let Components { span, payload, status } = ident.into_components();
 /// assert_eq!(payload, "foo");
 /// assert!(status.is_valid());
@@ -254,11 +254,11 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Ident<S, Span, Lang> {
   /// zero-sized language marker, which the rebuild names in its own type.
   ///
   /// The status is here because this trait promises a complete decomposition and because
-  /// [`FromComponents`](super::recovery::FromComponents) is the inverse: without it in both, a consumer who took
+  /// [`FromComponents`](super::FromComponents) is the inverse: without it in both, a consumer who took
   /// a carrier apart and put it back together would have to rebuild through
   /// [`new`](Ident::new), which always declares the result valid — the same laundering tokora#303
   /// removed from [`map`](Ident::map), reached one door over.
-  type Components = super::recovery::Components<Span, S>;
+  type Components = super::Components<Span, S>;
 
   #[inline(always)]
   fn into_components(self) -> Self::Components {
@@ -269,7 +269,7 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Ident<S, Span, Lang> {
       ident,
     } = self;
 
-    super::recovery::Components {
+    super::Components {
       span,
       payload: ident,
       status,
@@ -409,7 +409,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   //
   // `Keyword` and the seventeen `Lit*` types never had the names, so giving them inherent ones
   // would be the opposite defect — the new hazard — and they answer through
-  // [`RecoveryState`](super::recovery::RecoveryState) alone. `Ident` implements that trait too,
+  // [`RecoveryState`](super::RecoveryState) alone. `Ident` implements that trait too,
   // so generic code over carriers sees one uniform channel; these three are exactly its answers.
   //
   // The drift argument that removed them is about how the surface reads. This one is about
@@ -417,7 +417,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
 
   /// Returns `true` is this identifier represents an error identifier.
   ///
-  /// Also available as [`RecoveryState::is_error`](super::recovery::RecoveryState::is_error),
+  /// Also available as [`RecoveryState::is_error`](super::RecoveryState::is_error),
   /// which is the spelling every other carrier uses; this inherent form is `Ident`'s alone and
   /// predates the trait.
   #[inline(always)]
@@ -427,7 +427,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
 
   /// Returns `true` is this identifier represents a missing identifier.
   ///
-  /// Also available as [`RecoveryState::is_missing`](super::recovery::RecoveryState::is_missing),
+  /// Also available as [`RecoveryState::is_missing`](super::RecoveryState::is_missing),
   /// which is the spelling every other carrier uses; this inherent form is `Ident`'s alone and
   /// predates the trait.
   #[inline(always)]
@@ -437,7 +437,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> Ident<S, Span, Lang> {
 
   /// Returns `true` is this identifier is valid (not error or missing).
   ///
-  /// Also available as [`RecoveryState::is_valid`](super::recovery::RecoveryState::is_valid),
+  /// Also available as [`RecoveryState::is_valid`](super::RecoveryState::is_valid),
   /// which is the spelling every other carrier uses; this inherent form is `Ident`'s alone and
   /// predates the trait.
   #[inline(always)]
@@ -475,7 +475,7 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   /// The status-setting constructor, crate-internal.
   ///
   /// Public construction with a chosen status goes through
-  /// [`FromComponents`](super::recovery::FromComponents), whose argument is an associated
+  /// [`FromComponents`](super::FromComponents), whose argument is an associated
   /// type rather than a bare `Status` — see that trait for the type-directed inference
   /// route that made an inherent `with_status` unsafe to ship.
   #[inline(always)]
@@ -549,10 +549,10 @@ impl<S, Span, Lang: ?Sized> Ident<S, Span, Lang> {
   }
 }
 
-impl<S, Span, Lang: ?Sized> super::recovery::FromComponents for Ident<S, Span, Lang> {
+impl<S, Span, Lang: ?Sized> super::FromComponents for Ident<S, Span, Lang> {
   #[inline(always)]
   fn from_components(components: Self::Components) -> Self {
-    let super::recovery::Components {
+    let super::Components {
       span,
       payload,
       status,
@@ -562,7 +562,7 @@ impl<S, Span, Lang: ?Sized> super::recovery::FromComponents for Ident<S, Span, L
   }
 }
 
-impl<S: ?Sized, Span, Lang: ?Sized> super::recovery::RecoveryState for Ident<S, Span, Lang> {
+impl<S: ?Sized, Span, Lang: ?Sized> super::RecoveryState for Ident<S, Span, Lang> {
   #[inline(always)]
   fn status(&self) -> Status {
     self.status

--- a/tokora/src/types/ident_list.rs
+++ b/tokora/src/types/ident_list.rs
@@ -129,8 +129,8 @@ impl<S, Span, Container, Lang: ?Sized> AsSpan<Span> for IdentList<S, Span, Conta
 /// The three predicates below are **inherent and stay inherent**, unlike the carriers'.
 ///
 /// They are not the same question. A carrier is in exactly one of three states, which is what
-/// [`RecoveryState`](super::RecoveryState) reports; a list is an aggregate, and `is_error` and `is_missing` can both be
-/// true of one at the same time. No single [`Status`](super::Status) can say that, so this type
+/// [`RecoveryState`](super::recovery::RecoveryState) reports; a list is an aggregate, and `is_error` and `is_missing` can both be
+/// true of one at the same time. No single [`Status`](super::recovery::Status) can say that, so this type
 /// does not implement the trait and there is no name for it to displace — these three predate
 /// tokora#320 and are unchanged by it.
 impl<S, Span, Container, Lang: ?Sized> IdentList<S, Span, Container, Lang> {

--- a/tokora/src/types/ident_list.rs
+++ b/tokora/src/types/ident_list.rs
@@ -1,6 +1,9 @@
 use core::marker::PhantomData;
 
-use crate::{span::AsSpan, types::Ident};
+use crate::{
+  span::AsSpan,
+  types::{Ident, RecoveryState},
+};
 
 /// A list of identifiers.
 ///
@@ -129,6 +132,13 @@ impl<S, Span, Container, Lang: ?Sized> AsSpan<Span> for IdentList<S, Span, Conta
   }
 }
 
+/// The three predicates below are **inherent and stay inherent**, unlike the carriers'.
+///
+/// They are not the same question. A carrier is in exactly one of three states, which is what
+/// [`RecoveryState`] reports; a list is an aggregate, and `is_error` and `is_missing` can both be
+/// true of one at the same time. No single [`Status`](super::Status) can say that, so this type
+/// does not implement the trait and there is no name for it to displace — these three predate
+/// tokora#320 and are unchanged by it.
 impl<S, Span, Container, Lang: ?Sized> IdentList<S, Span, Container, Lang> {
   /// Returns `true` if all identifiers in the path are valid.
   #[inline(always)]

--- a/tokora/src/types/ident_list.rs
+++ b/tokora/src/types/ident_list.rs
@@ -2,13 +2,20 @@ use core::marker::PhantomData;
 
 use crate::{
   span::AsSpan,
-  types::{Ident, RecoveryState},
+  types::{Ident, recovery::RecoveryState},
 };
 
 /// A list of identifiers.
 ///
 /// `S` remains sized because the default container stores `Ident<S, Span>` values
 /// inline in a `Vec`; use the individual [`Ident`] carrier for an unsized source.
+// `PartialEq`/`Eq` are derived while the other four are written out. A derive constrains every
+// type parameter, which is why the other four are hand-written — none of them reads `S` or
+// `Lang`. These two cannot join them: the derive is what emits `StructuralPartialEq`, without
+// which a `const` of this type cannot appear in a `match` pattern, and that is not observable
+// by checking rendered output. The residual is that comparing or matching one still needs `S`
+// and `Lang` to be `PartialEq + Eq`, exactly as 0.9 required.
+#[derive(PartialEq, Eq)]
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub struct IdentList<
   S,
@@ -26,6 +33,13 @@ pub struct IdentList<
 ///
 /// `S` remains sized to keep this type's API consistent with its `Vec`-backed
 /// form; use the individual [`Ident`] carrier for an unsized source.
+// `PartialEq`/`Eq` are derived while the other four are written out. A derive constrains every
+// type parameter, which is why the other four are hand-written — none of them reads `S` or
+// `Lang`. These two cannot join them: the derive is what emits `StructuralPartialEq`, without
+// which a `const` of this type cannot appear in a `match` pattern, and that is not observable
+// by checking rendered output. The residual is that comparing or matching one still needs `S`
+// and `Lang` to be `PartialEq + Eq`, exactly as 0.9 required.
+#[derive(PartialEq, Eq)]
 #[cfg(not(any(feature = "alloc", feature = "std")))]
 pub struct IdentList<S, Span, Container, Lang: ?Sized = ()> {
   span: Span,
@@ -88,26 +102,6 @@ impl<S, Span, Container, Lang> ::core::marker::Copy for IdentList<S, Span, Conta
 where
   Span: ::core::marker::Copy,
   Container: ::core::marker::Copy,
-  Lang: ?Sized,
-{
-}
-
-impl<S, Span, Container, Lang> ::core::cmp::PartialEq for IdentList<S, Span, Container, Lang>
-where
-  Span: ::core::cmp::PartialEq,
-  Container: ::core::cmp::PartialEq,
-  Lang: ?Sized,
-{
-  #[inline]
-  fn eq(&self, other: &Self) -> bool {
-    self.span == other.span && self.identifiers == other.identifiers
-  }
-}
-
-impl<S, Span, Container, Lang> ::core::cmp::Eq for IdentList<S, Span, Container, Lang>
-where
-  Span: ::core::cmp::Eq,
-  Container: ::core::cmp::Eq,
   Lang: ?Sized,
 {
 }

--- a/tokora/src/types/ident_list.rs
+++ b/tokora/src/types/ident_list.rs
@@ -129,7 +129,7 @@ impl<S, Span, Container, Lang: ?Sized> AsSpan<Span> for IdentList<S, Span, Conta
 /// The three predicates below are **inherent and stay inherent**, unlike the carriers'.
 ///
 /// They are not the same question. A carrier is in exactly one of three states, which is what
-/// [`RecoveryState`](super::recovery::RecoveryState) reports; a list is an aggregate, and `is_error` and `is_missing` can both be
+/// [`RecoveryState`](super::RecoveryState) reports; a list is an aggregate, and `is_error` and `is_missing` can both be
 /// true of one at the same time. No single [`Status`](super::Status) can say that, so this type
 /// does not implement the trait and there is no name for it to displace — these three predate
 /// tokora#320 and are unchanged by it.

--- a/tokora/src/types/ident_list.rs
+++ b/tokora/src/types/ident_list.rs
@@ -1,9 +1,9 @@
 use core::marker::PhantomData;
 
-use crate::{
-  span::AsSpan,
-  types::{Ident, recovery::RecoveryState},
-};
+// No `RecoveryState` import: `Ident`'s three predicates are inherent, so they win the pick here
+// without one. That is the same resolution a downstream crate gets, and the reason `Ident` keeps
+// them — see the rule stated beside them in `ident.rs`.
+use crate::{span::AsSpan, types::Ident};
 
 /// A list of identifiers.
 ///
@@ -129,7 +129,7 @@ impl<S, Span, Container, Lang: ?Sized> AsSpan<Span> for IdentList<S, Span, Conta
 /// The three predicates below are **inherent and stay inherent**, unlike the carriers'.
 ///
 /// They are not the same question. A carrier is in exactly one of three states, which is what
-/// [`RecoveryState`] reports; a list is an aggregate, and `is_error` and `is_missing` can both be
+/// [`RecoveryState`](super::recovery::RecoveryState) reports; a list is an aggregate, and `is_error` and `is_missing` can both be
 /// true of one at the same time. No single [`Status`](super::Status) can say that, so this type
 /// does not implement the trait and there is no name for it to displace — these three predate
 /// tokora#320 and are unchanged by it.

--- a/tokora/src/types/ident_list.rs
+++ b/tokora/src/types/ident_list.rs
@@ -6,7 +6,6 @@ use crate::{span::AsSpan, types::Ident};
 ///
 /// `S` remains sized because the default container stores `Ident<S, Span>` values
 /// inline in a `Vec`; use the individual [`Ident`] carrier for an unsized source.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub struct IdentList<
   S,
@@ -24,13 +23,103 @@ pub struct IdentList<
 ///
 /// `S` remains sized to keep this type's API consistent with its `Vec`-backed
 /// form; use the individual [`Ident`] carrier for an unsized source.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg(not(any(feature = "alloc", feature = "std")))]
 pub struct IdentList<S, Span, Container, Lang: ?Sized = ()> {
   span: Span,
   identifiers: Container,
   _m: PhantomData<S>,
   _lang: PhantomData<Lang>,
+}
+
+// The six impls below replace a `derive`, and the only thing that changes is the bound list.
+//
+// A derive constrains **every** type parameter, so `#[derive(Debug)]` on a type holding a
+// `PhantomData<Lang>` emitted `Lang: Debug` — a requirement on a marker that is never printed,
+// never compared and never hashed, because `PhantomData<T>` implements all six for any `T`
+// unconditionally. The effect was that `IdentList<..., MyLang>` was not `Debug`, `Copy` or
+// comparable unless the consumer derived those on `MyLang` too, for a reason that does not
+// exist. tokora#320 caught it the way such things are caught: a doctest that would not compile
+// until four derives were added to the marker.
+//
+// Rendered output and comparison order are unchanged. `Debug` still prints every field in
+// declaration order including the marker, `PartialEq` still short-circuits in that order, and
+// `Hash` still feeds the same bytes — `PhantomData` hashes nothing, so omitting it is not a
+// change.
+
+impl<S, Span, Container, Lang> ::core::fmt::Debug for IdentList<S, Span, Container, Lang>
+where
+  Span: ::core::fmt::Debug,
+  Container: ::core::fmt::Debug,
+  Lang: ?Sized,
+{
+  fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+    // Declaration order, which is the order the derive printed in: `span`, `identifiers`, then
+    // the two markers. Nothing about the rendering changes here, only the bounds above.
+    f.debug_struct("IdentList")
+      .field("span", &&self.span)
+      .field("identifiers", &&self.identifiers)
+      .field("_m", &&self._m)
+      .field("_lang", &&self._lang)
+      .finish()
+  }
+}
+
+impl<S, Span, Container, Lang> ::core::clone::Clone for IdentList<S, Span, Container, Lang>
+where
+  Span: ::core::clone::Clone,
+  Container: ::core::clone::Clone,
+  Lang: ?Sized,
+{
+  #[inline]
+  fn clone(&self) -> Self {
+    Self {
+      _m: ::core::marker::PhantomData,
+      _lang: ::core::marker::PhantomData,
+      span: ::core::clone::Clone::clone(&self.span),
+      identifiers: ::core::clone::Clone::clone(&self.identifiers),
+    }
+  }
+}
+
+impl<S, Span, Container, Lang> ::core::marker::Copy for IdentList<S, Span, Container, Lang>
+where
+  Span: ::core::marker::Copy,
+  Container: ::core::marker::Copy,
+  Lang: ?Sized,
+{
+}
+
+impl<S, Span, Container, Lang> ::core::cmp::PartialEq for IdentList<S, Span, Container, Lang>
+where
+  Span: ::core::cmp::PartialEq,
+  Container: ::core::cmp::PartialEq,
+  Lang: ?Sized,
+{
+  #[inline]
+  fn eq(&self, other: &Self) -> bool {
+    self.span == other.span && self.identifiers == other.identifiers
+  }
+}
+
+impl<S, Span, Container, Lang> ::core::cmp::Eq for IdentList<S, Span, Container, Lang>
+where
+  Span: ::core::cmp::Eq,
+  Container: ::core::cmp::Eq,
+  Lang: ?Sized,
+{
+}
+
+impl<S, Span, Container, Lang> ::core::hash::Hash for IdentList<S, Span, Container, Lang>
+where
+  Span: ::core::hash::Hash,
+  Container: ::core::hash::Hash,
+  Lang: ?Sized,
+{
+  #[inline]
+  fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
+    ::core::hash::Hash::hash(&self.span, state);
+    ::core::hash::Hash::hash(&self.identifiers, state);
+  }
 }
 
 impl<S, Span, Container, Lang: ?Sized> AsSpan<Span> for IdentList<S, Span, Container, Lang> {

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -55,7 +55,7 @@
 //! allowing creation of placeholder keywords during error recovery:
 //!
 //! ```rust,ignore
-//! use tokora::{error::ErrorNode, types::RecoveryState};
+//! use tokora::{error::ErrorNode, types::recovery::RecoveryState};
 //!
 //! // Create placeholder for malformed identifier
 //! let bad_ident = Keyword::<String, SimpleSpan, YulLang>::error(span);
@@ -67,7 +67,7 @@
 //! ```
 //!
 //! Which of the three states a keyword is in is read through
-//! [`RecoveryState`](super::RecoveryState), which must be in scope, and never from the payload.
+//! [`RecoveryState`](super::recovery::RecoveryState), which must be in scope, and never from the payload.
 //! There is no inherent accessor: see the trait for why an inherent one cannot fail loudly. The payload of a placeholder
 //! is whatever `S::error` / `S::missing` produced — for `&str` the literal `"<error>"`, a
 //! value a caller can also spell by hand — and it is mutable through
@@ -76,7 +76,7 @@
 
 use core::marker::PhantomData;
 
-use super::status::Status;
+use super::recovery::Status;
 use crate::{
   error::ErrorNode,
   span::{AsSpan, SimpleSpan},
@@ -165,6 +165,21 @@ use crate::{
 /// *ident.span_mut() = SimpleSpan::new(10, 18);
 /// assert_eq!(ident.span(), SimpleSpan::new(10, 18));
 /// ```
+// `PartialEq` and `Eq` are **derived** while the other four are written out, and that split is
+// the point rather than an inconsistency.
+//
+// A derive constrains every type parameter, which is why `Debug`, `Clone`, `Copy` and `Hash` are
+// hand-written here: none of them reads `Lang`, so none of them should demand anything of it.
+// `PartialEq`/`Eq` cannot join them. The derive is also what emits `StructuralPartialEq`, and
+// without that marker a `const` of this type cannot appear in a `match` pattern — "constant of
+// non-structural type", a property no amount of checking the rendered output can see, because it
+// is not observable except by trying to use a value in a pattern.
+//
+// So the residual is stated rather than hidden: comparing or pattern-matching one of these still
+// needs the language marker to be `PartialEq + Eq`. Printing, cloning, copying and hashing do
+// not. That is four of the six bounds dropped against 0.9, and structural matching kept exactly
+// as 0.9 had it.
+#[derive(PartialEq, Eq)]
 pub struct Keyword<S: ?Sized, Span = SimpleSpan, Lang: ?Sized = ()> {
   _lang: PhantomData<Lang>,
   status: Status,
@@ -224,26 +239,6 @@ impl<S, Span, Lang> ::core::marker::Copy for Keyword<S, Span, Lang>
 where
   S: ::core::marker::Copy,
   Span: ::core::marker::Copy,
-  Lang: ?Sized,
-{
-}
-
-impl<S, Span, Lang> ::core::cmp::PartialEq for Keyword<S, Span, Lang>
-where
-  S: ::core::cmp::PartialEq + ?Sized,
-  Span: ::core::cmp::PartialEq,
-  Lang: ?Sized,
-{
-  #[inline]
-  fn eq(&self, other: &Self) -> bool {
-    self.status == other.status && self.span == other.span && self.ident == other.ident
-  }
-}
-
-impl<S, Span, Lang> ::core::cmp::Eq for Keyword<S, Span, Lang>
-where
-  S: ::core::cmp::Eq + ?Sized,
-  Span: ::core::cmp::Eq,
   Lang: ?Sized,
 {
 }
@@ -347,8 +342,13 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   /// # Examples
   ///
   /// ```rust
-  /// use tokora::{SimpleSpan, types::{Keyword, RecoveryState, Status}};
-  /// # struct MyLang;
+  /// use tokora::{SimpleSpan, types::{Keyword, Status}};
+  /// use tokora::types::recovery::RecoveryState;
+  /// // Comparing carriers needs the marker to be `PartialEq`: `PartialEq`/`Eq` stay derived
+  /// // so a `const` carrier keeps working in a `match` pattern, and a derive constrains
+  /// // every parameter. `Debug`, `Clone`, `Copy` and `Hash` need nothing of it.
+  /// #[derive(PartialEq)]
+  /// struct MyLang;
   ///
   /// let span = SimpleSpan::new(0, 4);
   /// let recovered = Keyword::<&str, SimpleSpan, MyLang>::with_status(span, "then", Status::Missing);
@@ -562,7 +562,7 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   }
 }
 
-impl<S: ?Sized, Span, Lang: ?Sized> super::RecoveryState for Keyword<S, Span, Lang> {
+impl<S: ?Sized, Span, Lang: ?Sized> super::recovery::RecoveryState for Keyword<S, Span, Lang> {
   #[inline(always)]
   fn status(&self) -> Status {
     self.status

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -293,7 +293,7 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Keyword<S, Span, Lang> {
   /// zero-sized language marker, which the rebuild names in its own type.
   ///
   /// The status is here because this trait promises a complete decomposition and because
-  /// [`with_status`](Keyword::with_status) is the inverse: without it in both, a consumer who
+  /// [`FromComponents`](super::recovery::FromComponents) is the inverse: without it in both, a consumer who
   /// took a carrier apart and put it back together would have to rebuild through
   /// [`new`](Keyword::new), which always declares the result valid — the same laundering
   /// tokora#303 removed from [`map`](Keyword::map), reached one door over.
@@ -331,38 +331,14 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
     Self::with_status(span, source, Status::Valid)
   }
 
-  /// Creates a keyword with an explicitly given recovery status.
+  /// The status-setting constructor, crate-internal.
   ///
-  /// The inverse of [`into_components`](Self::into_components), and the only constructor that
-  /// can express a state other than valid over a payload the caller chose: [`new`](Self::new)
-  /// always declares the result valid, and [`ErrorNode::error`](ErrorNode::error) /
-  /// [`ErrorNode::missing`](ErrorNode::missing) pick the payload themselves. A dialect with its
-  /// own placeholder spelling needs this one.
-  ///
-  /// # Examples
-  ///
-  /// ```rust
-  /// use tokora::{SimpleSpan, types::{Keyword, Status}};
-  /// use tokora::types::recovery::RecoveryState;
-  /// // Comparing carriers needs the marker to be `PartialEq`: `PartialEq`/`Eq` stay derived
-  /// // so a `const` carrier keeps working in a `match` pattern, and a derive constrains
-  /// // every parameter. `Debug`, `Clone`, `Copy` and `Hash` need nothing of it.
-  /// #[derive(PartialEq)]
-  /// struct MyLang;
-  ///
-  /// let span = SimpleSpan::new(0, 4);
-  /// let recovered = Keyword::<&str, SimpleSpan, MyLang>::with_status(span, "then", Status::Missing);
-  ///
-  /// assert!(recovered.is_missing());
-  /// assert_eq!(recovered.source_ref(), &"then");
-  ///
-  /// // Round trip: the three components rebuild the value they came from.
-  /// let (span, source, status) = recovered.into_components();
-  /// let rebuilt = Keyword::<&str, SimpleSpan, MyLang>::with_status(span, source, status);
-  /// assert_eq!(rebuilt, recovered);
-  /// ```
+  /// Public construction with a chosen status goes through
+  /// [`FromComponents`](super::recovery::FromComponents), whose argument is an associated
+  /// type rather than a bare `Status` — see that trait for the type-directed inference
+  /// route that made an inherent `with_status` unsafe to ship.
   #[inline(always)]
-  pub const fn with_status(span: Span, source: S, status: Status) -> Self {
+  const fn with_status(span: Span, source: S, status: Status) -> Self {
     Self {
       span,
       ident: source,
@@ -517,7 +493,8 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   /// delegates here rather than repeating the body. `Ident` and the `Lit*` family have no such
   /// second door.
   ///
-  /// The status is part of the result because [`with_status`](Self::with_status) is the inverse
+  /// The status is part of the result because
+  /// [`FromComponents`](super::recovery::FromComponents) is the inverse
   /// and a decomposition that dropped it could only be rebuilt through [`new`](Self::new), which
   /// always declares the result valid.
   #[inline(always)]
@@ -559,6 +536,15 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
       span,
       ident: f(ident),
     }
+  }
+}
+
+impl<S, Span, Lang: ?Sized> super::recovery::FromComponents for Keyword<S, Span, Lang> {
+  #[inline(always)]
+  fn from_components(components: Self::Components) -> Self {
+    let (span, source, status) = components;
+
+    Self::with_status(span, source, status)
   }
 }
 

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -55,7 +55,7 @@
 //! allowing creation of placeholder keywords during error recovery:
 //!
 //! ```rust,ignore
-//! use tokora::error::ErrorNode;
+//! use tokora::{error::ErrorNode, types::RecoveryState};
 //!
 //! // Create placeholder for malformed identifier
 //! let bad_ident = Keyword::<String, SimpleSpan, YulLang>::error(span);
@@ -66,9 +66,9 @@
 //! assert!(missing_ident.is_missing());
 //! ```
 //!
-//! Which of the three states a keyword is in is read from
-//! [`is_valid`](Keyword::is_valid), [`is_error`](Keyword::is_error) and
-//! [`is_missing`](Keyword::is_missing), never from the payload. The payload of a placeholder
+//! Which of the three states a keyword is in is read from [`RecoveryState`](super::RecoveryState)
+//! — which must be in scope — or from [`Keyword::status`] in a const context, never from the
+//! payload. The payload of a placeholder
 //! is whatever `S::error` / `S::missing` produced — for `&str` the literal `"<error>"`, a
 //! value a caller can also spell by hand — and it is mutable through
 //! [`source_mut`](Keyword::source_mut), so it reports what the node says rather than whether
@@ -347,7 +347,7 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   /// # Examples
   ///
   /// ```rust
-  /// use tokora::{SimpleSpan, types::{Keyword, Status}};
+  /// use tokora::{SimpleSpan, types::{Keyword, RecoveryState, Status}};
   /// # struct MyLang;
   ///
   /// let span = SimpleSpan::new(0, 4);
@@ -476,22 +476,18 @@ impl<S: ?Sized, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
     &self.ident
   }
 
-  /// Returns `true` is this keyword represents an error keyword.
+  /// Returns the recovery state of this keyword.
+  ///
+  /// The three questions — valid, error, missing — are asked through
+  /// [`RecoveryState`](super::RecoveryState), which has to be in scope. They are not inherent
+  /// methods because those names are ones a consumer may already have on an extension trait of
+  /// their own, and an inherent method wins that pick silently; see the trait for the argument.
+  ///
+  /// This accessor is inherent so that the state stays readable in a const context, which a
+  /// trait method cannot be: `x.status().is_valid()` is `const` all the way down.
   #[inline(always)]
-  pub const fn is_error(&self) -> bool {
-    self.status.is_error()
-  }
-
-  /// Returns `true` is this keyword represents a missing keyword.
-  #[inline(always)]
-  pub const fn is_missing(&self) -> bool {
-    self.status.is_missing()
-  }
-
-  /// Returns `true` is this keyword is valid (not error or missing).
-  #[inline(always)]
-  pub const fn is_valid(&self) -> bool {
-    self.status.is_valid()
+  pub const fn status(&self) -> Status {
+    self.status
   }
 }
 
@@ -577,6 +573,13 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
       span,
       ident: f(ident),
     }
+  }
+}
+
+impl<S: ?Sized, Span, Lang: ?Sized> super::RecoveryState for Keyword<S, Span, Lang> {
+  #[inline(always)]
+  fn status(&self) -> Status {
+    self.status
   }
 }
 

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -55,7 +55,7 @@
 //! allowing creation of placeholder keywords during error recovery:
 //!
 //! ```rust,ignore
-//! use tokora::{error::ErrorNode, types::RecoveryState};
+//! use tokora::{error::ErrorNode, types::recovery::RecoveryState};
 //!
 //! // Create placeholder for malformed identifier
 //! let bad_ident = Keyword::<String, SimpleSpan, YulLang>::error(span);
@@ -67,7 +67,7 @@
 //! ```
 //!
 //! Which of the three states a keyword is in is read through
-//! [`RecoveryState`](super::RecoveryState), which must be in scope, and never from the payload.
+//! [`RecoveryState`](super::recovery::RecoveryState), which must be in scope, and never from the payload.
 //! There is no inherent accessor: see the trait for why an inherent one cannot fail loudly. The payload of a placeholder
 //! is whatever `S::error` / `S::missing` produced — for `&str` the literal `"<error>"`, a
 //! value a caller can also spell by hand — and it is mutable through
@@ -76,7 +76,7 @@
 
 use core::marker::PhantomData;
 
-use super::Status;
+use super::recovery::Status;
 use crate::{
   error::ErrorNode,
   span::{AsSpan, SimpleSpan},
@@ -135,7 +135,7 @@ use crate::{
 /// ## Extracting Components
 ///
 /// ```rust
-/// # use tokora::types::{Keyword, Components};
+/// # use tokora::types::{Keyword, recovery::Components};
 /// # use tokora::SimpleSpan;
 /// # use tokora::utils::IntoComponents;
 /// # struct MyLang;
@@ -143,7 +143,7 @@ use crate::{
 /// let ident = Keyword::<&str, SimpleSpan, MyLang>::new(span, "foo");
 ///
 /// // Destructure into span, payload and recovery status. A named struct, not a tuple: see
-/// // `types::Components` for the `..` pattern that made a three-tuple unsafe.
+/// // `types::recovery::Components` for the `..` pattern that made a three-tuple unsafe.
 /// let Components { span, payload, status } = ident.into_components();
 /// assert_eq!(payload, "foo");
 /// assert!(status.is_valid());
@@ -294,11 +294,11 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Keyword<S, Span, Lang> {
   /// zero-sized language marker, which the rebuild names in its own type.
   ///
   /// The status is here because this trait promises a complete decomposition and because
-  /// [`FromComponents`](super::FromComponents) is the inverse: without it in both, a consumer who
+  /// [`FromComponents`](super::recovery::FromComponents) is the inverse: without it in both, a consumer who
   /// took a carrier apart and put it back together would have to rebuild through
   /// [`new`](Keyword::new), which always declares the result valid — the same laundering
   /// tokora#303 removed from [`map`](Keyword::map), reached one door over.
-  type Components = super::Components<Span, S>;
+  type Components = super::recovery::Components<Span, S>;
 
   #[inline(always)]
   fn into_components(self) -> Self::Components {
@@ -335,7 +335,7 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   /// The status-setting constructor, crate-internal.
   ///
   /// Public construction with a chosen status goes through
-  /// [`FromComponents`](super::FromComponents), whose argument is an associated
+  /// [`FromComponents`](super::recovery::FromComponents), whose argument is an associated
   /// type rather than a bare `Status` — see that trait for the type-directed inference
   /// route that made an inherent `with_status` unsafe to ship.
   #[inline(always)]
@@ -495,11 +495,11 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   /// second door.
   ///
   /// The status is part of the result because
-  /// [`FromComponents`](super::FromComponents) is the inverse
+  /// [`FromComponents`](super::recovery::FromComponents) is the inverse
   /// and a decomposition that dropped it could only be rebuilt through [`new`](Self::new), which
   /// always declares the result valid.
   #[inline(always)]
-  pub fn into_components(self) -> super::Components<Span, S> {
+  pub fn into_components(self) -> super::recovery::Components<Span, S> {
     let Self {
       _lang,
       status,
@@ -507,7 +507,7 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
       ident,
     } = self;
 
-    super::Components {
+    super::recovery::Components {
       span,
       payload: ident,
       status,
@@ -544,10 +544,10 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   }
 }
 
-impl<S, Span, Lang: ?Sized> super::FromComponents for Keyword<S, Span, Lang> {
+impl<S, Span, Lang: ?Sized> super::recovery::FromComponents for Keyword<S, Span, Lang> {
   #[inline(always)]
   fn from_components(components: Self::Components) -> Self {
-    let super::Components {
+    let super::recovery::Components {
       span,
       payload,
       status,
@@ -557,7 +557,7 @@ impl<S, Span, Lang: ?Sized> super::FromComponents for Keyword<S, Span, Lang> {
   }
 }
 
-impl<S: ?Sized, Span, Lang: ?Sized> super::RecoveryState for Keyword<S, Span, Lang> {
+impl<S: ?Sized, Span, Lang: ?Sized> super::recovery::RecoveryState for Keyword<S, Span, Lang> {
   #[inline(always)]
   fn status(&self) -> Status {
     self.status

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -66,9 +66,9 @@
 //! assert!(missing_ident.is_missing());
 //! ```
 //!
-//! Which of the three states a keyword is in is read from [`RecoveryState`](super::RecoveryState)
-//! — which must be in scope — or from [`Keyword::status`] in a const context, never from the
-//! payload. The payload of a placeholder
+//! Which of the three states a keyword is in is read through
+//! [`RecoveryState`](super::RecoveryState), which must be in scope, and never from the payload.
+//! There is no inherent accessor: see the trait for why an inherent one cannot fail loudly. The payload of a placeholder
 //! is whatever `S::error` / `S::missing` produced — for `&str` the literal `"<error>"`, a
 //! value a caller can also spell by hand — and it is mutable through
 //! [`source_mut`](Keyword::source_mut), so it reports what the node says rather than whether
@@ -474,20 +474,6 @@ impl<S: ?Sized, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   #[inline(always)]
   pub const fn source_ref(&self) -> &S {
     &self.ident
-  }
-
-  /// Returns the recovery state of this keyword.
-  ///
-  /// The three questions — valid, error, missing — are asked through
-  /// [`RecoveryState`](super::RecoveryState), which has to be in scope. They are not inherent
-  /// methods because those names are ones a consumer may already have on an extension trait of
-  /// their own, and an inherent method wins that pick silently; see the trait for the argument.
-  ///
-  /// This accessor is inherent so that the state stays readable in a const context, which a
-  /// trait method cannot be: `x.status().is_valid()` is `const` all the way down.
-  #[inline(always)]
-  pub const fn status(&self) -> Status {
-    self.status
   }
 }
 

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -135,16 +135,17 @@ use crate::{
 /// ## Extracting Components
 ///
 /// ```rust
-/// # use tokora::types::Keyword;
+/// # use tokora::types::{Keyword, recovery::Components};
 /// # use tokora::SimpleSpan;
 /// # use tokora::utils::IntoComponents;
 /// # struct MyLang;
 /// # let span = SimpleSpan::new(0, 3);
 /// let ident = Keyword::<&str, SimpleSpan, MyLang>::new(span, "foo");
 ///
-/// // Destructure into span, source and recovery status
-/// let (span, source, status) = ident.into_components();
-/// assert_eq!(source, "foo");
+/// // Destructure into span, payload and recovery status. A named struct, not a tuple: see
+/// // `types::recovery::Components` for the `..` pattern that made a three-tuple unsafe.
+/// let Components { span, payload, status } = ident.into_components();
+/// assert_eq!(payload, "foo");
 /// assert!(status.is_valid());
 /// ```
 ///
@@ -297,7 +298,7 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Keyword<S, Span, Lang> {
   /// took a carrier apart and put it back together would have to rebuild through
   /// [`new`](Keyword::new), which always declares the result valid — the same laundering
   /// tokora#303 removed from [`map`](Keyword::map), reached one door over.
-  type Components = (Span, S, Status);
+  type Components = super::recovery::Components<Span, S>;
 
   #[inline(always)]
   fn into_components(self) -> Self::Components {
@@ -498,7 +499,7 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   /// and a decomposition that dropped it could only be rebuilt through [`new`](Self::new), which
   /// always declares the result valid.
   #[inline(always)]
-  pub fn into_components(self) -> (Span, S, Status) {
+  pub fn into_components(self) -> super::recovery::Components<Span, S> {
     let Self {
       _lang,
       status,
@@ -506,7 +507,11 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
       ident,
     } = self;
 
-    (span, ident, status)
+    super::recovery::Components {
+      span,
+      payload: ident,
+      status,
+    }
   }
 
   /// Maps the source string to a new type, preserving the span, the language, and the
@@ -542,9 +547,13 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
 impl<S, Span, Lang: ?Sized> super::recovery::FromComponents for Keyword<S, Span, Lang> {
   #[inline(always)]
   fn from_components(components: Self::Components) -> Self {
-    let (span, source, status) = components;
+    let super::recovery::Components {
+      span,
+      payload,
+      status,
+    } = components;
 
-    Self::with_status(span, source, status)
+    Self::with_status(span, payload, status)
   }
 }
 

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -142,9 +142,10 @@ use crate::{
 /// # let span = SimpleSpan::new(0, 3);
 /// let ident = Keyword::<&str, SimpleSpan, MyLang>::new(span, "foo");
 ///
-/// // Destructure into span and source
-/// let (span, source) = ident.into_components();
+/// // Destructure into span, source and recovery status
+/// let (span, source, status) = ident.into_components();
 /// assert_eq!(source, "foo");
+/// assert!(status.is_valid());
 /// ```
 ///
 /// ## Mutable Access
@@ -204,11 +205,19 @@ impl<S: ?Sized, Span, Lang: ?Sized> AsSpan<Span> for Keyword<S, Span, Lang> {
 }
 
 impl<S, Span, Lang: ?Sized> IntoComponents for Keyword<S, Span, Lang> {
-  type Components = (Span, S);
+  /// The span, the source, **and the recovery status** — every field this type holds beyond the
+  /// zero-sized language marker, which the rebuild names in its own type.
+  ///
+  /// The status is here because this trait promises a complete decomposition and because
+  /// [`with_status`](Keyword::with_status) is the inverse: without it in both, a consumer who
+  /// took a carrier apart and put it back together would have to rebuild through
+  /// [`new`](Keyword::new), which always declares the result valid — the same laundering
+  /// tokora#303 removed from [`map`](Keyword::map), reached one door over.
+  type Components = (Span, S, Status);
 
   #[inline(always)]
   fn into_components(self) -> Self::Components {
-    (self.span, self.ident)
+    Keyword::into_components(self)
   }
 }
 
@@ -238,8 +247,34 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
     Self::with_status(span, source, Status::Valid)
   }
 
+  /// Creates a keyword with an explicitly given recovery status.
+  ///
+  /// The inverse of [`into_components`](Self::into_components), and the only constructor that
+  /// can express a state other than valid over a payload the caller chose: [`new`](Self::new)
+  /// always declares the result valid, and [`ErrorNode::error`](ErrorNode::error) /
+  /// [`ErrorNode::missing`](ErrorNode::missing) pick the payload themselves. A dialect with its
+  /// own placeholder spelling needs this one.
+  ///
+  /// # Examples
+  ///
+  /// ```rust
+  /// use tokora::{SimpleSpan, types::{Keyword, Status}};
+  /// # #[derive(Debug, Clone, Copy, PartialEq)]
+  /// # struct MyLang;
+  ///
+  /// let span = SimpleSpan::new(0, 4);
+  /// let recovered = Keyword::<&str, SimpleSpan, MyLang>::with_status(span, "then", Status::Missing);
+  ///
+  /// assert!(recovered.is_missing());
+  /// assert_eq!(recovered.source_ref(), &"then");
+  ///
+  /// // Round trip: the three components rebuild the value they came from.
+  /// let (span, source, status) = recovered.into_components();
+  /// let rebuilt = Keyword::<&str, SimpleSpan, MyLang>::with_status(span, source, status);
+  /// assert_eq!(rebuilt, recovered);
+  /// ```
   #[inline(always)]
-  const fn with_status(span: Span, source: S, status: Status) -> Self {
+  pub const fn with_status(span: Span, source: S, status: Status) -> Self {
     Self {
       span,
       ident: source,
@@ -403,10 +438,28 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
     self.ident
   }
 
-  /// Consumes the identifier and returns the span and source string.
+  /// Consumes the keyword and returns the span, the source string and the recovery status.
+  ///
+  /// This is an inherent method with the same name as
+  /// [`IntoComponents::into_components`](IntoComponents::into_components), which `Keyword` also
+  /// implements, and an inherent item wins the pick at an unqualified call site. That makes the
+  /// two returning *different* shapes a defect no diagnostic would report, so the trait impl
+  /// delegates here rather than repeating the body. `Ident` and the `Lit*` family have no such
+  /// second door.
+  ///
+  /// The status is part of the result because [`with_status`](Self::with_status) is the inverse
+  /// and a decomposition that dropped it could only be rebuilt through [`new`](Self::new), which
+  /// always declares the result valid.
   #[inline(always)]
-  pub fn into_components(self) -> (Span, S) {
-    (self.span, self.ident)
+  pub fn into_components(self) -> (Span, S, Status) {
+    let Self {
+      _lang,
+      status,
+      span,
+      ident,
+    } = self;
+
+    (span, ident, status)
   }
 
   /// Maps the source string to a new type, preserving the span, the language, and the

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -165,12 +165,101 @@ use crate::{
 /// *ident.span_mut() = SimpleSpan::new(10, 18);
 /// assert_eq!(ident.span(), SimpleSpan::new(10, 18));
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Keyword<S: ?Sized, Span = SimpleSpan, Lang: ?Sized = ()> {
   _lang: PhantomData<Lang>,
   status: Status,
   span: Span,
   ident: S,
+}
+
+// The six impls below replace a `derive`, and the only thing that changes is the bound list.
+//
+// A derive constrains **every** type parameter, so `#[derive(Debug)]` on a type holding a
+// `PhantomData<Lang>` emitted `Lang: Debug` — a requirement on a marker that is never printed,
+// never compared and never hashed, because `PhantomData<T>` implements all six for any `T`
+// unconditionally. The effect was that `Keyword<..., MyLang>` was not `Debug`, `Copy` or
+// comparable unless the consumer derived those on `MyLang` too, for a reason that does not
+// exist. tokora#320 caught it the way such things are caught: a doctest that would not compile
+// until four derives were added to the marker.
+//
+// Rendered output and comparison order are unchanged. `Debug` still prints every field in
+// declaration order including the marker, `PartialEq` still short-circuits in that order, and
+// `Hash` still feeds the same bytes — `PhantomData` hashes nothing, so omitting it is not a
+// change.
+
+impl<S, Span, Lang> ::core::fmt::Debug for Keyword<S, Span, Lang>
+where
+  S: ::core::fmt::Debug + ?Sized,
+  Span: ::core::fmt::Debug,
+  Lang: ?Sized,
+{
+  fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+    f.debug_struct("Keyword")
+      .field("_lang", &&self._lang)
+      .field("status", &&self.status)
+      .field("span", &&self.span)
+      .field("ident", &&self.ident)
+      .finish()
+  }
+}
+
+impl<S, Span, Lang> ::core::clone::Clone for Keyword<S, Span, Lang>
+where
+  S: ::core::clone::Clone,
+  Span: ::core::clone::Clone,
+  Lang: ?Sized,
+{
+  #[inline]
+  fn clone(&self) -> Self {
+    Self {
+      _lang: ::core::marker::PhantomData,
+      status: self.status,
+      span: ::core::clone::Clone::clone(&self.span),
+      ident: ::core::clone::Clone::clone(&self.ident),
+    }
+  }
+}
+
+impl<S, Span, Lang> ::core::marker::Copy for Keyword<S, Span, Lang>
+where
+  S: ::core::marker::Copy,
+  Span: ::core::marker::Copy,
+  Lang: ?Sized,
+{
+}
+
+impl<S, Span, Lang> ::core::cmp::PartialEq for Keyword<S, Span, Lang>
+where
+  S: ::core::cmp::PartialEq + ?Sized,
+  Span: ::core::cmp::PartialEq,
+  Lang: ?Sized,
+{
+  #[inline]
+  fn eq(&self, other: &Self) -> bool {
+    self.status == other.status && self.span == other.span && self.ident == other.ident
+  }
+}
+
+impl<S, Span, Lang> ::core::cmp::Eq for Keyword<S, Span, Lang>
+where
+  S: ::core::cmp::Eq + ?Sized,
+  Span: ::core::cmp::Eq,
+  Lang: ?Sized,
+{
+}
+
+impl<S, Span, Lang> ::core::hash::Hash for Keyword<S, Span, Lang>
+where
+  S: ::core::hash::Hash + ?Sized,
+  Span: ::core::hash::Hash,
+  Lang: ?Sized,
+{
+  #[inline]
+  fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
+    ::core::hash::Hash::hash(&self.status, state);
+    ::core::hash::Hash::hash(&self.span, state);
+    ::core::hash::Hash::hash(&self.ident, state);
+  }
 }
 
 impl<S, Span, Lang: ?Sized> From<Keyword<S, Span, Lang>> for super::Ident<S, Span, Lang> {
@@ -259,7 +348,6 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   ///
   /// ```rust
   /// use tokora::{SimpleSpan, types::{Keyword, Status}};
-  /// # #[derive(Debug, Clone, Copy, PartialEq)]
   /// # struct MyLang;
   ///
   /// let span = SimpleSpan::new(0, 4);

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -55,7 +55,7 @@
 //! allowing creation of placeholder keywords during error recovery:
 //!
 //! ```rust,ignore
-//! use tokora::{error::ErrorNode, types::recovery::RecoveryState};
+//! use tokora::{error::ErrorNode, types::RecoveryState};
 //!
 //! // Create placeholder for malformed identifier
 //! let bad_ident = Keyword::<String, SimpleSpan, YulLang>::error(span);
@@ -67,7 +67,7 @@
 //! ```
 //!
 //! Which of the three states a keyword is in is read through
-//! [`RecoveryState`](super::recovery::RecoveryState), which must be in scope, and never from the payload.
+//! [`RecoveryState`](super::RecoveryState), which must be in scope, and never from the payload.
 //! There is no inherent accessor: see the trait for why an inherent one cannot fail loudly. The payload of a placeholder
 //! is whatever `S::error` / `S::missing` produced — for `&str` the literal `"<error>"`, a
 //! value a caller can also spell by hand — and it is mutable through
@@ -76,7 +76,7 @@
 
 use core::marker::PhantomData;
 
-use super::recovery::Status;
+use super::Status;
 use crate::{
   error::ErrorNode,
   span::{AsSpan, SimpleSpan},
@@ -135,7 +135,7 @@ use crate::{
 /// ## Extracting Components
 ///
 /// ```rust
-/// # use tokora::types::{Keyword, recovery::Components};
+/// # use tokora::types::{Keyword, Components};
 /// # use tokora::SimpleSpan;
 /// # use tokora::utils::IntoComponents;
 /// # struct MyLang;
@@ -143,7 +143,7 @@ use crate::{
 /// let ident = Keyword::<&str, SimpleSpan, MyLang>::new(span, "foo");
 ///
 /// // Destructure into span, payload and recovery status. A named struct, not a tuple: see
-/// // `types::recovery::Components` for the `..` pattern that made a three-tuple unsafe.
+/// // `types::Components` for the `..` pattern that made a three-tuple unsafe.
 /// let Components { span, payload, status } = ident.into_components();
 /// assert_eq!(payload, "foo");
 /// assert!(status.is_valid());
@@ -294,11 +294,11 @@ impl<S, Span, Lang: ?Sized> IntoComponents for Keyword<S, Span, Lang> {
   /// zero-sized language marker, which the rebuild names in its own type.
   ///
   /// The status is here because this trait promises a complete decomposition and because
-  /// [`FromComponents`](super::recovery::FromComponents) is the inverse: without it in both, a consumer who
+  /// [`FromComponents`](super::FromComponents) is the inverse: without it in both, a consumer who
   /// took a carrier apart and put it back together would have to rebuild through
   /// [`new`](Keyword::new), which always declares the result valid — the same laundering
   /// tokora#303 removed from [`map`](Keyword::map), reached one door over.
-  type Components = super::recovery::Components<Span, S>;
+  type Components = super::Components<Span, S>;
 
   #[inline(always)]
   fn into_components(self) -> Self::Components {
@@ -335,7 +335,7 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   /// The status-setting constructor, crate-internal.
   ///
   /// Public construction with a chosen status goes through
-  /// [`FromComponents`](super::recovery::FromComponents), whose argument is an associated
+  /// [`FromComponents`](super::FromComponents), whose argument is an associated
   /// type rather than a bare `Status` — see that trait for the type-directed inference
   /// route that made an inherent `with_status` unsafe to ship.
   #[inline(always)]
@@ -495,11 +495,11 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   /// second door.
   ///
   /// The status is part of the result because
-  /// [`FromComponents`](super::recovery::FromComponents) is the inverse
+  /// [`FromComponents`](super::FromComponents) is the inverse
   /// and a decomposition that dropped it could only be rebuilt through [`new`](Self::new), which
   /// always declares the result valid.
   #[inline(always)]
-  pub fn into_components(self) -> super::recovery::Components<Span, S> {
+  pub fn into_components(self) -> super::Components<Span, S> {
     let Self {
       _lang,
       status,
@@ -507,7 +507,7 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
       ident,
     } = self;
 
-    super::recovery::Components {
+    super::Components {
       span,
       payload: ident,
       status,
@@ -544,10 +544,10 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   }
 }
 
-impl<S, Span, Lang: ?Sized> super::recovery::FromComponents for Keyword<S, Span, Lang> {
+impl<S, Span, Lang: ?Sized> super::FromComponents for Keyword<S, Span, Lang> {
   #[inline(always)]
   fn from_components(components: Self::Components) -> Self {
-    let super::recovery::Components {
+    let super::Components {
       span,
       payload,
       status,
@@ -557,7 +557,7 @@ impl<S, Span, Lang: ?Sized> super::recovery::FromComponents for Keyword<S, Span,
   }
 }
 
-impl<S: ?Sized, Span, Lang: ?Sized> super::recovery::RecoveryState for Keyword<S, Span, Lang> {
+impl<S: ?Sized, Span, Lang: ?Sized> super::RecoveryState for Keyword<S, Span, Lang> {
   #[inline(always)]
   fn status(&self) -> Status {
     self.status

--- a/tokora/src/types/keyword.rs
+++ b/tokora/src/types/keyword.rs
@@ -59,13 +59,24 @@
 //!
 //! // Create placeholder for malformed identifier
 //! let bad_ident = Keyword::<String, SimpleSpan, YulLang>::error(span);
+//! assert!(bad_ident.is_error());
 //!
 //! // Create placeholder for missing identifier
 //! let missing_ident = Keyword::<String, SimpleSpan, YulLang>::missing(span);
+//! assert!(missing_ident.is_missing());
 //! ```
+//!
+//! Which of the three states a keyword is in is read from
+//! [`is_valid`](Keyword::is_valid), [`is_error`](Keyword::is_error) and
+//! [`is_missing`](Keyword::is_missing), never from the payload. The payload of a placeholder
+//! is whatever `S::error` / `S::missing` produced — for `&str` the literal `"<error>"`, a
+//! value a caller can also spell by hand — and it is mutable through
+//! [`source_mut`](Keyword::source_mut), so it reports what the node says rather than whether
+//! the parser found one.
 
 use core::marker::PhantomData;
 
+use super::status::Status;
 use crate::{
   error::ErrorNode,
   span::{AsSpan, SimpleSpan},
@@ -156,26 +167,32 @@ use crate::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Keyword<S: ?Sized, Span = SimpleSpan, Lang: ?Sized = ()> {
   _lang: PhantomData<Lang>,
+  status: Status,
   span: Span,
   ident: S,
 }
 
 impl<S, Span, Lang: ?Sized> From<Keyword<S, Span, Lang>> for super::Ident<S, Span, Lang> {
-  /// The resulting identifier is reported as valid unconditionally. `Keyword` has no field
-  /// that can hold a recovery status and no predicate that can report one, so there is
-  /// nothing to carry across. This conversion therefore cannot distinguish a keyword that
-  /// was spelled out in the source from one built by `Keyword::error` or `Keyword::missing`,
-  /// and it reports the latter as valid too — that gap is tracked as tokora#301 and is not
-  /// fixable here, because the information does not exist on the source side.
+  /// The recovery status crosses unchanged: a keyword built by
+  /// [`error`](ErrorNode::error) or [`missing`](ErrorNode::missing) becomes an identifier that
+  /// reports itself the same way, and only a keyword actually spelled out in the source
+  /// produces a valid one. Both carriers hold the same status type, so there is nothing to
+  /// fabricate here — which is what tokora#301 fixed, and why this impl no longer rebuilds
+  /// through [`Ident::new`](super::Ident::new).
   ///
   /// The source is destructured exhaustively so that a `Keyword` field added later stops this
   /// impl from compiling — a cross-type rebuild cannot be made total on the target side, but it
   /// can be made total on the side whose fields it reads.
   #[inline(always)]
   fn from(keyword: Keyword<S, Span, Lang>) -> Self {
-    let Keyword { _lang, span, ident } = keyword;
+    let Keyword {
+      _lang,
+      status,
+      span,
+      ident,
+    } = keyword;
 
-    Self::new(span, ident)
+    Self::with_status(span, ident, status)
   }
 }
 
@@ -218,9 +235,15 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   /// ```
   #[inline(always)]
   pub const fn new(span: Span, source: S) -> Self {
+    Self::with_status(span, source, Status::Valid)
+  }
+
+  #[inline(always)]
+  const fn with_status(span: Span, source: S, status: Status) -> Self {
     Self {
       span,
       ident: source,
+      status,
       _lang: PhantomData,
     }
   }
@@ -329,6 +352,24 @@ impl<S: ?Sized, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
   pub const fn source_ref(&self) -> &S {
     &self.ident
   }
+
+  /// Returns `true` is this keyword represents an error keyword.
+  #[inline(always)]
+  pub const fn is_error(&self) -> bool {
+    self.status.is_error()
+  }
+
+  /// Returns `true` is this keyword represents a missing keyword.
+  #[inline(always)]
+  pub const fn is_missing(&self) -> bool {
+    self.status.is_missing()
+  }
+
+  /// Returns `true` is this keyword is valid (not error or missing).
+  #[inline(always)]
+  pub const fn is_valid(&self) -> bool {
+    self.status.is_valid()
+  }
 }
 
 impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
@@ -368,19 +409,30 @@ impl<S, Span, Lang: ?Sized> Keyword<S, Span, Lang> {
     (self.span, self.ident)
   }
 
-  /// Maps the source string to a new type, preserving the span and language.
+  /// Maps the source string to a new type, preserving the span, the language, and the
+  /// recovery status.
   ///
-  /// Destructures `Self` exhaustively rather than rebuilding through [`Self::new`]. Today
-  /// the two are equivalent, because `Keyword` carries nothing beyond the span, the source
-  /// and the language marker — but a `new`-based body drops any field added later without
+  /// Recovery status is orthogonal to the source representation: mapping `Keyword<&str>` to
+  /// `Keyword<String>` changes how the spelling is stored, not whether the parser actually
+  /// found a keyword there. An [`error`](ErrorNode::error) or [`missing`](ErrorNode::missing)
+  /// placeholder therefore stays one across the map.
+  ///
+  /// Destructures `Self` exhaustively rather than rebuilding through [`Self::new`], because
+  /// `new` always produces a valid keyword: a `new`-based body would drop the status without
   /// a diagnostic, which is exactly how [`Ident::map`](super::Ident::map) came to launder
   /// recovery placeholders into valid syntax. This form fails to compile instead.
   #[inline(always)]
   pub fn map<U>(self, f: impl FnOnce(S) -> U) -> Keyword<U, Span, Lang> {
-    let Self { _lang, span, ident } = self;
+    let Self {
+      _lang,
+      status,
+      span,
+      ident,
+    } = self;
 
     Keyword {
       _lang,
+      status,
       span,
       ident: f(ident),
     }
@@ -405,10 +457,11 @@ where
   ///
   /// // Parser found "123abc" where an identifier was expected
   /// let bad_ident = Keyword::<String, SimpleSpan, YulLang>::error(span);
+  /// assert!(bad_ident.is_error());
   /// ```
   #[inline]
   fn error(span: Span) -> Self {
-    Self::new(span.clone(), S::error(span))
+    Self::with_status(span.clone(), S::error(span), Status::Error)
   }
 
   /// Creates a placeholder identifier for **missing required content**.
@@ -427,9 +480,10 @@ where
   /// // Correct: let name = 5;
   /// // Found:   let = 5;
   /// let missing_ident = Keyword::<String, SimpleSpan, YulLang>::missing(span);
+  /// assert!(missing_ident.is_missing());
   /// ```
   #[inline]
   fn missing(span: Span) -> Self {
-    Self::new(span.clone(), S::missing(span))
+    Self::with_status(span.clone(), S::missing(span), Status::Missing)
   }
 }

--- a/tokora/src/types/lit.rs
+++ b/tokora/src/types/lit.rs
@@ -248,7 +248,7 @@ macro_rules! define_literal {
       /// the zero-sized language marker, which the rebuild names in its own type.
       ///
       /// The status is here because this trait promises a complete decomposition and because
-      /// `with_status` is the inverse: without it in both, a consumer who took a literal apart
+      /// `FromComponents` is the inverse: without it in both, a consumer who took a literal apart
       /// and put it back together would have to rebuild through `new`, which always declares the
       /// result valid.
       type Components = (Span, D, Status);
@@ -318,14 +318,11 @@ macro_rules! define_literal {
         Self::with_status(span, data, Status::Valid)
       }
 
-      /// Creates a literal with an explicitly given recovery status.
-      ///
-      /// The inverse of `into_components`, and the only constructor that can express a state
-      /// other than valid over data the caller chose: `new` always declares the result valid,
-      /// and `ErrorNode::error` / `ErrorNode::missing` pick the data themselves. A dialect with
-      /// its own placeholder spelling needs this one.
+      /// The status-setting constructor, crate-internal. Public construction with a chosen
+      /// status goes through `FromComponents`; see that trait for why an inherent
+      /// `with_status` could be re-targeted by a type-directed argument.
       #[inline(always)]
-      pub const fn with_status(span: Span, data: D, status: Status) -> Self {
+      const fn with_status(span: Span, data: D, status: Status) -> Self {
         Self {
           span,
           data,
@@ -343,6 +340,17 @@ macro_rules! define_literal {
         D: Copy,
       {
         self.data
+      }
+    }
+
+    impl<D, Span, Lang: ?::core::marker::Sized> $crate::types::recovery::FromComponents
+      for $name<D, Span, Lang>
+    {
+      #[inline(always)]
+      fn from_components(components: Self::Components) -> Self {
+        let (span, data, status) = components;
+
+        Self::with_status(span, data, status)
       }
     }
 

--- a/tokora/src/types/lit.rs
+++ b/tokora/src/types/lit.rs
@@ -98,7 +98,7 @@
 
 use core::marker::PhantomData;
 
-use super::recovery::Status;
+use super::Status;
 use crate::{error::ErrorNode, span::AsSpan, utils::IntoComponents};
 
 /// A macro to generate literal type structures.
@@ -251,13 +251,13 @@ macro_rules! define_literal {
       /// `FromComponents` is the inverse: without it in both, a consumer who took a literal apart
       /// and put it back together would have to rebuild through `new`, which always declares the
       /// result valid.
-      type Components = $crate::types::recovery::Components<Span, D>;
+      type Components = $crate::types::Components<Span, D>;
 
       #[inline(always)]
       fn into_components(self) -> Self::Components {
         let Self { _lang, status, span, data } = self;
 
-        $crate::types::recovery::Components { span, payload: data, status }
+        $crate::types::Components { span, payload: data, status }
       }
     }
 
@@ -343,18 +343,18 @@ macro_rules! define_literal {
       }
     }
 
-    impl<D, Span, Lang: ?::core::marker::Sized> $crate::types::recovery::FromComponents
+    impl<D, Span, Lang: ?::core::marker::Sized> $crate::types::FromComponents
       for $name<D, Span, Lang>
     {
       #[inline(always)]
       fn from_components(components: Self::Components) -> Self {
-        let $crate::types::recovery::Components { span, payload, status } = components;
+        let $crate::types::Components { span, payload, status } = components;
 
         Self::with_status(span, payload, status)
       }
     }
 
-    impl<D: ?::core::marker::Sized, Span, Lang: ?::core::marker::Sized> $crate::types::recovery::RecoveryState
+    impl<D: ?::core::marker::Sized, Span, Lang: ?::core::marker::Sized> $crate::types::RecoveryState
       for $name<D, Span, Lang>
     {
       #[inline(always)]

--- a/tokora/src/types/lit.rs
+++ b/tokora/src/types/lit.rs
@@ -148,7 +148,6 @@ macro_rules! define_literal {
       #[doc = "// " $example_desc]
       #[doc = "let bad_lit = " $name "::<String, SimpleSpan, YulLang>::error(span);"]
       /// ```
-      #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
       pub struct $name<
         D: ?::core::marker::Sized $( = $default)?,
         Span = $crate::__private::span::SimpleSpan,
@@ -158,6 +157,90 @@ macro_rules! define_literal {
         status: Status,
         span: Span,
         data: D,
+      }
+
+      // Written out rather than derived, and the only thing that changes is the bound list. A
+      // derive constrains **every** type parameter, so `#[derive(Debug)]` here emitted
+      // `Lang: Debug` — a requirement on a marker that is never printed, compared or hashed,
+      // since `PhantomData<T>` implements all six for any `T` unconditionally. Seventeen literal
+      // types were unusable with an underived language marker for a reason that does not exist.
+      //
+      // Rendering, comparison order and hashed bytes are unchanged: every field is still visited
+      // in declaration order, the possibly-unsized one still goes in behind a second reference
+      // the way the derive passes it, and `PhantomData` hashes nothing.
+      impl<D, Span, Lang> ::core::fmt::Debug for $name<D, Span, Lang>
+      where
+        D: ::core::fmt::Debug + ?::core::marker::Sized,
+        Span: ::core::fmt::Debug,
+        Lang: ?::core::marker::Sized,
+      {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+          f.debug_struct(::core::stringify!($name))
+            .field("_lang", &&self._lang)
+            .field("status", &&self.status)
+            .field("span", &&self.span)
+            .field("data", &&self.data)
+            .finish()
+        }
+      }
+
+      impl<D, Span, Lang> ::core::clone::Clone for $name<D, Span, Lang>
+      where
+        D: ::core::clone::Clone,
+        Span: ::core::clone::Clone,
+        Lang: ?::core::marker::Sized,
+      {
+        #[inline]
+        fn clone(&self) -> Self {
+          Self {
+            _lang: PhantomData,
+            status: self.status,
+            span: ::core::clone::Clone::clone(&self.span),
+            data: ::core::clone::Clone::clone(&self.data),
+          }
+        }
+      }
+
+      impl<D, Span, Lang> ::core::marker::Copy for $name<D, Span, Lang>
+      where
+        D: ::core::marker::Copy,
+        Span: ::core::marker::Copy,
+        Lang: ?::core::marker::Sized,
+      {
+      }
+
+      impl<D, Span, Lang> ::core::cmp::PartialEq for $name<D, Span, Lang>
+      where
+        D: ::core::cmp::PartialEq + ?::core::marker::Sized,
+        Span: ::core::cmp::PartialEq,
+        Lang: ?::core::marker::Sized,
+      {
+        #[inline]
+        fn eq(&self, other: &Self) -> bool {
+          self.status == other.status && self.span == other.span && self.data == other.data
+        }
+      }
+
+      impl<D, Span, Lang> ::core::cmp::Eq for $name<D, Span, Lang>
+      where
+        D: ::core::cmp::Eq + ?::core::marker::Sized,
+        Span: ::core::cmp::Eq,
+        Lang: ?::core::marker::Sized,
+      {
+      }
+
+      impl<D, Span, Lang> ::core::hash::Hash for $name<D, Span, Lang>
+      where
+        D: ::core::hash::Hash + ?::core::marker::Sized,
+        Span: ::core::hash::Hash,
+        Lang: ?::core::marker::Sized,
+      {
+        #[inline]
+        fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
+          ::core::hash::Hash::hash(&self.status, state);
+          ::core::hash::Hash::hash(&self.span, state);
+          ::core::hash::Hash::hash(&self.data, state);
+        }
       }
     }
 

--- a/tokora/src/types/lit.rs
+++ b/tokora/src/types/lit.rs
@@ -89,8 +89,9 @@
 //! assert!(missing_lit.is_missing());
 //! ```
 //!
-//! Which of the three states a literal is in is read from the `RecoveryState` trait — which must
-//! be in scope — or from the inherent `status` accessor in a const context, never from the data. A placeholder's data is whatever `D::error` /
+//! Which of the three states a literal is in is read through the `RecoveryState` trait, which
+//! must be in scope, and never from the data. There is no inherent accessor: see the trait for
+//! why an inherent one cannot fail loudly. A placeholder's data is whatever `D::error` /
 //! `D::missing` produced — for `&str` the literal `"<error>"`, a value a caller can also spell
 //! by hand — and it is mutable through `data_mut`, so it reports what the node says rather
 //! than whether the parser found one.
@@ -314,19 +315,6 @@ macro_rules! define_literal {
         &self.data
       }
 
-      /// Returns the recovery state of this literal.
-      ///
-      /// The three questions — valid, error, missing — are asked through `RecoveryState`, which
-      /// has to be in scope. They are not inherent methods because those names are ones a
-      /// consumer may already have on an extension trait of their own, and an inherent method
-      /// wins that pick silently; see the trait for the argument.
-      ///
-      /// This accessor is inherent so that the state stays readable in a const context, which a
-      /// trait method cannot be: `x.status().is_valid()` is `const` all the way down.
-      #[inline(always)]
-      pub const fn status(&self) -> Status {
-        self.status
-      }
     }
 
     impl<D, Span, Lang: ?::core::marker::Sized> $name<D, Span, Lang> {

--- a/tokora/src/types/lit.rs
+++ b/tokora/src/types/lit.rs
@@ -82,13 +82,22 @@
 //!
 //! // Create placeholder for malformed literal
 //! let bad_lit = LitDecimal::<String, SimpleSpan, YulLang>::error(span);
+//! assert!(bad_lit.is_error());
 //!
 //! // Create placeholder for missing literal
 //! let missing_lit = LitDecimal::<String, SimpleSpan, YulLang>::missing(span);
+//! assert!(missing_lit.is_missing());
 //! ```
+//!
+//! Which of the three states a literal is in is read from `is_valid`, `is_error` and
+//! `is_missing`, never from the data. A placeholder's data is whatever `D::error` /
+//! `D::missing` produced — for `&str` the literal `"<error>"`, a value a caller can also spell
+//! by hand — and it is mutable through `data_mut`, so it reports what the node says rather
+//! than whether the parser found one.
 
 use core::marker::PhantomData;
 
+use super::status::Status;
 use crate::{error::ErrorNode, span::AsSpan, utils::IntoComponents};
 
 /// A macro to generate literal type structures.
@@ -146,6 +155,7 @@ macro_rules! define_literal {
         Lang: ?::core::marker::Sized = (),
       > {
         _lang: PhantomData<Lang>,
+        status: Status,
         span: Span,
         data: D,
       }
@@ -211,6 +221,24 @@ macro_rules! define_literal {
       pub const fn data_ref(&self) -> &D {
         &self.data
       }
+
+      /// Returns `true` is this literal represents an error literal.
+      #[inline(always)]
+      pub const fn is_error(&self) -> bool {
+        self.status.is_error()
+      }
+
+      /// Returns `true` is this literal represents a missing literal.
+      #[inline(always)]
+      pub const fn is_missing(&self) -> bool {
+        self.status.is_missing()
+      }
+
+      /// Returns `true` is this literal is valid (not error or missing).
+      #[inline(always)]
+      pub const fn is_valid(&self) -> bool {
+        self.status.is_valid()
+      }
     }
 
     impl<D, Span, Lang: ?::core::marker::Sized> $name<D, Span, Lang> {
@@ -222,9 +250,15 @@ macro_rules! define_literal {
       /// - `data`: The literal's data
       #[inline(always)]
       pub const fn new(span: Span, data: D) -> Self {
+        Self::with_status(span, data, Status::Valid)
+      }
+
+      #[inline(always)]
+      const fn with_status(span: Span, data: D, status: Status) -> Self {
         Self {
           span,
           data,
+          status,
           _lang: PhantomData,
         }
       }
@@ -247,15 +281,21 @@ macro_rules! define_literal {
       Span: Clone,
     {
       /// Creates a placeholder literal for **malformed content**.
+      ///
+      /// The result reports itself through `is_error`; the data is a placeholder, not the
+      /// channel.
       #[inline(always)]
       fn error(span: Span) -> Self {
-        Self::new(span.clone(), D::error(span))
+        Self::with_status(span.clone(), D::error(span), Status::Error)
       }
 
       /// Creates a placeholder literal for **missing required content**.
+      ///
+      /// The result reports itself through `is_missing`; the data is a placeholder, not the
+      /// channel.
       #[inline(always)]
       fn missing(span: Span) -> Self {
-        Self::new(span.clone(), D::missing(span))
+        Self::with_status(span.clone(), D::missing(span), Status::Missing)
       }
     }
   };

--- a/tokora/src/types/lit.rs
+++ b/tokora/src/types/lit.rs
@@ -98,7 +98,7 @@
 
 use core::marker::PhantomData;
 
-use super::Status;
+use super::recovery::Status;
 use crate::{error::ErrorNode, span::AsSpan, utils::IntoComponents};
 
 /// A macro to generate literal type structures.
@@ -251,13 +251,13 @@ macro_rules! define_literal {
       /// `FromComponents` is the inverse: without it in both, a consumer who took a literal apart
       /// and put it back together would have to rebuild through `new`, which always declares the
       /// result valid.
-      type Components = $crate::types::Components<Span, D>;
+      type Components = $crate::types::recovery::Components<Span, D>;
 
       #[inline(always)]
       fn into_components(self) -> Self::Components {
         let Self { _lang, status, span, data } = self;
 
-        $crate::types::Components { span, payload: data, status }
+        $crate::types::recovery::Components { span, payload: data, status }
       }
     }
 
@@ -343,18 +343,18 @@ macro_rules! define_literal {
       }
     }
 
-    impl<D, Span, Lang: ?::core::marker::Sized> $crate::types::FromComponents
+    impl<D, Span, Lang: ?::core::marker::Sized> $crate::types::recovery::FromComponents
       for $name<D, Span, Lang>
     {
       #[inline(always)]
       fn from_components(components: Self::Components) -> Self {
-        let $crate::types::Components { span, payload, status } = components;
+        let $crate::types::recovery::Components { span, payload, status } = components;
 
         Self::with_status(span, payload, status)
       }
     }
 
-    impl<D: ?::core::marker::Sized, Span, Lang: ?::core::marker::Sized> $crate::types::RecoveryState
+    impl<D: ?::core::marker::Sized, Span, Lang: ?::core::marker::Sized> $crate::types::recovery::RecoveryState
       for $name<D, Span, Lang>
     {
       #[inline(always)]

--- a/tokora/src/types/lit.rs
+++ b/tokora/src/types/lit.rs
@@ -77,7 +77,7 @@
 //! All literal types implement [`ErrorNode`] when `S: ErrorNode`:
 //!
 //! ```rust,ignore
-//! use tokora::types::LitDecimal;
+//! use tokora::types::{LitDecimal, RecoveryState};
 //! use tokora::error::ErrorNode;
 //!
 //! // Create placeholder for malformed literal
@@ -89,8 +89,8 @@
 //! assert!(missing_lit.is_missing());
 //! ```
 //!
-//! Which of the three states a literal is in is read from `is_valid`, `is_error` and
-//! `is_missing`, never from the data. A placeholder's data is whatever `D::error` /
+//! Which of the three states a literal is in is read from the `RecoveryState` trait — which must
+//! be in scope — or from the inherent `status` accessor in a const context, never from the data. A placeholder's data is whatever `D::error` /
 //! `D::missing` produced — for `&str` the literal `"<error>"`, a value a caller can also spell
 //! by hand — and it is mutable through `data_mut`, so it reports what the node says rather
 //! than whether the parser found one.
@@ -314,22 +314,18 @@ macro_rules! define_literal {
         &self.data
       }
 
-      /// Returns `true` is this literal represents an error literal.
+      /// Returns the recovery state of this literal.
+      ///
+      /// The three questions — valid, error, missing — are asked through `RecoveryState`, which
+      /// has to be in scope. They are not inherent methods because those names are ones a
+      /// consumer may already have on an extension trait of their own, and an inherent method
+      /// wins that pick silently; see the trait for the argument.
+      ///
+      /// This accessor is inherent so that the state stays readable in a const context, which a
+      /// trait method cannot be: `x.status().is_valid()` is `const` all the way down.
       #[inline(always)]
-      pub const fn is_error(&self) -> bool {
-        self.status.is_error()
-      }
-
-      /// Returns `true` is this literal represents a missing literal.
-      #[inline(always)]
-      pub const fn is_missing(&self) -> bool {
-        self.status.is_missing()
-      }
-
-      /// Returns `true` is this literal is valid (not error or missing).
-      #[inline(always)]
-      pub const fn is_valid(&self) -> bool {
-        self.status.is_valid()
+      pub const fn status(&self) -> Status {
+        self.status
       }
     }
 
@@ -370,6 +366,15 @@ macro_rules! define_literal {
         D: Copy,
       {
         self.data
+      }
+    }
+
+    impl<D: ?::core::marker::Sized, Span, Lang: ?::core::marker::Sized> $crate::types::RecoveryState
+      for $name<D, Span, Lang>
+    {
+      #[inline(always)]
+      fn status(&self) -> Status {
+        self.status
       }
     }
 

--- a/tokora/src/types/lit.rs
+++ b/tokora/src/types/lit.rs
@@ -98,7 +98,7 @@
 
 use core::marker::PhantomData;
 
-use super::status::Status;
+use super::recovery::Status;
 use crate::{error::ErrorNode, span::AsSpan, utils::IntoComponents};
 
 /// A macro to generate literal type structures.
@@ -149,6 +149,13 @@ macro_rules! define_literal {
       #[doc = "// " $example_desc]
       #[doc = "let bad_lit = " $name "::<String, SimpleSpan, YulLang>::error(span);"]
       /// ```
+      // `PartialEq`/`Eq` are derived while the other four are written out. A derive constrains
+      // every type parameter, which is why the other four are hand-written — none of them reads
+      // `Lang`. These two cannot join them: the derive is what emits `StructuralPartialEq`,
+      // without which a `const` of one of these seventeen types cannot appear in a `match`
+      // pattern, and that is not observable by checking rendered output. The residual is that
+      // comparing or matching one still needs `Lang` to be `PartialEq + Eq`, as 0.9 required.
+      #[derive(PartialEq, Eq)]
       pub struct $name<
         D: ?::core::marker::Sized $( = $default)?,
         Span = $crate::__private::span::SimpleSpan,
@@ -210,25 +217,7 @@ macro_rules! define_literal {
       {
       }
 
-      impl<D, Span, Lang> ::core::cmp::PartialEq for $name<D, Span, Lang>
-      where
-        D: ::core::cmp::PartialEq + ?::core::marker::Sized,
-        Span: ::core::cmp::PartialEq,
-        Lang: ?::core::marker::Sized,
-      {
-        #[inline]
-        fn eq(&self, other: &Self) -> bool {
-          self.status == other.status && self.span == other.span && self.data == other.data
-        }
-      }
 
-      impl<D, Span, Lang> ::core::cmp::Eq for $name<D, Span, Lang>
-      where
-        D: ::core::cmp::Eq + ?::core::marker::Sized,
-        Span: ::core::cmp::Eq,
-        Lang: ?::core::marker::Sized,
-      {
-      }
 
       impl<D, Span, Lang> ::core::hash::Hash for $name<D, Span, Lang>
       where
@@ -357,7 +346,7 @@ macro_rules! define_literal {
       }
     }
 
-    impl<D: ?::core::marker::Sized, Span, Lang: ?::core::marker::Sized> $crate::types::RecoveryState
+    impl<D: ?::core::marker::Sized, Span, Lang: ?::core::marker::Sized> $crate::types::recovery::RecoveryState
       for $name<D, Span, Lang>
     {
       #[inline(always)]

--- a/tokora/src/types/lit.rs
+++ b/tokora/src/types/lit.rs
@@ -251,13 +251,13 @@ macro_rules! define_literal {
       /// `FromComponents` is the inverse: without it in both, a consumer who took a literal apart
       /// and put it back together would have to rebuild through `new`, which always declares the
       /// result valid.
-      type Components = (Span, D, Status);
+      type Components = $crate::types::recovery::Components<Span, D>;
 
       #[inline(always)]
       fn into_components(self) -> Self::Components {
         let Self { _lang, status, span, data } = self;
 
-        (span, data, status)
+        $crate::types::recovery::Components { span, payload: data, status }
       }
     }
 
@@ -348,9 +348,9 @@ macro_rules! define_literal {
     {
       #[inline(always)]
       fn from_components(components: Self::Components) -> Self {
-        let (span, data, status) = components;
+        let $crate::types::recovery::Components { span, payload, status } = components;
 
-        Self::with_status(span, data, status)
+        Self::with_status(span, payload, status)
       }
     }
 

--- a/tokora/src/types/lit.rs
+++ b/tokora/src/types/lit.rs
@@ -171,11 +171,20 @@ macro_rules! define_literal {
     }
 
     impl<D, Span, Lang: ?::core::marker::Sized> IntoComponents for $name<D, Span, Lang> {
-      type Components = (Span, D);
+      /// The span, the data, **and the recovery status** — every field this type holds beyond
+      /// the zero-sized language marker, which the rebuild names in its own type.
+      ///
+      /// The status is here because this trait promises a complete decomposition and because
+      /// `with_status` is the inverse: without it in both, a consumer who took a literal apart
+      /// and put it back together would have to rebuild through `new`, which always declares the
+      /// result valid.
+      type Components = (Span, D, Status);
 
       #[inline(always)]
       fn into_components(self) -> Self::Components {
-        (self.span, self.data)
+        let Self { _lang, status, span, data } = self;
+
+        (span, data, status)
       }
     }
 
@@ -253,8 +262,14 @@ macro_rules! define_literal {
         Self::with_status(span, data, Status::Valid)
       }
 
+      /// Creates a literal with an explicitly given recovery status.
+      ///
+      /// The inverse of `into_components`, and the only constructor that can express a state
+      /// other than valid over data the caller chose: `new` always declares the result valid,
+      /// and `ErrorNode::error` / `ErrorNode::missing` pick the data themselves. A dialect with
+      /// its own placeholder spelling needs this one.
       #[inline(always)]
-      const fn with_status(span: Span, data: D, status: Status) -> Self {
+      pub const fn with_status(span: Span, data: D, status: Status) -> Self {
         Self {
           span,
           data,

--- a/tokora/src/types/mod.rs
+++ b/tokora/src/types/mod.rs
@@ -86,29 +86,24 @@ pub use ident::*;
 pub use ident_list::*;
 pub use keyword::*;
 pub use lit::*;
-// Everything the recovery API exposes is re-exported here as ITEMS, and `recovery` is a private
-// module, because the kinds resolve differently under a consumer's glob. Measured against
-// rustc 1.100.0-nightly, over three axes:
+// Nothing from `recovery` is re-exported here, and that includes `Status`.
 //
-//                    vs an extern crate    vs a second glob    vs a local definition
-//   module           SILENT redirect       E0659               local wins
-//   trait            E0790                 SILENT, 1st glob    local wins
-//   type / fn/const  E0599 / no interaction E0659              local wins
+// An earlier draft did re-export the type, on a measurement that said a TYPE name collides loudly
+// under a consumer's glob while a TRAIT name does not. The type half of that was wrong: the probe
+// asked the shadowing type for an associated item it did not have, so it could only be loud. With
+// both sides carrying the item the consumer reaches for, a glob-added type silently shadows an
+// extern crate of the same name exactly as a module does — a dependency aliased `Status` has
+// `Status::Error.is_error()` flip from its answer to tokora's, both revisions compiling.
 //
-// A `pub mod recovery` therefore put a MODULE name into `types::*`, and a consumer with a
-// dependency named `recovery` had every `recovery::...` path silently rebound to tokora — a whole
-// crate path prefix, in code unrelated to this API. Re-exporting the items instead removes that
-// entirely and leaves only the trait names, whose only silent axis is a second glob and whose
-// blast radius is four method names on tokora's own carriers. Both cannot be closed at once: a
-// public trait must live in a module, and every module is either already globbed or a new name in
-// one. That is written out on `recovery`'s own header.
-pub use recovery::{Components, FromComponents, RecoveryState, Status};
+// So the count is what matters, not the kind: `recovery` alone puts ONE new name into `types::*`,
+// where re-exporting the four items puts four, two silent on each axis. See `recovery`'s header
+// for the re-measured table and the residual this leaves.
 
 mod ident;
 mod ident_list;
 mod keyword;
 mod lit;
-mod recovery;
+pub mod recovery;
 
 /// A type representing a recoverable parse node, which can be a valid node,
 /// an error node with span, or a missing node with span.

--- a/tokora/src/types/mod.rs
+++ b/tokora/src/types/mod.rs
@@ -86,13 +86,20 @@ pub use ident::*;
 pub use ident_list::*;
 pub use keyword::*;
 pub use lit::*;
-pub use status::*;
+// `Status` is re-exported into `types` and `RecoveryState` deliberately is not. Reproduced
+// against rustc 1.100.0-nightly, the two names behave differently under a consumer's second glob:
+// a TYPE name is `error[E0659]: ambiguous`, while a TRAIT name compiles with only a
+// warn-by-default `ambiguous_glob_imported_traits` and silently picks whichever glob came first.
+// A trait in `types::*` would therefore let `use tokora::types::*; use their_crate::*;` rebind a
+// same-named `is_valid` with no error — so the trait must be named to be reached. See
+// `recovery`'s own header.
+pub use recovery::Status;
 
 mod ident;
 mod ident_list;
 mod keyword;
 mod lit;
-mod status;
+pub mod recovery;
 
 /// A type representing a recoverable parse node, which can be a valid node,
 /// an error node with span, or a missing node with span.

--- a/tokora/src/types/mod.rs
+++ b/tokora/src/types/mod.rs
@@ -91,6 +91,7 @@ mod ident;
 mod ident_list;
 mod keyword;
 mod lit;
+mod status;
 
 /// A type representing a recoverable parse node, which can be a valid node,
 /// an error node with span, or a missing node with span.

--- a/tokora/src/types/mod.rs
+++ b/tokora/src/types/mod.rs
@@ -86,6 +86,7 @@ pub use ident::*;
 pub use ident_list::*;
 pub use keyword::*;
 pub use lit::*;
+pub use status::*;
 
 mod ident;
 mod ident_list;

--- a/tokora/src/types/mod.rs
+++ b/tokora/src/types/mod.rs
@@ -90,12 +90,12 @@ pub use lit::*;
 // type without naming the module; `RecoveryState`, `FromComponents` and `Components` are reached
 // through `types::recovery`.
 //
-// That split is ordinary library design, not a safety measurement. A draft of this release chose
-// placements by counting how many names a glob could collide with, and that was the wrong
-// criterion: a glob-import name clash is not a silent semantic change, it is the ordinary cost of
-// a glob, which is the consumer's own choice, and it is paid at compile time with a leading `::`
-// as the one-line fix. `recovery`'s header carries the measured table those rounds produced,
-// which does stand, and the dated crates.io check behind keeping the module's name.
+// That split is ordinary library design, and the line it sits on is stated in `recovery`'s header:
+// tokora must not silently change what a method on a tokora type means, while a name a consumer's
+// own glob shadows is that glob's cost and `::` is its fix. `Status` here is the second kind — a
+// path into the consumer's namespace, not a call on a tokora type — so it is placed where a glob
+// will find it. That header also carries the measured table those rounds produced, both clashes as
+// measured, and the dated crates.io check behind the module's name.
 pub use recovery::Status;
 
 mod ident;

--- a/tokora/src/types/mod.rs
+++ b/tokora/src/types/mod.rs
@@ -86,20 +86,29 @@ pub use ident::*;
 pub use ident_list::*;
 pub use keyword::*;
 pub use lit::*;
-// `Status` is re-exported into `types` and `RecoveryState` deliberately is not. Reproduced
-// against rustc 1.100.0-nightly, the two names behave differently under a consumer's second glob:
-// a TYPE name is `error[E0659]: ambiguous`, while a TRAIT name compiles with only a
-// warn-by-default `ambiguous_glob_imported_traits` and silently picks whichever glob came first.
-// A trait in `types::*` would therefore let `use tokora::types::*; use their_crate::*;` rebind a
-// same-named `is_valid` with no error — so the trait must be named to be reached. See
-// `recovery`'s own header.
-pub use recovery::Status;
+// Everything the recovery API exposes is re-exported here as ITEMS, and `recovery` is a private
+// module, because the kinds resolve differently under a consumer's glob. Measured against
+// rustc 1.100.0-nightly, over three axes:
+//
+//                    vs an extern crate    vs a second glob    vs a local definition
+//   module           SILENT redirect       E0659               local wins
+//   trait            E0790                 SILENT, 1st glob    local wins
+//   type / fn/const  E0599 / no interaction E0659              local wins
+//
+// A `pub mod recovery` therefore put a MODULE name into `types::*`, and a consumer with a
+// dependency named `recovery` had every `recovery::...` path silently rebound to tokora — a whole
+// crate path prefix, in code unrelated to this API. Re-exporting the items instead removes that
+// entirely and leaves only the trait names, whose only silent axis is a second glob and whose
+// blast radius is four method names on tokora's own carriers. Both cannot be closed at once: a
+// public trait must live in a module, and every module is either already globbed or a new name in
+// one. That is written out on `recovery`'s own header.
+pub use recovery::{Components, FromComponents, RecoveryState, Status};
 
 mod ident;
 mod ident_list;
 mod keyword;
 mod lit;
-pub mod recovery;
+mod recovery;
 
 /// A type representing a recoverable parse node, which can be a valid node,
 /// an error node with span, or a missing node with span.

--- a/tokora/src/types/mod.rs
+++ b/tokora/src/types/mod.rs
@@ -86,18 +86,17 @@ pub use ident::*;
 pub use ident_list::*;
 pub use keyword::*;
 pub use lit::*;
-// Nothing from `recovery` is re-exported here, and that includes `Status`.
+// `Status` is re-exported here so a consumer who writes `use tokora::types::*` gets the status
+// type without naming the module; `RecoveryState`, `FromComponents` and `Components` are reached
+// through `types::recovery`.
 //
-// An earlier draft did re-export the type, on a measurement that said a TYPE name collides loudly
-// under a consumer's glob while a TRAIT name does not. The type half of that was wrong: the probe
-// asked the shadowing type for an associated item it did not have, so it could only be loud. With
-// both sides carrying the item the consumer reaches for, a glob-added type silently shadows an
-// extern crate of the same name exactly as a module does — a dependency aliased `Status` has
-// `Status::Error.is_error()` flip from its answer to tokora's, both revisions compiling.
-//
-// So the count is what matters, not the kind: `recovery` alone puts ONE new name into `types::*`,
-// where re-exporting the four items puts four, two silent on each axis. See `recovery`'s header
-// for the re-measured table and the residual this leaves.
+// That split is ordinary library design, not a safety measurement. A draft of this release chose
+// placements by counting how many names a glob could collide with, and that was the wrong
+// criterion: a glob-import name clash is not a silent semantic change, it is the ordinary cost of
+// a glob, which is the consumer's own choice, and it is paid at compile time with a leading `::`
+// as the one-line fix. `recovery`'s header carries the measured table those rounds produced,
+// which does stand, and the dated crates.io check behind keeping the module's name.
+pub use recovery::Status;
 
 mod ident;
 mod ident_list;

--- a/tokora/src/types/recovery.rs
+++ b/tokora/src/types/recovery.rs
@@ -1,48 +1,56 @@
 //! The recovery state of a syntax carrier, the trait that reads it, and the parts it decomposes
-//! into. Every item here is re-exported from [`types`](super); this module is **private**.
+//! into. This module is public and must be named: nothing here is re-exported into
+//! [`types`](super).
 //!
-//! # Why the module is private, and why that is not a full repair
+//! # Why a module, and what it does not fix
 //!
-//! Three axes, measured against `rustc 1.100.0-nightly` with a consumer whose source never
-//! changes and a library that gains one item:
+//! Every placement puts *some* new name into a namespace a consumer can already glob, and the
+//! kinds do not resolve alike. Measured against `rustc 1.100.0-nightly` with the consumer's source
+//! held fixed and the library gaining one item — and, this time, with **both sides exposing the
+//! item the consumer reaches for**, which is what the first attempt got wrong:
 //!
-//! |            | vs an extern crate of that name  | vs a second glob            | vs a local def |
+//! | kind       | vs an extern crate of that name  | vs a second glob            | vs a local def |
 //! |------------|----------------------------------|-----------------------------|----------------|
 //! | **module** | **silent redirect**              | `E0659`                     | local wins     |
+//! | **type**   | **silent redirect**              | `E0659`                     | local wins     |
 //! | **trait**  | `E0790`                          | **silent, first glob wins** | local wins     |
-//! | type       | `E0599`                          | `E0659`                     | local wins     |
 //! | fn / const | no interaction (value namespace) | `E0659`                     | local wins     |
 //!
-//! A `pub mod recovery` inside `types` put a MODULE name into `use tokora::types::*`, and a
-//! consumer with a dependency named `recovery` then had **every** `recovery::...` path silently
-//! rebound to tokora — a whole crate path prefix, in code with nothing to do with this API, with
-//! no error and no warning. Making the module private removes that.
+//! The `type` row was first measured as `E0599`, loud. That was wrong, and wrong in a way worth
+//! recording: the probe asked for an associated item the shadowing type did not have, so it could
+//! only be loud. With a dependency aliased `Status` exporting `Error`, and tokora's `Status`
+//! carrying an `Error` variant with an inherent `is_error()`, `Status::Error.is_error()` compiles
+//! on both revisions and **the boolean inverts**. A collision provoked by asking for something one
+//! side lacks is a verdict about the probe, not about the kind.
 //!
-//! **It does not remove the other one, and the two cannot both be removed.** A public trait has
-//! to live in some module. If that module is already globbed, the trait name is silent on the
-//! second-glob axis; if it is a new module, the module name is silent on the extern-crate axis.
-//! There is no third place to put it, so this is a choice between two residuals rather than a
-//! repair. It was made on blast radius: the module hazard redirects an entire path prefix and is
-//! triggered by a dependency name a consumer may not control, while the trait hazard reaches four
-//! method names on tokora's own carriers and needs a same-named trait glob-imported from the
-//! consumer's own prelude.
+//! So **no kind that can carry this API is loud on both axes.** The question is not which kind is
+//! safe but how few silent names a placement adds, and the floor is one — a public trait must live
+//! in a module, and every module is either already globbed or a new name in one.
 //!
-//! The residual, stated: a consumer who glob-imports both `tokora::types::*` and a prelude of
-//! their own holding a trait named `RecoveryState` or `FromComponents` gets
-//! `ambiguous_glob_imported_traits` — a warning, not an error — and the first glob wins.
+//! A module reaches that floor: `recovery` is the only name this API puts into `types::*`. The
+//! alternative that was briefly shipped — re-exporting all four items into `types` — put **four**
+//! there instead: `Status` and `Components` silent against an extern crate, `RecoveryState` and
+//! `FromComponents` silent against a second glob. That is four times the exposure on both axes, so
+//! it was withdrawn.
+//!
+//! **The residual, stated as what it is.** A consumer with a dependency named or aliased
+//! `recovery` who writes `use tokora::types::*;` has every `recovery::...` path rebound here, with
+//! no error and no warning. The only remaining lever is the module's *name*, and that is
+//! probability rather than safety: no identifier is barred from being a crate alias, so a more
+//! distinctive name would lower the chance without removing the mode. It is not taken, because the
+//! gain cannot be quantified and the churn is real.
 
-/// `tokora::types::recovery` is not a path a consumer can name — the module is private and its
-/// items are re-exported from `types`. This is the in-tree pin for that, because the hazard it
-/// closes needs a second crate to demonstrate and so cannot be a unit test:
+/// Nothing here is re-exported into [`types`](super), and `Status` is the one that had to be
+/// withdrawn: a glob-added TYPE shadows a same-named extern crate exactly as a module does, which
+/// the first measurement missed. These two doctests are the in-tree pin for that, because the
+/// hazard itself needs a second crate to demonstrate and cannot be a unit test.
 ///
-/// ```compile_fail,E0603
-/// use tokora::types::recovery::RecoveryState;
+/// ```compile_fail,E0432
+/// use tokora::types::Status;
 /// ```
 ///
-/// The items are reached from `types` directly:
-///
 /// ```rust
-/// use tokora::types::{Components, FromComponents, RecoveryState, Status};
+/// use tokora::types::recovery::{Components, FromComponents, RecoveryState, Status};
 /// ```
 /// The recovery state of a syntax carrier: whether the parser found the construct, found
 /// something malformed where it should have been, or found nothing at all.
@@ -278,7 +286,7 @@ pub trait RecoveryState {
 /// What replaces them binds by name, so no elision can slide a binding onto the status:
 ///
 /// ```rust
-/// # use tokora::{SimpleSpan, types::{LitDecimal, Components}, utils::IntoComponents};
+/// # use tokora::{SimpleSpan, types::{LitDecimal, recovery::Components}, utils::IntoComponents};
 /// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
 /// let Components { span, payload, status } = lit.into_components();
 /// assert_eq!(payload, "42");
@@ -300,7 +308,7 @@ pub struct Components<Span, Payload> {
 /// took it apart into — the exact inverse, over the same associated type.
 ///
 /// ```rust
-/// use tokora::{SimpleSpan, error::ErrorNode, types::{LitDecimal, FromComponents}};
+/// use tokora::{SimpleSpan, error::ErrorNode, types::{LitDecimal, recovery::FromComponents}};
 /// use tokora::utils::IntoComponents;
 ///
 /// let placeholder = LitDecimal::<&str>::error(SimpleSpan::new(0, 3));

--- a/tokora/src/types/recovery.rs
+++ b/tokora/src/types/recovery.rs
@@ -8,8 +8,7 @@
 //! # How a name added to a globbed namespace behaves, by kind
 //!
 //! This table is a measured fact and is the durable result of the rounds that produced it. What it
-//! is **not** is the reason for the placement above — see *Why the placement is not derived from
-//! this table*.
+//! is **not** is the reason for the placement above — see *The line this API is placed on*.
 //!
 //! Measured against `rustc 1.100.0-nightly` with the consumer's source held fixed and the library
 //! gaining one item — and with **both sides exposing the item the consumer reaches for**, which is
@@ -31,54 +30,55 @@
 //!
 //! So **no kind that can carry this API is loud on both axes.** That is the finding, and it holds.
 //!
-//! # Why the placement is not derived from this table
+//! # The line this API is placed on
 //!
-//! A draft of this release read the table as a budget and chose placements by counting how many
-//! names a consumer's glob could collide with. That was the wrong criterion, and two rounds of it
-//! cancelled each other out.
+//! **tokora must not silently change what a method on a tokora type means. A name a consumer's own
+//! glob shadows is that glob's cost, and `::` is its fix.**
 //!
-//! This crate's concern is a **silent semantic change**: code that keeps compiling and means
-//! something different, with nothing to tell the consumer. `map` laundering a recovery placeholder
-//! into valid syntax was that. An inherent `is_valid` displacing a consumer's own was that. A
-//! glob-import name clash is **not**: a glob is the consumer's own choice, the clash is that
-//! choice's ordinary cost, and it is paid at compile time with a leading `::` as the one-line fix.
+//! Those are two different axes, and almost every repair in tokora#320 is the first one.
+//! `literal.is_valid()`, where `literal` is a `Lit*`, an [`Ident`](super::Ident) or a
+//! [`Keyword`](super::Keyword): the consumer is holding **tokora's** type, calling what they
+//! believe is their own check, and getting tokora's answer. That is tokora changing what its own
+//! API means underneath them, with nothing at the call site to say so. Moving the three questions
+//! onto [`RecoveryState`], withdrawing an inherent `status`, withdrawing an inherent `with_status`
+//! for [`FromComponents`], and making [`Components`] a braced struct are all that one class.
 //!
-//! It is also a rule nothing could follow. If a public module may not be added because some crate
-//! might share its name, no public module can ever be added again.
+//! The names in this module's *path* — `Status` in `types::*`, and `recovery` itself — are the
+//! second axis. Neither is a call on a tokora type. Both are a path into the consumer's own
+//! namespace being shadowed by a glob **they** wrote, in code that has nothing to do with tokora's
+//! carriers. That is namespace hygiene: the ordinary cost of `use ...::*`, whose remedy the
+//! language already provides. `::recovery::Recovery` and `::my_status::Status` reach past any glob,
+//! and it is the same one-line remedy in both cases.
 //!
-//! So the placement above is ordinary library design — the vocabulary type where a glob will find
-//! it, the traits behind a path — and the table is kept because it is true, not because it decided
-//! anything.
+//! This matters because the earlier reasoning used *loud versus silent* as the deciding property,
+//! and that does not survive: of these two names the one that clashes loudly is the module, and the
+//! one that can clash quietly is `Status`. Sorting them that way would keep the wrong one. Sorting
+//! by **whose type the call is on** puts both outside the line and leaves every carrier repair
+//! inside it.
 //!
-//! What that costs, measured rather than assumed: with `Status` in `types::*`, a consumer whose
-//! own dependency is aliased `Status` and who writes `use tokora::types::*;` resolves
-//! `Status::Error.is_error()` here rather than to their crate, and both revisions compile. That is
-//! the one name in this API whose glob clash can be quiet rather than a compile error, and it is
-//! accepted for the reason above: a glob is the consumer's choice, and `::` is the fix. The
-//! module's own name does not have that property — see below.
+//! It is also a rule nothing could follow. If a public name may not be added because some crate
+//! might share it, no public module or vocabulary type can ever be added again.
 //!
-//! # The module's name, checked rather than argued
+//! # Both clashes, measured
 //!
-//! A consumer with a dependency named or aliased `recovery` who writes `use tokora::types::*;` has
-//! `recovery::...` paths resolve here instead of to their crate. That is a *silent* change only if
-//! this module also exports the item they were reaching for; reach for anything else and the
-//! result is `E0432` at their own import line, fixed by one leading `::` — which is what
-//! `::recovery::Recovery` is for.
+//! Recorded so nobody re-derives them. They are evidence for the placement above, not open
+//! questions.
 //!
-//! **A crate of this name is published, and that is the evidence for keeping the name rather than
-//! a warning about it.** Checked against the crates.io API on **2026-08-27**: `recovery` 0.1.6,
-//! ~16.1k downloads, last updated 2025-09-14. Its documentation instructs `use recovery::Recovery;`
-//! — and `Recovery` is not one of this module's four names, so a consumer of both crates who
-//! upgrades gets a compile error at that import, measured as `E0432` (plus `E0659` where the name
-//! is then used), never a redirect. The genuinely silent case would need a crate that is both named
-//! `recovery` **and** exports one of `Status`, `Components`, `RecoveryState` or `FromComponents`.
+//! **`Status`, quiet.** A consumer whose own dependency is aliased `Status` and who writes
+//! `use tokora::types::*;` resolves `Status::Error.is_error()` here rather than to their crate.
+//! Compiled both ways against a real second crate: the boolean reads `false` before and `true`
+//! after. Disambiguated by `::my_status::Status`.
 //!
-//! So the name stays, for the reason above rather than because the risk is small: a rename would
-//! be applying *no silent semantic change* to something that is not one. A rename was drafted on
-//! that mistake and withdrawn.
+//! **`recovery`, loud.** A crate of that name **is published** — 0.1.6, ~16.1k downloads, last
+//! updated 2025-09-14, checked against the crates.io API on **2026-08-27** — and its documentation
+//! instructs `use recovery::Recovery;`. `Recovery` is not one of this module's four names, so a
+//! consumer of both crates gets `E0432` at their own import line, plus `E0659` where the name is
+//! then used. Measured, not assumed. Disambiguated by `::recovery::Recovery`.
 //!
-//! If the check above goes stale — that crate yanked, or one published that exports a name this
-//! module also has — the date is what makes the claim re-checkable instead of re-argued.
+//! A rename of this module was drafted when the deciding property was still loud-versus-silent,
+//! and withdrawn. If the check above goes stale — that crate yanked, or one published that exports
+//! a name this module also has — the date is what makes the claim re-checkable instead of
+//! re-argued.
 
 /// Reachable both ways: as `types::Status`, which is where a glob finds it, and through this
 /// module beside the rest of the recovery API.

--- a/tokora/src/types/recovery.rs
+++ b/tokora/src/types/recovery.rs
@@ -1,13 +1,19 @@
 //! The recovery state of a syntax carrier, the trait that reads it, and the parts it decomposes
-//! into. This module is public and must be named: nothing here is re-exported into
-//! [`types`](super).
+//! into.
 //!
-//! # Why a module, and what it does not fix
+//! [`Status`] is re-exported as `types::Status`, so a consumer globbing `tokora::types::*` has the
+//! status type without naming this module. [`RecoveryState`], [`FromComponents`] and
+//! [`Components`] are reached through this path.
 //!
-//! Every placement puts *some* new name into a namespace a consumer can already glob, and the
-//! kinds do not resolve alike. Measured against `rustc 1.100.0-nightly` with the consumer's source
-//! held fixed and the library gaining one item — and, this time, with **both sides exposing the
-//! item the consumer reaches for**, which is what the first attempt got wrong:
+//! # How a name added to a globbed namespace behaves, by kind
+//!
+//! This table is a measured fact and is the durable result of the rounds that produced it. What it
+//! is **not** is the reason for the placement above — see *Why the placement is not derived from
+//! this table*.
+//!
+//! Measured against `rustc 1.100.0-nightly` with the consumer's source held fixed and the library
+//! gaining one item — and with **both sides exposing the item the consumer reaches for**, which is
+//! what the first attempt got wrong:
 //!
 //! | kind       | vs an extern crate of that name  | vs a second glob            | vs a local def |
 //! |------------|----------------------------------|-----------------------------|----------------|
@@ -23,34 +29,70 @@
 //! on both revisions and **the boolean inverts**. A collision provoked by asking for something one
 //! side lacks is a verdict about the probe, not about the kind.
 //!
-//! So **no kind that can carry this API is loud on both axes.** The question is not which kind is
-//! safe but how few silent names a placement adds, and the floor is one — a public trait must live
-//! in a module, and every module is either already globbed or a new name in one.
+//! So **no kind that can carry this API is loud on both axes.** That is the finding, and it holds.
 //!
-//! A module reaches that floor: `recovery` is the only name this API puts into `types::*`. The
-//! alternative that was briefly shipped — re-exporting all four items into `types` — put **four**
-//! there instead: `Status` and `Components` silent against an extern crate, `RecoveryState` and
-//! `FromComponents` silent against a second glob. That is four times the exposure on both axes, so
-//! it was withdrawn.
+//! # Why the placement is not derived from this table
 //!
-//! **The residual, stated as what it is.** A consumer with a dependency named or aliased
-//! `recovery` who writes `use tokora::types::*;` has every `recovery::...` path rebound here, with
-//! no error and no warning. The only remaining lever is the module's *name*, and that is
-//! probability rather than safety: no identifier is barred from being a crate alias, so a more
-//! distinctive name would lower the chance without removing the mode. It is not taken, because the
-//! gain cannot be quantified and the churn is real.
+//! A draft of this release read the table as a budget and chose placements by counting how many
+//! names a consumer's glob could collide with. That was the wrong criterion, and two rounds of it
+//! cancelled each other out.
+//!
+//! This crate's concern is a **silent semantic change**: code that keeps compiling and means
+//! something different, with nothing to tell the consumer. `map` laundering a recovery placeholder
+//! into valid syntax was that. An inherent `is_valid` displacing a consumer's own was that. A
+//! glob-import name clash is **not**: a glob is the consumer's own choice, the clash is that
+//! choice's ordinary cost, and it is paid at compile time with a leading `::` as the one-line fix.
+//!
+//! It is also a rule nothing could follow. If a public module may not be added because some crate
+//! might share its name, no public module can ever be added again.
+//!
+//! So the placement above is ordinary library design — the vocabulary type where a glob will find
+//! it, the traits behind a path — and the table is kept because it is true, not because it decided
+//! anything.
+//!
+//! What that costs, measured rather than assumed: with `Status` in `types::*`, a consumer whose
+//! own dependency is aliased `Status` and who writes `use tokora::types::*;` resolves
+//! `Status::Error.is_error()` here rather than to their crate, and both revisions compile. That is
+//! the one name in this API whose glob clash can be quiet rather than a compile error, and it is
+//! accepted for the reason above: a glob is the consumer's choice, and `::` is the fix. The
+//! module's own name does not have that property — see below.
+//!
+//! # The module's name, checked rather than argued
+//!
+//! A consumer with a dependency named or aliased `recovery` who writes `use tokora::types::*;` has
+//! `recovery::...` paths resolve here instead of to their crate. That is a *silent* change only if
+//! this module also exports the item they were reaching for; reach for anything else and the
+//! result is `E0432` at their own import line, fixed by one leading `::` — which is what
+//! `::recovery::Recovery` is for.
+//!
+//! **A crate of this name is published, and that is the evidence for keeping the name rather than
+//! a warning about it.** Checked against the crates.io API on **2026-08-27**: `recovery` 0.1.6,
+//! ~16.1k downloads, last updated 2025-09-14. Its documentation instructs `use recovery::Recovery;`
+//! — and `Recovery` is not one of this module's four names, so a consumer of both crates who
+//! upgrades gets a compile error at that import, measured as `E0432` (plus `E0659` where the name
+//! is then used), never a redirect. The genuinely silent case would need a crate that is both named
+//! `recovery` **and** exports one of `Status`, `Components`, `RecoveryState` or `FromComponents`.
+//!
+//! So the name stays, for the reason above rather than because the risk is small: a rename would
+//! be applying *no silent semantic change* to something that is not one. A rename was drafted on
+//! that mistake and withdrawn.
+//!
+//! If the check above goes stale — that crate yanked, or one published that exports a name this
+//! module also has — the date is what makes the claim re-checkable instead of re-argued.
 
-/// Nothing here is re-exported into [`types`](super), and `Status` is the one that had to be
-/// withdrawn: a glob-added TYPE shadows a same-named extern crate exactly as a module does, which
-/// the first measurement missed. These two doctests are the in-tree pin for that, because the
-/// hazard itself needs a second crate to demonstrate and cannot be a unit test.
-///
-/// ```compile_fail,E0432
-/// use tokora::types::Status;
-/// ```
+/// Reachable both ways: as `types::Status`, which is where a glob finds it, and through this
+/// module beside the rest of the recovery API.
 ///
 /// ```rust
-/// use tokora::types::recovery::{Components, FromComponents, RecoveryState, Status};
+/// use tokora::types::Status;
+/// use tokora::types::recovery::{Components, FromComponents, RecoveryState, Status as Same};
+/// # const _: () = { let _: fn(Status) -> Same = |s| s; };
+/// ```
+///
+/// The traits and [`Components`] are **not** in `types::*`, so they are named rather than globbed:
+///
+/// ```compile_fail,E0432
+/// use tokora::types::RecoveryState;
 /// ```
 /// The recovery state of a syntax carrier: whether the parser found the construct, found
 /// something malformed where it should have been, or found nothing at all.

--- a/tokora/src/types/recovery.rs
+++ b/tokora/src/types/recovery.rs
@@ -1,3 +1,31 @@
+//! The recovery state of a syntax carrier, and the trait that reads it.
+//!
+//! # Why this is a module you have to name
+//!
+//! [`RecoveryState`] is deliberately **not** re-exported into [`types`](super), so
+//! `use tokora::types::*;` does not bring it into scope and `use tokora::types::recovery::RecoveryState;`
+//! is how you reach it. That costs one import, and it buys the property the trait exists for.
+//!
+//! A trait and a type behave differently under a consumer's second glob import, which was
+//! reproduced against `rustc 1.100.0-nightly` rather than reasoned about:
+//!
+//! - Two globs offering the same **type** name: `error[E0659]: ambiguous`. Hard, at the use site.
+//! - Two globs offering the same **trait** name: it *compiles*. `ambiguous_glob_imported_traits`
+//!   is warn-by-default (a future-incompatibility, rust-lang/rust#152822), and the method call
+//!   silently resolves to whichever glob was written **first** — so either side can win depending
+//!   on import order.
+//! - Two globs offering the same **method** through differently named traits: `error[E0034]`.
+//!   Hard.
+//!
+//! So a trait in `types::*` would let `use tokora::types::*; use their_crate::*;` rebind a
+//! consumer's own `is_valid` with no error at all — the same silent rebind that moving these
+//! questions off inherent methods was meant to close, one level further out at the re-export.
+//! Naming the module removes the second glob: a consumer's glob-imported trait is then unopposed,
+//! and a consumer who imports this one explicitly has said which they meant, since an explicit
+//! import beats a glob.
+//!
+//! [`Status`] *is* re-exported as `types::Status`, because a type name collides loudly.
+
 /// The recovery state of a syntax carrier: whether the parser found the construct, found
 /// something malformed where it should have been, or found nothing at all.
 ///

--- a/tokora/src/types/recovery.rs
+++ b/tokora/src/types/recovery.rs
@@ -1,31 +1,49 @@
-//! The recovery state of a syntax carrier, and the trait that reads it.
+//! The recovery state of a syntax carrier, the trait that reads it, and the parts it decomposes
+//! into. Every item here is re-exported from [`types`](super); this module is **private**.
 //!
-//! # Why this is a module you have to name
+//! # Why the module is private, and why that is not a full repair
 //!
-//! [`RecoveryState`] is deliberately **not** re-exported into [`types`](super), so
-//! `use tokora::types::*;` does not bring it into scope and `use tokora::types::recovery::RecoveryState;`
-//! is how you reach it. That costs one import, and it buys the property the trait exists for.
+//! Three axes, measured against `rustc 1.100.0-nightly` with a consumer whose source never
+//! changes and a library that gains one item:
 //!
-//! A trait and a type behave differently under a consumer's second glob import, which was
-//! reproduced against `rustc 1.100.0-nightly` rather than reasoned about:
+//! |            | vs an extern crate of that name  | vs a second glob            | vs a local def |
+//! |------------|----------------------------------|-----------------------------|----------------|
+//! | **module** | **silent redirect**              | `E0659`                     | local wins     |
+//! | **trait**  | `E0790`                          | **silent, first glob wins** | local wins     |
+//! | type       | `E0599`                          | `E0659`                     | local wins     |
+//! | fn / const | no interaction (value namespace) | `E0659`                     | local wins     |
 //!
-//! - Two globs offering the same **type** name: `error[E0659]: ambiguous`. Hard, at the use site.
-//! - Two globs offering the same **trait** name: it *compiles*. `ambiguous_glob_imported_traits`
-//!   is warn-by-default (a future-incompatibility, rust-lang/rust#152822), and the method call
-//!   silently resolves to whichever glob was written **first** — so either side can win depending
-//!   on import order.
-//! - Two globs offering the same **method** through differently named traits: `error[E0034]`.
-//!   Hard.
+//! A `pub mod recovery` inside `types` put a MODULE name into `use tokora::types::*`, and a
+//! consumer with a dependency named `recovery` then had **every** `recovery::...` path silently
+//! rebound to tokora — a whole crate path prefix, in code with nothing to do with this API, with
+//! no error and no warning. Making the module private removes that.
 //!
-//! So a trait in `types::*` would let `use tokora::types::*; use their_crate::*;` rebind a
-//! consumer's own `is_valid` with no error at all — the same silent rebind that moving these
-//! questions off inherent methods was meant to close, one level further out at the re-export.
-//! Naming the module removes the second glob: a consumer's glob-imported trait is then unopposed,
-//! and a consumer who imports this one explicitly has said which they meant, since an explicit
-//! import beats a glob.
+//! **It does not remove the other one, and the two cannot both be removed.** A public trait has
+//! to live in some module. If that module is already globbed, the trait name is silent on the
+//! second-glob axis; if it is a new module, the module name is silent on the extern-crate axis.
+//! There is no third place to put it, so this is a choice between two residuals rather than a
+//! repair. It was made on blast radius: the module hazard redirects an entire path prefix and is
+//! triggered by a dependency name a consumer may not control, while the trait hazard reaches four
+//! method names on tokora's own carriers and needs a same-named trait glob-imported from the
+//! consumer's own prelude.
 //!
-//! [`Status`] *is* re-exported as `types::Status`, because a type name collides loudly.
+//! The residual, stated: a consumer who glob-imports both `tokora::types::*` and a prelude of
+//! their own holding a trait named `RecoveryState` or `FromComponents` gets
+//! `ambiguous_glob_imported_traits` — a warning, not an error — and the first glob wins.
 
+/// `tokora::types::recovery` is not a path a consumer can name — the module is private and its
+/// items are re-exported from `types`. This is the in-tree pin for that, because the hazard it
+/// closes needs a second crate to demonstrate and so cannot be a unit test:
+///
+/// ```compile_fail,E0603
+/// use tokora::types::recovery::RecoveryState;
+/// ```
+///
+/// The items are reached from `types` directly:
+///
+/// ```rust
+/// use tokora::types::{Components, FromComponents, RecoveryState, Status};
+/// ```
 /// The recovery state of a syntax carrier: whether the parser found the construct, found
 /// something malformed where it should have been, or found nothing at all.
 ///
@@ -260,7 +278,7 @@ pub trait RecoveryState {
 /// What replaces them binds by name, so no elision can slide a binding onto the status:
 ///
 /// ```rust
-/// # use tokora::{SimpleSpan, types::{LitDecimal, recovery::Components}, utils::IntoComponents};
+/// # use tokora::{SimpleSpan, types::{LitDecimal, Components}, utils::IntoComponents};
 /// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
 /// let Components { span, payload, status } = lit.into_components();
 /// assert_eq!(payload, "42");
@@ -282,7 +300,7 @@ pub struct Components<Span, Payload> {
 /// took it apart into — the exact inverse, over the same associated type.
 ///
 /// ```rust
-/// use tokora::{SimpleSpan, error::ErrorNode, types::{LitDecimal, recovery::FromComponents}};
+/// use tokora::{SimpleSpan, error::ErrorNode, types::{LitDecimal, FromComponents}};
 /// use tokora::utils::IntoComponents;
 ///
 /// let placeholder = LitDecimal::<&str>::error(SimpleSpan::new(0, 3));

--- a/tokora/src/types/recovery.rs
+++ b/tokora/src/types/recovery.rs
@@ -162,6 +162,122 @@ pub trait RecoveryState {
   }
 }
 
+/// The parts a recovery carrier decomposes into: a span, a payload, and the recovery state.
+///
+/// This is [`IntoComponents::Components`](crate::utils::IntoComponents::Components) for
+/// [`Ident`](super::Ident), [`Keyword`](super::Keyword) and every `Lit*` type, the return of
+/// `Keyword`'s inherent `into_components`, and the argument of
+/// [`FromComponents::from_components`]. One shape in all three
+/// places, so the decomposition and its inverse cannot disagree about what a part is.
+///
+/// # Why a struct and not a three-tuple
+///
+/// The three-tuple came first, and it was defended as safe on the grounds that widening the old
+/// `(Span, Payload)` changes the **arity**, so every existing destructuring breaks loudly. That
+/// is false, and one line defeats it:
+///
+/// ```rust,ignore
+/// let (_, .., value) = literal.into_components();
+/// value.is_valid()
+/// ```
+///
+/// `..` matches zero elements against the old pair and one against the triple, so `value` is the
+/// payload before and the status after. Both compile whenever the payload also answers
+/// `is_valid`, and since `new` assigns [`Status::Valid`], a payload the caller's own check
+/// rejects then reports valid. `(.., b)` and `t.1` are the same defect in other spellings.
+///
+/// That was the third exemption of its kind on this branch to be refuted — after "the return type
+/// differs" and "the argument type is a `Status`" — and all three failed the same way: each
+/// estimated *what a consumer could have written* and estimated it too small. So this is not a
+/// better-argued exemption. It is a shape that **no** tuple pattern can match, whatever it binds
+/// and however it spells the rest, because a braced struct is not a tuple. `let (a, b)`,
+/// `(_, b)`, `(a, ..)`, `(_, .., b)`, `(.., b)`, a trailing comma, `ref` bindings, a `match` arm,
+/// `.0` and `.1` were each compiled against both shapes: all ten build on 0.9 and all ten are
+/// rejected here, with `E0308` for the patterns and `E0609` for the index accesses.
+///
+/// It is also the better API. Three positional parts whose third is a status is exactly the shape
+/// that made `..` dangerous; a named field says which is which.
+///
+/// # Every pre-existing tuple pattern, refused
+///
+/// Each of these is the source a 0.9 consumer wrote against `(Span, Payload)`, and each is now a
+/// compile error with the code named — so a stale destructuring cannot survive the upgrade in any
+/// spelling, whatever it binds and however it elides the rest.
+///
+/// ```compile_fail,E0308
+/// # use tokora::{SimpleSpan, types::LitDecimal, utils::IntoComponents};
+/// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
+/// let (span, payload) = lit.into_components();
+/// ```
+///
+/// ```compile_fail,E0308
+/// # use tokora::{SimpleSpan, types::LitDecimal, utils::IntoComponents};
+/// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
+/// let (_, payload) = lit.into_components();
+/// ```
+///
+/// ```compile_fail,E0308
+/// # use tokora::{SimpleSpan, types::LitDecimal, utils::IntoComponents};
+/// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
+/// let (span, ..) = lit.into_components();
+/// ```
+///
+/// The one that made a three-tuple unsafe — `..` matches zero elements against a pair and one
+/// against a triple, so this bound the payload before and the status after:
+///
+/// ```compile_fail,E0308
+/// # use tokora::{SimpleSpan, types::LitDecimal, utils::IntoComponents};
+/// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
+/// let (_, .., value) = lit.into_components();
+/// ```
+///
+/// ```compile_fail,E0308
+/// # use tokora::{SimpleSpan, types::LitDecimal, utils::IntoComponents};
+/// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
+/// let (.., value) = lit.into_components();
+/// ```
+///
+/// ```compile_fail,E0308
+/// # use tokora::{SimpleSpan, types::LitDecimal, utils::IntoComponents};
+/// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
+/// match lit.into_components() { (_, payload) => { let _ = payload; } }
+/// ```
+///
+/// Index access is refused too, with its own code:
+///
+/// ```compile_fail,E0609
+/// # use tokora::{SimpleSpan, types::LitDecimal, utils::IntoComponents};
+/// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
+/// let _ = lit.into_components().1;
+/// ```
+///
+/// ```compile_fail,E0609
+/// # use tokora::{SimpleSpan, types::LitDecimal, utils::IntoComponents};
+/// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
+/// let _ = lit.into_components().0;
+/// ```
+///
+/// What replaces them binds by name, so no elision can slide a binding onto the status:
+///
+/// ```rust
+/// # use tokora::{SimpleSpan, types::{LitDecimal, recovery::Components}, utils::IntoComponents};
+/// # let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
+/// let Components { span, payload, status } = lit.into_components();
+/// assert_eq!(payload, "42");
+/// assert!(status.is_valid());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Components<Span, Payload> {
+  /// Where the construct was, or would have been.
+  pub span: Span,
+  /// The spelling the carrier holds. For a recovery placeholder this is whatever
+  /// [`ErrorNode`](crate::error::ErrorNode) produced, and it is **not** the recovery channel —
+  /// read `status`.
+  pub payload: Payload,
+  /// Whether the parser found the construct, found something malformed, or found nothing.
+  pub status: Status,
+}
+
 /// Rebuilds a syntax carrier from the components [`IntoComponents`](crate::utils::IntoComponents)
 /// took it apart into — the exact inverse, over the same associated type.
 ///

--- a/tokora/src/types/recovery.rs
+++ b/tokora/src/types/recovery.rs
@@ -39,13 +39,13 @@
 /// It is not decoration on the carrier: it is the third thing every carrier is made of, beside
 /// the span and the payload. So it appears in
 /// [`IntoComponents::Components`](crate::utils::IntoComponents::Components) — which promises a
-/// *complete* decomposition — and it is accepted back by each carrier's `with_status`
-/// constructor. Those two are inverses, which is what makes the round trip an identity in all
+/// *complete* decomposition — and it is accepted back by [`FromComponents`], the inverse over
+/// the same associated type. Those two are inverses, which is what makes the round trip an identity in all
 /// three states; without the status in both, a decompose-and-rebuild would report every
 /// recovered node as valid syntax, the same laundering tokora#303 removed from `Ident::map`.
 ///
 /// A consumer does not have to interpret it to carry it, and mostly should not: pass it through
-/// `with_status`, or ask it one of the three questions below.
+/// [`FromComponents`], or ask it one of the three questions below.
 ///
 /// # Non-exhaustive
 ///
@@ -160,4 +160,47 @@ pub trait RecoveryState {
   fn is_missing(&self) -> bool {
     self.status().is_missing()
   }
+}
+
+/// Rebuilds a syntax carrier from the components [`IntoComponents`](crate::utils::IntoComponents)
+/// took it apart into — the exact inverse, over the same associated type.
+///
+/// ```rust
+/// use tokora::{SimpleSpan, error::ErrorNode, types::{LitDecimal, recovery::FromComponents}};
+/// use tokora::utils::IntoComponents;
+///
+/// let placeholder = LitDecimal::<&str>::error(SimpleSpan::new(0, 3));
+/// let rebuilt = LitDecimal::<&str>::from_components(placeholder.into_components());
+///
+/// assert_eq!(rebuilt, placeholder);
+/// ```
+///
+/// # Why this replaced a `with_status` constructor
+///
+/// The same job was briefly done by a `pub const fn with_status(span, payload, status)` inherent
+/// on each of the nineteen carriers, on the argument that its `Status` parameter could not be
+/// supplied by any expression written before that type existed. **That is false for a
+/// type-directed expression**, and it was measured rather than argued: an unchanged
+/// `unsafe { core::mem::zeroed() }`, `unsafe { core::mem::transmute::<u8, _>(0) }` or
+/// `unsafe { MaybeUninit::uninit().assume_init() }` in that argument position is inferred as a
+/// consumer's own status enum before the upgrade and as [`Status`] after. Both revisions compile,
+/// there is no ambiguity, and dispatch moves from the consumer's trait to tokora's inherent
+/// function — with `Status::Valid` at discriminant zero, a consumer's zero-valued *rejection*
+/// state becomes valid syntax. The `MaybeUninit` route is worse still: it yields whatever the
+/// stack held.
+///
+/// Bounded routes are not affected and were measured too — `Default::default()`, `x.into()`, an
+/// associated constant and a generic `fn mk<T: Default>() -> T` all fail with `E0277` or `E0308`,
+/// because each needs a trait impl or a named type that [`Status`] does not provide. The silent
+/// routes are exactly the *unbounded* ones.
+///
+/// So the constructor is a trait method rather than an inherent one, which puts it where a
+/// consumer's inherent item outranks it instead of the other way round, and this module is not
+/// glob-re-exported, so it has to be named. It takes one argument whose type is an associated
+/// type of the implementor, and it is reachable by construction to anyone who can decompose:
+/// `T::from_components(x.into_components())` is the round trip, and it is total in all three
+/// recovery states.
+pub trait FromComponents: crate::utils::IntoComponents + Sized {
+  /// Rebuilds the value from its components, carrying the recovery state across unchanged.
+  fn from_components(components: Self::Components) -> Self;
 }

--- a/tokora/src/types/status.rs
+++ b/tokora/src/types/status.rs
@@ -1,43 +1,59 @@
-/// The recovery state of a syntax carrier, and the field the `is_valid` / `is_error` /
-/// `is_missing` predicates read.
+/// The recovery state of a syntax carrier: whether the parser found the construct, found
+/// something malformed where it should have been, or found nothing at all.
 ///
-/// `Ident`, `Keyword` and every `Lit*` type hold one of these. The rule they are all keeping —
-/// that a carrier reports its recovery state through a status field and never through the
-/// payload — is stated once, on the `ErrorNode` trait, under *Two Shapes of Implementor*; this
-/// type is that rule's single implementation, which is why it lives here rather than in
-/// `ident.rs` where tokora#266 first needed it.
+/// [`Ident`](super::Ident), [`Keyword`](super::Keyword) and every `Lit*` type hold one of these.
+/// The rule they are all keeping — that a carrier reports its recovery state through this field
+/// and never through its payload — is stated once, on
+/// [`ErrorNode`](crate::error::ErrorNode), under *Two Shapes of Implementor*.
 ///
-/// What is local to this file is the mechanics:
+/// # Why it is a value a consumer can hold
 ///
-/// - `new` is the door that declares a carrier valid, and the `ErrorNode` constructors are the
-///   two doors that declare it recovered. There is no other way to set this field.
-/// - Every operation that rebuilds a carrier — `Ident::map`, `Keyword::map`,
-///   `From<Keyword> for Ident` — destructures it by name, so a rebuild that stops carrying it
-///   fails to compile instead of silently reporting a placeholder as valid syntax. That is what
-///   tokora#303 installed on `Keyword` before there was a status for it to catch, and what
-///   tokora#301 gave it something to catch.
+/// It is not decoration on the carrier: it is the third thing every carrier is made of, beside
+/// the span and the payload. So it appears in
+/// [`IntoComponents::Components`](crate::utils::IntoComponents::Components) — which promises a
+/// *complete* decomposition — and it is accepted back by each carrier's `with_status`
+/// constructor. Those two are inverses, which is what makes the round trip an identity in all
+/// three states; without the status in both, a decompose-and-rebuild would report every
+/// recovered node as valid syntax, the same laundering tokora#303 removed from `Ident::map`.
+///
+/// A consumer does not have to interpret it to carry it, and mostly should not: pass it through
+/// `with_status`, or ask it one of the three questions below.
+///
+/// # Non-exhaustive
+///
+/// A fourth recovery state is admissible in a future version, so a `match` on this enum needs a
+/// wildcard arm. [`is_valid`](Self::is_valid) is not `!is_error() && !is_missing()` for that
+/// reason — ask the question you mean.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(u8)]
 #[non_exhaustive]
-pub(super) enum Status {
+pub enum Status {
+  /// The parser found the construct, spelled out in the source.
   Valid,
+  /// The parser found something where the construct should have been, and it was malformed —
+  /// the state [`ErrorNode::error`](crate::error::ErrorNode::error) declares.
   Error,
+  /// The parser found nothing where the construct was required — the state
+  /// [`ErrorNode::missing`](crate::error::ErrorNode::missing) declares.
   Missing,
 }
 
 impl Status {
+  /// Returns `true` if this is the malformed-content state.
   #[inline(always)]
-  pub(super) const fn is_error(self) -> bool {
+  pub const fn is_error(self) -> bool {
     matches!(self, Self::Error)
   }
 
+  /// Returns `true` if this is the absent-content state.
   #[inline(always)]
-  pub(super) const fn is_missing(self) -> bool {
+  pub const fn is_missing(self) -> bool {
     matches!(self, Self::Missing)
   }
 
+  /// Returns `true` if this is the found-in-the-source state.
   #[inline(always)]
-  pub(super) const fn is_valid(self) -> bool {
+  pub const fn is_valid(self) -> bool {
     matches!(self, Self::Valid)
   }
 }

--- a/tokora/src/types/status.rs
+++ b/tokora/src/types/status.rs
@@ -1,0 +1,43 @@
+/// The recovery state of a syntax carrier, and the field the `is_valid` / `is_error` /
+/// `is_missing` predicates read.
+///
+/// `Ident`, `Keyword` and every `Lit*` type hold one of these. The rule they are all keeping —
+/// that a carrier reports its recovery state through a status field and never through the
+/// payload — is stated once, on the `ErrorNode` trait, under *Two Shapes of Implementor*; this
+/// type is that rule's single implementation, which is why it lives here rather than in
+/// `ident.rs` where tokora#266 first needed it.
+///
+/// What is local to this file is the mechanics:
+///
+/// - `new` is the door that declares a carrier valid, and the `ErrorNode` constructors are the
+///   two doors that declare it recovered. There is no other way to set this field.
+/// - Every operation that rebuilds a carrier — `Ident::map`, `Keyword::map`,
+///   `From<Keyword> for Ident` — destructures it by name, so a rebuild that stops carrying it
+///   fails to compile instead of silently reporting a placeholder as valid syntax. That is what
+///   tokora#303 installed on `Keyword` before there was a status for it to catch, and what
+///   tokora#301 gave it something to catch.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
+#[non_exhaustive]
+pub(super) enum Status {
+  Valid,
+  Error,
+  Missing,
+}
+
+impl Status {
+  #[inline(always)]
+  pub(super) const fn is_error(self) -> bool {
+    matches!(self, Self::Error)
+  }
+
+  #[inline(always)]
+  pub(super) const fn is_missing(self) -> bool {
+    matches!(self, Self::Missing)
+  }
+
+  #[inline(always)]
+  pub(super) const fn is_valid(self) -> bool {
+    matches!(self, Self::Valid)
+  }
+}

--- a/tokora/src/types/status.rs
+++ b/tokora/src/types/status.rs
@@ -76,15 +76,41 @@ impl Status {
 /// naming both candidates and picks with `RecoveryState::is_valid(&x)` or their own equivalent; a
 /// consumer who imports neither, or only their own, keeps exactly the behaviour they had.
 ///
-/// # `status` is inherent, and that is deliberate
+/// # `status` is on this trait too, and nowhere else
 ///
-/// A trait method cannot be `const fn`, so the three questions above are not usable in a const
-/// context. Each carrier therefore keeps a `const fn status(&self)` of its own, and
-/// `x.status().is_valid()` is const all the way down.
+/// It was briefly an inherent `const fn` on each carrier, on the reasoning that a *return* type
+/// which did not exist before could not be displaced silently: a consumer whose own `status()`
+/// returned something else would get a type error. **That reasoning is wrong**, and the
+/// counterexample is one line:
 ///
-/// That name is inherent, so it *can* win a pick — but it cannot do so silently: it returns
-/// [`Status`], a type that did not exist before tokora#320, so a consumer whose own `status()`
-/// returned something else gets a type error rather than a different answer.
+/// ```rust,ignore
+/// literal.status().is_valid()
+/// ```
+///
+/// A differing return type is only loud if the caller *stores* the value. When the next step is a
+/// method both types offer — and [`Status`] offers exactly the names a consumer's semantic status
+/// is most likely to carry — the whole chain still typechecks and the meaning changes underneath
+/// it. Since `new` marks any caller-supplied payload [`Status::Valid`], a literal their own check
+/// would have rejected then passes.
+///
+/// So the test a name has to survive is not *does the signature differ* but **does the whole call
+/// chain still typecheck with a different meaning**, and an inherent accessor of any name fails
+/// it whenever the returned types share a method. There is no inherent reader left to displace
+/// anything: `x.status()` and `Carrier::status(&x)` both resolve here.
+///
+/// # What that costs
+///
+/// A trait method cannot be `const fn`, so the recovery state is **not readable in a const
+/// context** by any spelling. Nothing in this crate read it in one, and the state is a parse
+/// result, which is not const-constructible in practice.
+///
+/// Two ways to keep const were available and both are worse. A `pub` field is reachable by
+/// nothing method-call syntax can displace — but a public field is a public *setter*, and
+/// `x.status = Status::Valid` would launder a recovery placeholder into valid syntax by
+/// assignment, which is the whole defect this type exists to close. A receiver-less associated
+/// function is unreachable by method syntax, but `Carrier::status(&x)` in path position displaces
+/// a consumer's trait item the same way, so it trades a certainty for an improbability — and the
+/// reasoning it would rest on is the reasoning that was just wrong.
 pub trait RecoveryState {
   /// The recovery state this value is in.
   fn status(&self) -> Status;

--- a/tokora/src/types/status.rs
+++ b/tokora/src/types/status.rs
@@ -57,3 +57,53 @@ impl Status {
     matches!(self, Self::Valid)
   }
 }
+
+/// Reads the recovery state of a syntax carrier: [`Ident`](super::Ident),
+/// [`Keyword`](super::Keyword) and every `Lit*` type implement it.
+///
+/// # Why the three questions live on a trait
+///
+/// `is_valid`, `is_error` and `is_missing` are names a consumer may already have on their own
+/// extension trait, meaning something of their own — "this literal's payload parses as a number",
+/// say. Rust prefers an **inherent** method over a trait's at an unqualified call site, so
+/// shipping these as inherent methods would have made `literal.is_valid()` keep compiling and
+/// quietly stop calling the consumer's check, with no diagnostic anywhere. tokora#320 widened
+/// [`IntoComponents`](crate::utils::IntoComponents) rather than withdrawing it precisely because
+/// widening fails loudly, and the same standard applied here rules inherent predicates out: a
+/// silent change of meaning on upgrade is the one outcome that standard exists to prevent.
+///
+/// On a trait the clash cannot be silent. A consumer who imports both gets an ambiguity error
+/// naming both candidates and picks with `RecoveryState::is_valid(&x)` or their own equivalent; a
+/// consumer who imports neither, or only their own, keeps exactly the behaviour they had.
+///
+/// # `status` is inherent, and that is deliberate
+///
+/// A trait method cannot be `const fn`, so the three questions above are not usable in a const
+/// context. Each carrier therefore keeps a `const fn status(&self)` of its own, and
+/// `x.status().is_valid()` is const all the way down.
+///
+/// That name is inherent, so it *can* win a pick — but it cannot do so silently: it returns
+/// [`Status`], a type that did not exist before tokora#320, so a consumer whose own `status()`
+/// returned something else gets a type error rather than a different answer.
+pub trait RecoveryState {
+  /// The recovery state this value is in.
+  fn status(&self) -> Status;
+
+  /// Returns `true` if the parser found this construct spelled out in the source.
+  #[inline]
+  fn is_valid(&self) -> bool {
+    self.status().is_valid()
+  }
+
+  /// Returns `true` if this value is a malformed-content placeholder.
+  #[inline]
+  fn is_error(&self) -> bool {
+    self.status().is_error()
+  }
+
+  /// Returns `true` if this value is an absent-content placeholder.
+  #[inline]
+  fn is_missing(&self) -> bool {
+    self.status().is_missing()
+  }
+}

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+// `RecoveryState` is no longer re-exported into `types`, so `use super::*` does not bring it in —
+// which is the whole repair, and this line is what an ordinary consumer writes instead.
+use super::recovery::RecoveryState;
 use std::{
   string::{String, ToString},
   vec,
@@ -882,12 +885,28 @@ fn an_error_node_placeholder_survives_a_decompose_and_rebuild() {
 /// consumer to do the same for a reason that does not exist.
 struct BareLang;
 
-/// The six traits every carrier in this module claims. `Recoverable` is deliberately absent: it
-/// claims `PartialOrd`/`Ord` as well and `Copy` not at all, and it holds no `PhantomData`, so it
-/// is not in this population.
-fn requires_the_six<T>(_: &T)
+/// A marker that carries the two the `PartialEq` derive still demands, and nothing else.
+#[derive(PartialEq, Eq)]
+struct EqLang;
+
+/// The four a bare marker buys: nothing in `Debug`, `Clone`, `Copy` or `Hash` reads `Lang`, so
+/// none of them may demand anything of it.
+fn requires_the_four<T>(_: &T)
 where
-  T: core::fmt::Debug + Clone + Copy + PartialEq + Eq + core::hash::Hash,
+  T: core::fmt::Debug + Clone + Copy + core::hash::Hash,
+{
+}
+
+/// The two a bare marker does **not** buy, and the reason is stated where the derives are: the
+/// `PartialEq` derive is what emits `StructuralPartialEq`, so keeping it is what keeps a `const`
+/// of a carrier usable in a `match` pattern — and a derive constrains every parameter. Comparing
+/// or matching therefore still needs `Lang: PartialEq + Eq`, exactly as 0.9 required.
+///
+/// `Recoverable` is deliberately absent from both: it claims `PartialOrd`/`Ord` as well and
+/// `Copy` not at all, and it holds no `PhantomData`, so it is not in this population.
+fn requires_the_other_two<T>(_: &T)
+where
+  T: PartialEq + Eq,
 {
 }
 
@@ -914,19 +933,24 @@ macro_rules! assert_marker_is_not_a_bound {
       let span = SimpleSpan::new(2, 8);
       let value = $carrier::<&str, SimpleSpan, BareLang>::with_status(span, "x", Status::Error);
 
-      requires_the_six(&value);
+      requires_the_four(&value);
 
       let copied = value;
-      let cloned = value.clone();
-      assert_eq!(copied, cloned, concat!(stringify!($carrier), ": Copy and Clone agree"));
+      let _cloned = value.clone();
       assert!(
-        format!("{value:?}").starts_with(concat!(stringify!($carrier), " {")),
+        format!("{copied:?}").starts_with(concat!(stringify!($carrier), " {")),
         concat!(stringify!($carrier), ": Debug names the type"),
       );
 
       let mut h = CountingHasher::default();
       value.hash(&mut h);
       assert_ne!(h.finish(), 0, concat!(stringify!($carrier), ": Hash reaches the fields"));
+
+      // The other two, over a marker that carries them — which is what the `PartialEq` derive
+      // costs and what `StructuralPartialEq` buys back.
+      let eq_marked = $carrier::<&str, SimpleSpan, EqLang>::with_status(span, "x", Status::Error);
+      requires_the_other_two(&eq_marked);
+      assert_eq!(eq_marked, eq_marked.clone(), concat!(stringify!($carrier), ": Eq over an Eq marker"));
     })+
   };
 }
@@ -964,15 +988,21 @@ fn no_carrier_demands_a_trait_of_its_language_marker() {
     span, segments,
   );
 
-  requires_the_six(&list);
+  requires_the_four(&list);
   assert!(list.is_valid());
-  assert_eq!(list, list.clone());
+
+  let eq_list = IdentList::<&str, SimpleSpan, [Ident<&str, SimpleSpan, EqLang>; 1], EqLang>::new(
+    span,
+    [Ident::<&str, SimpleSpan, EqLang>::new(span, "foo")],
+  );
+  requires_the_other_two(&eq_list);
+  assert_eq!(eq_list, eq_list.clone());
 }
 
 // --- A name this branch adds must not silently displace a consumer's own ---
 
 /// A downstream crate's scope, reproduced: the carriers are imported, and
-/// [`RecoveryState`](super::RecoveryState) deliberately is **not**. That is the position an
+/// [`RecoveryState`](super::recovery::RecoveryState) deliberately is **not**. That is the position an
 /// upgrading consumer is in, and it is why this is a module — `use super::*` in the parent puts
 /// the trait in scope, and a trait in scope contributes its method names whatever it is bound to.
 mod consumer_scope {
@@ -1013,7 +1043,7 @@ mod consumer_scope {
   /// tokora's own answer, reached without importing the trait — which is what a fully qualified
   /// path is for, and what the consumer would write on the rare call that wants it.
   fn tokora_status(lit: &LitDecimal<&str>) -> Status {
-    <LitDecimal<&str> as crate::types::RecoveryState>::status(lit)
+    <LitDecimal<&str> as crate::types::recovery::RecoveryState>::status(lit)
   }
 
   /// **The cell, and its two directions.**
@@ -1181,5 +1211,131 @@ mod consumer_scope {
     // The consumer's is still reachable, by name.
     let theirs = <LitDecimal<&str> as ConsumerCtor>::with_status(span, "42", false);
     assert_eq!(theirs.data_ref(), &"");
+  }
+}
+
+// --- A const of a carrier stays usable in a match pattern ---
+
+/// A language marker carrying the two the `PartialEq` derive demands.
+#[derive(PartialEq, Eq)]
+struct PatLang;
+
+/// **Structural matching, which is not observable by rendering.**
+///
+/// Round 3 replaced six derives with hand-written impls and checked the change by *rendering* —
+/// `Debug`'s field order, `PartialEq`'s short-circuit order, `Hash`'s bytes — and concluded
+/// nothing else moved. One thing had: `#[derive(PartialEq)]` also emits `StructuralPartialEq`,
+/// and without it a `const` of the type is rejected in a pattern with *"constant of non-structural
+/// type"*. No amount of printing a value can see that; only using one in a pattern can.
+///
+/// So `PartialEq`/`Eq` are derived again while `Debug`, `Clone`, `Copy` and `Hash` stay written
+/// out. The cell below is the differential: with the derives removed it does not compile, and the
+/// failure is at the pattern rather than at any assertion.
+///
+/// It covers a carrier of each shape — the two hand-written ones and one from the macro that
+/// generates seventeen.
+#[test]
+fn a_const_carrier_is_usable_in_a_match_pattern() {
+  // `SimpleSpan::new` is not a `const fn`, so the span parameter here is `()` — which is also the
+  // shape a dialect uses when it keeps a const table of spelled-out keywords.
+  const IDENT: Ident<&str, (), PatLang> = Ident::new((), "let");
+  const KEYWORD: Keyword<&str, (), PatLang> = Keyword::new((), "let");
+  const LIT: LitDecimal<&str, (), PatLang> = LitDecimal::new((), "42");
+
+  fn classify_ident(v: Ident<&str, (), PatLang>) -> u8 {
+    match v {
+      IDENT => 1,
+      _ => 0,
+    }
+  }
+
+  fn classify_keyword(v: Keyword<&str, (), PatLang>) -> u8 {
+    match v {
+      KEYWORD => 1,
+      _ => 0,
+    }
+  }
+
+  fn classify_lit(v: LitDecimal<&str, (), PatLang>) -> u8 {
+    match v {
+      LIT => 1,
+      _ => 0,
+    }
+  }
+
+  assert_eq!(classify_ident(IDENT), 1);
+  assert_eq!(classify_ident(Ident::new((), "other")), 0);
+  assert_eq!(classify_keyword(KEYWORD), 1);
+  assert_eq!(classify_lit(LIT), 1);
+
+  // A recovery placeholder is a different value from a hand-spelled one, in a pattern too — the
+  // status is part of what the pattern matches.
+  assert_eq!(
+    classify_ident(Ident::with_status((), "let", Status::Missing)),
+    0,
+    "the status participates in structural matching",
+  );
+}
+
+// --- A second glob must not be able to rebind a consumer's method ---
+
+/// A consumer crate that glob-imports **both** `tokora::types::*` and its own prelude.
+///
+/// This is the shape that survived moving the three questions onto a trait: the trait was
+/// re-exported into `types`, so `use tokora::types::*;` put it in scope beside a same-named one of
+/// the consumer's — and that is not the hard error a same-named *type* would give.
+///
+/// Reproduced against `rustc 1.100.0-nightly` before this was repaired, over three arrangements:
+///
+/// - two globs, same **trait** name: compiles. `ambiguous_glob_imported_traits` is warn-by-default
+///   (a future-incompatibility, rust-lang/rust#152822) and the call resolves to whichever glob was
+///   written **first**, so either side wins depending on import order.
+/// - two globs, same **type** name: `error[E0659]: ambiguous`. Hard.
+/// - two globs, same method through **differently named** traits: `error[E0034]`. Hard.
+///
+/// The repair is that `RecoveryState` is not in `types::*` at all — it lives in
+/// [`types::recovery`](super::recovery) and must be named. So the glob below contributes no
+/// competing `is_valid`, the consumer's is unopposed, and a consumer who wants tokora's writes an
+/// explicit import, which beats a glob and is a choice rather than an accident.
+mod second_glob {
+  /// The consumer's own prelude, glob-exported the way a crate's prelude is.
+  mod their_prelude {
+    use crate::types::LitDecimal;
+
+    pub trait RecoveryState {
+      fn is_valid(&self) -> bool;
+    }
+
+    impl RecoveryState for LitDecimal<&str> {
+      /// The semantic check: does the payload parse as a number?
+      fn is_valid(&self) -> bool {
+        !self.data_ref().is_empty() && self.data_ref().chars().all(|c| c.is_ascii_digit())
+      }
+    }
+  }
+
+  /// **The cell.** Two globs, one of them tokora's whole `types` namespace.
+  ///
+  /// With `pub use recovery::RecoveryState;` restored in `types/mod.rs` — the plant — this
+  /// function still compiles, emits only `ambiguous_glob_imported_traits`, and the assertion
+  /// below flips: `LitDecimal::new` marks every payload `Status::Valid`, so `"nope"` reads as
+  /// valid and the consumer's check is bypassed with no error anywhere.
+  #[test]
+  fn a_glob_of_tokora_types_does_not_rebind_the_consumers_predicate() {
+    use crate::types::*;
+    use their_prelude::*;
+
+    let nonsense = LitDecimal::<&str>::new(SimpleSpan::new(0, 4), "nope");
+    assert!(
+      !nonsense.is_valid(),
+      "a second glob must not rebind the consumer's semantic check",
+    );
+
+    // Tokora's own answer is still reachable, by naming it — which is the cost of the repair and
+    // the whole of it.
+    assert!(
+      <LitDecimal<&str> as crate::types::recovery::RecoveryState>::status(&nonsense).is_valid(),
+      "tokora's recovery status is the opposite answer, reached by naming the trait",
+    );
   }
 }

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -1062,6 +1062,93 @@ mod consumer_scope {
     assert!(tokora_status(&real).is_valid());
   }
 
+  /// A consumer's **semantic** status: their own type, with the method names such a type most
+  /// naturally carries.
+  #[derive(Debug, PartialEq)]
+  enum SemanticStatus {
+    Ok,
+    Overflows,
+  }
+
+  impl SemanticStatus {
+    fn is_valid(&self) -> bool {
+      matches!(self, Self::Ok)
+    }
+  }
+
+  /// The extension trait that the round-4 reasoning said could not be displaced silently.
+  trait ConsumerStatus {
+    fn status(&self) -> SemanticStatus;
+  }
+
+  impl ConsumerStatus for LitDecimal<&str> {
+    /// Rejects a literal that would not fit, whatever its recovery state is.
+    fn status(&self) -> SemanticStatus {
+      match self.data_ref().parse::<u8>() {
+        Ok(_) => SemanticStatus::Ok,
+        Err(_) => SemanticStatus::Overflows,
+      }
+    }
+  }
+
+  /// **The cell that refutes the round-4 argument, and pins the repair.**
+  ///
+  /// `status` was briefly inherent on all nineteen carriers, kept there to stay `const`, on the
+  /// reasoning that a *return* type which did not exist before could not be displaced silently: a
+  /// consumer whose `status()` returned something else would get a type error.
+  ///
+  /// A differing return type is only loud **if the caller stores the value**. The chain below
+  /// stores nothing, and [`Status`](crate::types::Status) offers `is_valid` too, so with an
+  /// inherent `status` in place `literal.status().is_valid()` keeps compiling and silently stops
+  /// asking the consumer's question. `new` marks any caller-supplied payload `Status::Valid`, so
+  /// `"999"` — which does not fit the consumer's `u8` — passes.
+  ///
+  /// So the test a name must survive is not *does the signature differ* but **does the whole call
+  /// chain still typecheck with a different meaning**. There is no inherent reader any more:
+  /// `status` is reached through `RecoveryState`, so this chain reaches the consumer's method,
+  /// and a consumer who imports the trait as well gets `error[E0034]` instead.
+  /// Every assertion below is a `bool`-valued **chain**, and that is the point: naming
+  /// `SemanticStatus` anywhere in this function would make the plant fail as `error[E0308]` on
+  /// the stored value instead — the shape that was always loud — and the silent one would never
+  /// get to run. An instrument that catches the defect by the wrong mechanism proves nothing
+  /// about the right one.
+  #[test]
+  fn a_chained_call_still_reaches_the_consumers_status() {
+    let span = SimpleSpan::new(0, 3);
+
+    // Fits a `u8`, and was spelled out in the source: both sides say valid, for different reasons.
+    let small = LitDecimal::<&str>::new(span, "42");
+    assert!(
+      small.status().is_valid(),
+      "the consumer's chain owns the unqualified call"
+    );
+    assert!(tokora_status(&small).is_valid());
+
+    // The pair that reverses under the plant: the consumer's check rejects an overflowing
+    // literal, while tokora's recovery status calls it valid because `new` said so.
+    let overflowing = LitDecimal::<&str>::new(span, "999");
+    assert!(
+      !overflowing.status().is_valid(),
+      "the consumer's semantic check rejects an overflowing literal",
+    );
+    assert!(
+      tokora_status(&overflowing).is_valid(),
+      "tokora's recovery status says valid, which is the answer that must not win here",
+    );
+  }
+
+  /// The other half of the contrast: a consumer who **stores** the value does get a type error if
+  /// an inherent `status` displaces theirs. That shape was never the problem, and recording it
+  /// here is what keeps the cell above honest about which shape is.
+  #[test]
+  fn a_stored_status_names_the_consumers_own_type() {
+    let span = SimpleSpan::new(0, 3);
+    let overflowing = LitDecimal::<&str>::new(span, "999");
+
+    let semantic: SemanticStatus = overflowing.status();
+    assert_eq!(semantic, SemanticStatus::Overflows);
+  }
+
   /// A consumer constructor with the same name and arity as the new inherent `with_status`.
   trait ConsumerCtor {
     fn with_status(span: SimpleSpan, data: &'static str, ok: bool) -> Self;

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -143,9 +143,10 @@ fn ident_list_of_mapped_recovery_segments_is_not_valid() {
 fn ident_into_components() {
   use crate::utils::IntoComponents;
   let ident = Ident::<&str>::new(SimpleSpan::new(0, 3), "foo");
-  let (span, source) = ident.into_components();
+  let (span, source, status) = ident.into_components();
   assert_eq!(span, SimpleSpan::new(0, 3));
   assert_eq!(source, "foo");
+  assert!(status.is_valid());
 }
 
 #[test]
@@ -196,7 +197,8 @@ fn keyword_map() {
 #[test]
 fn keyword_into_components() {
   let kw = Keyword::<&str>::new(SimpleSpan::new(0, 3), "let");
-  let (span, source) = kw.into_components();
+  let (span, source, status) = kw.into_components();
+  assert!(status.is_valid());
   assert_eq!(span, SimpleSpan::new(0, 3));
   assert_eq!(source, "let");
 }
@@ -376,7 +378,8 @@ fn lit_hex_new() {
 fn lit_into_components() {
   use crate::utils::IntoComponents;
   let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
-  let (span, data) = IntoComponents::into_components(lit);
+  let (span, data, status) = IntoComponents::into_components(lit);
+  assert!(status.is_valid());
   assert_eq!(span, SimpleSpan::new(0, 2));
   assert_eq!(data, "42");
 }
@@ -518,7 +521,8 @@ fn keyword_as_span() {
 fn keyword_into_components_trait() {
   use crate::utils::IntoComponents;
   let kw = Keyword::<&str>::new(SimpleSpan::new(0, 3), "let");
-  let (span, source) = IntoComponents::into_components(kw);
+  let (span, source, status) = IntoComponents::into_components(kw);
+  assert!(status.is_valid());
   assert_eq!(span, SimpleSpan::new(0, 3));
   assert_eq!(source, "let");
 }
@@ -526,9 +530,10 @@ fn keyword_into_components_trait() {
 #[test]
 fn keyword_into_components_method() {
   let kw = Keyword::<&str>::new(SimpleSpan::new(0, 3), "let");
-  let (span, source) = kw.into_components();
+  let (span, source, status) = kw.into_components();
   assert_eq!(span, SimpleSpan::new(0, 3));
   assert_eq!(source, "let");
+  assert!(status.is_valid());
 }
 
 // --- Additional Ident tests for coverage ---
@@ -549,7 +554,8 @@ fn ident_as_span() {
 fn ident_into_components_trait() {
   use crate::utils::IntoComponents;
   let ident = Ident::<&str>::new(SimpleSpan::new(0, 3), "foo");
-  let (span, source) = IntoComponents::into_components(ident);
+  let (span, source, status) = IntoComponents::into_components(ident);
+  assert!(status.is_valid());
   assert_eq!(span, SimpleSpan::new(0, 3));
   assert_eq!(source, "foo");
 }
@@ -687,7 +693,8 @@ fn lit_false_new() {
 fn lit_decimal_into_components_trait() {
   use crate::utils::IntoComponents;
   let lit = LitHex::<&str>::new(SimpleSpan::new(0, 4), "0xFF");
-  let (span, data) = IntoComponents::into_components(lit);
+  let (span, data, status) = IntoComponents::into_components(lit);
+  assert!(status.is_valid());
   assert_eq!(span, SimpleSpan::new(0, 4));
   assert_eq!(data, "0xFF");
 }
@@ -722,4 +729,137 @@ fn lit_bump() {
   let mut lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
   lit.bump(&5);
   assert_eq!(lit.span(), SimpleSpan::new(5, 7));
+}
+
+// --- Round trip: decompose and rebuild, over every carrier and every state ---
+
+/// Decomposes and rebuilds one carrier in each of its three states, and checks four things per
+/// state: the span survives, the payload survives, **the status survives**, and the rebuilt value
+/// equals the one it came from.
+///
+/// The last is the one that matters. `IntoComponents` promises a complete decomposition, so its
+/// output has to be enough to reconstruct the input — and before tokora#320 it was not: the tuple
+/// was `(Span, Payload)` over a carrier holding a status too, so `error(span)` and
+/// `new(span, "<error>")` decomposed identically and any rebuild through `new` reported a
+/// recovery placeholder as valid syntax.
+///
+/// Written over the carrier list rather than over one exemplar, because that list is the
+/// population: seventeen of the nineteen come from one `define_literal!` body, and a test that
+/// named only `LitDecimal` would report green over the sixteen it never ran.
+macro_rules! assert_status_survives_a_round_trip {
+  ($($carrier:ident),+ $(,)?) => {
+    $({
+      let span = SimpleSpan::new(3, 9);
+
+      for status in [Status::Valid, Status::Error, Status::Missing] {
+        let name = stringify!($carrier);
+        let original = $carrier::<&str>::with_status(span, "payload", status);
+
+        let (sp, payload, st) = IntoComponents::into_components(original);
+        assert_eq!(sp, span, "{name} in {status:?}: span");
+        assert_eq!(payload, "payload", "{name} in {status:?}: payload");
+        assert_eq!(st, status, "{name} in {status:?}: status survives the decomposition");
+
+        let rebuilt = $carrier::<&str>::with_status(sp, payload, st);
+        assert_eq!(rebuilt, original, "{name} in {status:?}: the round trip is the identity");
+        assert_eq!(rebuilt.is_valid(), status.is_valid(), "{name} in {status:?}: is_valid");
+        assert_eq!(rebuilt.is_error(), status.is_error(), "{name} in {status:?}: is_error");
+        assert_eq!(rebuilt.is_missing(), status.is_missing(), "{name} in {status:?}: is_missing");
+      }
+    })+
+  };
+}
+
+#[test]
+fn every_carrier_survives_a_decompose_and_rebuild_in_every_state() {
+  use crate::utils::IntoComponents;
+
+  assert_status_survives_a_round_trip!(
+    Ident,
+    Keyword,
+    Lit,
+    LitDecimal,
+    LitHex,
+    LitOctal,
+    LitBinary,
+    LitFloat,
+    LitHexFloat,
+    LitString,
+    LitMultilineString,
+    LitRawString,
+    LitChar,
+    LitByte,
+    LitByteString,
+    LitBool,
+    LitTrue,
+    LitFalse,
+    LitNull,
+  );
+}
+
+/// `Keyword` carries a second decomposition door: an inherent `into_components` that wins the
+/// pick over the trait's at an unqualified call site. The two returning different shapes would be
+/// a defect no diagnostic reports, so both are driven here.
+#[test]
+fn keywords_inherent_decomposition_agrees_with_the_trait_one() {
+  use crate::utils::IntoComponents;
+
+  let span = SimpleSpan::new(1, 5);
+
+  for status in [Status::Valid, Status::Error, Status::Missing] {
+    let kw = Keyword::<&str>::with_status(span, "then", status);
+
+    let inherent = Keyword::into_components(kw);
+    let via_trait = IntoComponents::into_components(kw);
+
+    assert_eq!(inherent, via_trait, "{status:?}: the two doors agree");
+    assert_eq!(
+      inherent.2, status,
+      "{status:?}: the inherent door carries the status"
+    );
+    assert_eq!(
+      Keyword::<&str>::with_status(inherent.0, inherent.1, inherent.2),
+      kw,
+      "{status:?}: the inherent door's output rebuilds its input",
+    );
+  }
+}
+
+/// The states an `ErrorNode` constructor declares survive the same trip. This is the shape a
+/// consumer actually writes — take a recovered node apart, put it back — and the one that used to
+/// come back valid.
+#[test]
+fn an_error_node_placeholder_survives_a_decompose_and_rebuild() {
+  use crate::utils::IntoComponents;
+
+  let span = SimpleSpan::new(0, 5);
+
+  for (label, kw, lit) in [
+    (
+      "error",
+      Keyword::<&str>::error(span),
+      LitDecimal::<&str>::error(span),
+    ),
+    (
+      "missing",
+      Keyword::<&str>::missing(span),
+      LitDecimal::<&str>::missing(span),
+    ),
+  ] {
+    let (sp, src, st) = IntoComponents::into_components(kw);
+    let rebuilt = Keyword::<&str>::with_status(sp, src, st);
+    assert_eq!(rebuilt, kw, "{label}: keyword round trip");
+    assert!(
+      !rebuilt.is_valid(),
+      "{label}: a rebuilt keyword is not valid syntax"
+    );
+
+    let (sp, data, st) = IntoComponents::into_components(lit);
+    let rebuilt = LitDecimal::<&str>::with_status(sp, data, st);
+    assert_eq!(rebuilt, lit, "{label}: literal round trip");
+    assert!(
+      !rebuilt.is_valid(),
+      "{label}: a rebuilt literal is not valid syntax"
+    );
+  }
 }

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -207,18 +207,105 @@ fn keyword_into_ident() {
   let ident: Ident<&str> = kw.into();
   assert_eq!(ident.source(), "let");
   assert_eq!(ident.span(), SimpleSpan::new(0, 3));
+  assert!(ident.is_valid());
 }
 
 #[test]
 fn keyword_error_node() {
   let err = Keyword::<&str>::error(SimpleSpan::new(0, 5));
+  assert!(err.is_error());
+  assert!(!err.is_valid());
   assert_eq!(err.source(), "<error>");
 }
 
 #[test]
 fn keyword_missing_node() {
   let missing = Keyword::<&str>::missing(SimpleSpan::new(0, 5));
+  assert!(missing.is_missing());
+  assert!(!missing.is_valid());
   assert_eq!(missing.source(), "<missing>");
+}
+
+/// The conversion carries the recovery status instead of fabricating `Valid`. The valid row is
+/// the non-vacuity control: it passed before this channel existed, so a green table is evidence
+/// about the two recovery rows.
+#[test]
+fn keyword_into_ident_carries_the_recovery_status() {
+  let span = SimpleSpan::new(4, 7);
+
+  let rows: [(&str, Keyword<&str>, [bool; 3]); 3] = [
+    ("valid", Keyword::new(span, "let"), [true, false, false]),
+    ("error", Keyword::error(span), [false, true, false]),
+    ("missing", Keyword::missing(span), [false, false, true]),
+  ];
+
+  for (label, keyword, [valid, error, missing]) in rows {
+    let ident: Ident<&str> = keyword.into();
+    assert_eq!(ident.is_valid(), valid, "{label}: is_valid");
+    assert_eq!(ident.is_error(), error, "{label}: is_error");
+    assert_eq!(ident.is_missing(), missing, "{label}: is_missing");
+  }
+}
+
+/// A source-only `map` changes how the spelling is stored, not whether the parser found one.
+#[test]
+fn keyword_map_preserves_recovery_status() {
+  let span = SimpleSpan::new(0, 3);
+
+  let rows: [(&str, Keyword<&str>, &str, [bool; 3]); 3] = [
+    (
+      "valid",
+      Keyword::new(span, "let"),
+      "LET",
+      [true, false, false],
+    ),
+    (
+      "error",
+      Keyword::error(span),
+      "<ERROR>",
+      [false, true, false],
+    ),
+    (
+      "missing",
+      Keyword::missing(span),
+      "<MISSING>",
+      [false, false, true],
+    ),
+  ];
+
+  for (label, keyword, expected_source, [valid, error, missing]) in rows {
+    let mapped: Keyword<String> = keyword.map(str::to_uppercase);
+    assert_eq!(mapped.source_ref(), expected_source, "{label}: source");
+    assert_eq!(mapped.span(), span, "{label}: span");
+    assert_eq!(mapped.is_valid(), valid, "{label}: is_valid");
+    assert_eq!(mapped.is_error(), error, "{label}: is_error");
+    assert_eq!(mapped.is_missing(), missing, "{label}: is_missing");
+  }
+}
+
+/// The payload is not the channel: spelling a sentinel into a carrier by hand does not make it
+/// a recovery placeholder, and editing a placeholder's payload does not make it valid syntax.
+#[test]
+fn a_sentinel_payload_is_not_a_recovery_status() {
+  let span = SimpleSpan::new(0, 7);
+
+  let mut hand_written = Keyword::<&str>::new(span, "<error>");
+  assert!(hand_written.is_valid());
+  assert!(!hand_written.is_error());
+
+  *hand_written.source_mut() = "<missing>";
+  assert!(hand_written.is_valid());
+  assert!(!hand_written.is_missing());
+
+  let mut recovered = Keyword::<&str>::missing(span);
+  *recovered.source_mut() = "let";
+  assert!(recovered.is_missing());
+  assert!(!recovered.is_valid());
+
+  let mut lit = LitDecimal::<&str>::error(span);
+  *lit.data_mut() = "42";
+  assert!(lit.is_error());
+  assert!(!lit.is_valid());
 }
 
 // --- Literal types tests ---
@@ -248,12 +335,16 @@ fn lit_decimal_data_mut() {
 #[test]
 fn lit_decimal_error_node() {
   let err = LitDecimal::<&str>::error(SimpleSpan::new(0, 5));
+  assert!(err.is_error());
+  assert!(!err.is_valid());
   assert_eq!(err.data(), "<error>");
 }
 
 #[test]
 fn lit_decimal_missing_node() {
   let missing = LitDecimal::<&str>::missing(SimpleSpan::new(0, 5));
+  assert!(missing.is_missing());
+  assert!(!missing.is_valid());
   assert_eq!(missing.data(), "<missing>");
 }
 
@@ -604,13 +695,26 @@ fn lit_decimal_into_components_trait() {
 #[test]
 fn lit_error_node_generic() {
   let err = Lit::<&str>::error(SimpleSpan::new(0, 5));
+  assert!(err.is_error());
+  assert!(!err.is_valid());
   assert_eq!(err.data(), "<error>");
 }
 
 #[test]
 fn lit_missing_node_generic() {
   let missing = Lit::<&str>::missing(SimpleSpan::new(0, 5));
+  assert!(missing.is_missing());
+  assert!(!missing.is_valid());
   assert_eq!(missing.data(), "<missing>");
+}
+
+/// A literal built by `new` is valid, whatever its data type — the status is the channel, and
+/// `new` is the door that declares it.
+#[test]
+fn a_literal_built_by_new_is_valid() {
+  assert!(LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42").is_valid());
+  assert!(LitBool::<bool>::new(SimpleSpan::new(0, 4), true).is_valid());
+  assert!(LitNull::<()>::new(SimpleSpan::new(0, 4), ()).is_valid());
 }
 
 #[test]

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -1009,7 +1009,7 @@ mod consumer_scope {
   use crate::{
     SimpleSpan,
     error::ErrorNode,
-    types::{LitDecimal, Status},
+    types::{Ident, LitDecimal, Status},
   };
 
   /// A downstream extension trait with the three names, meaning something of its own.
@@ -1177,6 +1177,69 @@ mod consumer_scope {
 
     let semantic: SemanticStatus = overflowing.status();
     assert_eq!(semantic, SemanticStatus::Overflows);
+  }
+
+  /// A downstream extension trait over `Ident`, in the shape the round-6 review describes: an
+  /// `is_valid` that merely accepts a non-empty payload.
+  ///
+  /// The shape matters. `Ident::error(span)` carries the `"<error>"` sentinel, which **is**
+  /// non-empty, so this check says *valid* about a value tokora knows is a recovery placeholder.
+  /// Whichever of the two answers a call reaches therefore decides whether a placeholder is
+  /// processed as real syntax.
+  trait ConsumerIdentChecks {
+    fn is_valid(&self) -> bool;
+  }
+
+  impl ConsumerIdentChecks for Ident<&str> {
+    fn is_valid(&self) -> bool {
+      !self.source_ref().is_empty()
+    }
+  }
+
+  /// **The fourth failure mode: a removal that silently un-displaces a consumer's method.**
+  ///
+  /// The first three modes were all about *adding* a name that displaces a consumer's. This one
+  /// runs the other way. `Ident::is_valid` is inherent on 0.9, so an inherent method wins the pick
+  /// and this consumer has been getting **tokora's** answer. Take the inherent one away — offering
+  /// the spelling only through a trait that is not in `types::*` — and the call still compiles,
+  /// with no ambiguity at all, and falls through to theirs. A recovery placeholder then reads as
+  /// valid syntax.
+  ///
+  /// Which is why the cell asserts a *behaviour* rather than a compilation. Planting the removal
+  /// back does not break the build; it flips the answer, and that is the whole hazard.
+  ///
+  /// `RecoveryState` is deliberately not imported in this module, exactly as a downstream crate
+  /// would have it, so nothing here is arranged to make tokora win.
+  #[test]
+  fn removing_idents_inherent_predicate_would_silently_reach_the_consumers() {
+    let span = SimpleSpan::new(0, 7);
+
+    // The pair that flips. tokora says "this is an error placeholder"; the consumer's check sees a
+    // non-empty payload and says "valid".
+    let placeholder = Ident::<&str>::error(span);
+    assert!(
+      !placeholder.is_valid(),
+      "a recovery placeholder must not be read as valid syntax",
+    );
+    assert_eq!(placeholder.source_ref(), &"<error>");
+    assert!(
+      ConsumerIdentChecks::is_valid(&placeholder),
+      "the consumer's own check would call it valid, which is what makes the fall-through unsafe",
+    );
+
+    // The non-vacuity control: the two agree on a real identifier, so a green cell is evidence
+    // about the pair above rather than about the arrangement.
+    let real = Ident::<&str>::new(span, "count");
+    assert!(real.is_valid());
+    assert!(ConsumerIdentChecks::is_valid(&real));
+
+    // A missing placeholder carries `"<missing>"`, non-empty for the same reason.
+    let missing = Ident::<&str>::missing(span);
+    assert!(
+      !missing.is_valid(),
+      "a missing placeholder is not valid syntax either"
+    );
+    assert!(ConsumerIdentChecks::is_valid(&missing));
   }
 
   /// A consumer constructor with the same name and arity as the new inherent `with_status`.

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 // `RecoveryState` is no longer re-exported into `types`, so `use super::*` does not bring it in —
 // which is the whole repair, and this line is what an ordinary consumer writes instead.
-use super::recovery::{Components, FromComponents, RecoveryState};
+use super::{Components, FromComponents, RecoveryState};
 use std::{
   string::{String, ToString},
   vec,
@@ -1050,7 +1050,7 @@ fn no_carrier_demands_a_trait_of_its_language_marker() {
 // --- A name this branch adds must not silently displace a consumer's own ---
 
 /// A downstream crate's scope, reproduced: the carriers are imported, and
-/// [`RecoveryState`](super::recovery::RecoveryState) deliberately is **not**. That is the position an
+/// [`RecoveryState`](super::RecoveryState) deliberately is **not**. That is the position an
 /// upgrading consumer is in, and it is why this is a module — `use super::*` in the parent puts
 /// the trait in scope, and a trait in scope contributes its method names whatever it is bound to.
 mod consumer_scope {
@@ -1091,7 +1091,7 @@ mod consumer_scope {
   /// tokora's own answer, reached without importing the trait — which is what a fully qualified
   /// path is for, and what the consumer would write on the rare call that wants it.
   fn tokora_status(lit: &LitDecimal<&str>) -> Status {
-    <LitDecimal<&str> as crate::types::recovery::RecoveryState>::status(lit)
+    <LitDecimal<&str> as crate::types::RecoveryState>::status(lit)
   }
 
   /// **The cell, and its two directions.**
@@ -1337,7 +1337,7 @@ mod consumer_scope {
   /// `MaybeUninit::uninit().assume_init()` is worse — it yields whatever the stack held.
   ///
   /// So the constructor is not in the inherent namespace at all: it is
-  /// [`FromComponents::from_components`](crate::types::recovery::FromComponents::from_components),
+  /// [`FromComponents::from_components`](crate::types::FromComponents::from_components),
   /// a trait method, which a consumer's inherent item outranks. The call below reaches the
   /// consumer's constructor and must keep doing so.
   #[test]
@@ -1379,7 +1379,7 @@ mod consumer_scope {
 
     // tokora's own status-preserving construction is still reachable, by the trait that replaced
     // the constructor — and it is the exact inverse of the decomposition.
-    use crate::{types::recovery::FromComponents, utils::IntoComponents};
+    use crate::{types::FromComponents, utils::IntoComponents};
     let placeholder = LitDecimal::<&str>::error(span);
     let rebuilt = LitDecimal::<&str>::from_components(placeholder.into_components());
     assert_eq!(rebuilt, placeholder);
@@ -1456,24 +1456,22 @@ fn a_const_carrier_is_usable_in_a_match_pattern() {
 
 // --- A second glob must not be able to rebind a consumer's method ---
 
-/// A consumer crate that glob-imports **both** `tokora::types::*` and its own prelude.
+/// **The accepted residual, pinned rather than described.**
 ///
-/// This is the shape that survived moving the three questions onto a trait: the trait was
-/// re-exported into `types`, so `use tokora::types::*;` put it in scope beside a same-named one of
-/// the consumer's — and that is not the hard error a same-named *type* would give.
+/// Round 6 moved `RecoveryState` out of `types::*` because a second glob offering the same trait
+/// name compiles, warns under the warn-by-default `ambiguous_glob_imported_traits`
+/// (rust-lang/rust#152822), and resolves to whichever glob came first. Round 9 moved it back,
+/// because the module that held it was itself a MODULE name in `types::*`, and a module is the
+/// one kind that is silent against an extern crate — a consumer with a dependency named
+/// `recovery` had every `recovery::...` path rebound to tokora, with no diagnostic at all.
 ///
-/// Reproduced against `rustc 1.100.0-nightly` before this was repaired, over three arrangements:
+/// The two cannot both be closed: a public trait must live in a module, and every module is
+/// either already globbed or a new name in one. So this cell no longer asserts that the
+/// consumer's trait wins — it records what actually happens, so the trade is a fact in the test
+/// suite rather than a sentence in a doc comment.
 ///
-/// - two globs, same **trait** name: compiles. `ambiguous_glob_imported_traits` is warn-by-default
-///   (a future-incompatibility, rust-lang/rust#152822) and the call resolves to whichever glob was
-///   written **first**, so either side wins depending on import order.
-/// - two globs, same **type** name: `error[E0659]: ambiguous`. Hard.
-/// - two globs, same method through **differently named** traits: `error[E0034]`. Hard.
-///
-/// The repair is that `RecoveryState` is not in `types::*` at all — it lives in
-/// [`types::recovery`](super::recovery) and must be named. So the glob below contributes no
-/// competing `is_valid`, the consumer's is unopposed, and a consumer who wants tokora's writes an
-/// explicit import, which beats a glob and is a choice rather than an accident.
+/// If `ambiguous_glob_imported_traits` becomes the hard error its future-incompatibility note
+/// promises, this cell stops compiling and that is the signal to revisit.
 mod second_glob {
   /// The consumer's own prelude, glob-exported the way a crate's prelude is.
   mod their_prelude {
@@ -1491,28 +1489,28 @@ mod second_glob {
     }
   }
 
-  /// **The cell.** Two globs, one of them tokora's whole `types` namespace.
+  /// Two globs, one of them tokora's whole `types` namespace, both offering a `RecoveryState`.
   ///
-  /// With `pub use recovery::RecoveryState;` restored in `types/mod.rs` — the plant — this
-  /// function still compiles, emits only `ambiguous_glob_imported_traits`, and the assertion
-  /// below flips: `LitDecimal::new` marks every payload `Status::Valid`, so `"nope"` reads as
-  /// valid and the consumer's check is bypassed with no error anywhere.
+  /// The `allow` is the residual itself: without it this is an error here, because the crate
+  /// denies warnings. A downstream crate gets the warning and the code runs.
   #[test]
-  fn a_glob_of_tokora_types_does_not_rebind_the_consumers_predicate() {
+  #[allow(unused_imports, ambiguous_glob_imported_traits)]
+  fn two_globs_of_the_same_trait_name_resolve_to_the_first_glob() {
     use crate::types::*;
     use their_prelude::*;
 
     let nonsense = LitDecimal::<&str>::new(SimpleSpan::new(0, 4), "nope");
+
+    // tokora's glob is written first, so tokora's trait wins — and `new` called it valid.
     assert!(
-      !nonsense.is_valid(),
-      "a second glob must not rebind the consumer's semantic check",
+      nonsense.is_valid(),
+      "the first glob wins: this is tokora's recovery status, not the consumer's payload check",
     );
 
-    // Tokora's own answer is still reachable, by naming it — which is the cost of the repair and
-    // the whole of it.
+    // The consumer's answer is the opposite one, and is still reachable by naming their trait.
     assert!(
-      <LitDecimal<&str> as crate::types::recovery::RecoveryState>::status(&nonsense).is_valid(),
-      "tokora's recovery status is the opposite answer, reached by naming the trait",
+      !their_prelude::RecoveryState::is_valid(&nonsense),
+      "the consumer's semantic check rejects a non-numeric payload",
     );
   }
 }
@@ -1554,7 +1552,7 @@ mod second_glob {
 /// The cell below is the in-tree half: it holds the shapes a consumer would have written, in the
 /// form they now have to take. Each is `compile_fail` in its tuple spelling — that half cannot be
 /// a runtime assertion, so it is a doctest on
-/// [`Components`](super::recovery::Components) rather than a `#[test]`, and this function pins the
+/// [`Components`](super::Components) rather than a `#[test]`, and this function pins the
 /// *positive* half: that the named form binds what its name says.
 #[test]
 fn the_components_struct_binds_by_name_not_by_position() {

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -863,3 +863,108 @@ fn an_error_node_placeholder_survives_a_decompose_and_rebuild() {
     );
   }
 }
+
+// --- A language marker is a marker: no carrier may demand traits of it ---
+
+/// A language marker written the way a consumer actually writes one — a bare unit struct with
+/// **no derives at all**.
+///
+/// This is the whole instrument. Every carrier in this module holds a `PhantomData<Lang>`, and a
+/// `derive` constrains every type parameter, so the six derived impls each carried a `Lang:` bound
+/// that nothing in the body uses: `PhantomData<T>` is `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`
+/// and `Hash` for any `T`, unconditionally. Before tokora#320 that made
+/// `Ident<&str, SimpleSpan, BareLang>` neither printable, copyable, comparable nor hashable, and
+/// the cells below did not compile.
+///
+/// It was found the way such things are found — a doctest that would not build until four derives
+/// were added to its marker — and the workaround was the reason to fix it rather than file it:
+/// published documentation that derives `Debug + Clone + Copy + PartialEq` on a marker teaches a
+/// consumer to do the same for a reason that does not exist.
+struct BareLang;
+
+/// The six traits every carrier in this module claims. `Recoverable` is deliberately absent: it
+/// claims `PartialOrd`/`Ord` as well and `Copy` not at all, and it holds no `PhantomData`, so it
+/// is not in this population.
+fn requires_the_six<T>(_: &T)
+where
+  T: core::fmt::Debug + Clone + Copy + PartialEq + Eq + core::hash::Hash,
+{
+}
+
+#[derive(Default)]
+struct CountingHasher(u64);
+
+impl core::hash::Hasher for CountingHasher {
+  fn finish(&self) -> u64 {
+    self.0
+  }
+
+  fn write(&mut self, bytes: &[u8]) {
+    self.0 = self.0.wrapping_add(bytes.len() as u64);
+  }
+}
+
+/// Names the bound and then exercises it, so the cell proves the impls work rather than only that
+/// they resolve.
+macro_rules! assert_marker_is_not_a_bound {
+  ($($carrier:ident),+ $(,)?) => {
+    $({
+      use core::hash::{Hash, Hasher};
+
+      let span = SimpleSpan::new(2, 8);
+      let value = $carrier::<&str, SimpleSpan, BareLang>::with_status(span, "x", Status::Error);
+
+      requires_the_six(&value);
+
+      let copied = value;
+      let cloned = value.clone();
+      assert_eq!(copied, cloned, concat!(stringify!($carrier), ": Copy and Clone agree"));
+      assert!(
+        format!("{value:?}").starts_with(concat!(stringify!($carrier), " {")),
+        concat!(stringify!($carrier), ": Debug names the type"),
+      );
+
+      let mut h = CountingHasher::default();
+      value.hash(&mut h);
+      assert_ne!(h.finish(), 0, concat!(stringify!($carrier), ": Hash reaches the fields"));
+    })+
+  };
+}
+
+#[test]
+fn no_carrier_demands_a_trait_of_its_language_marker() {
+  assert_marker_is_not_a_bound!(
+    Ident,
+    Keyword,
+    Lit,
+    LitDecimal,
+    LitHex,
+    LitOctal,
+    LitBinary,
+    LitFloat,
+    LitHexFloat,
+    LitString,
+    LitMultilineString,
+    LitRawString,
+    LitChar,
+    LitByte,
+    LitByteString,
+    LitBool,
+    LitTrue,
+    LitFalse,
+    LitNull,
+  );
+
+  // `IdentList` is the twentieth, and the one where **two** parameters were phantom: `S` appears
+  // only in `PhantomData<S>` and in the default container, so a derive demanded `S: Debug` too.
+  // The container has to be `Copy` for the `Copy` cell to mean anything, so it is an array.
+  let span = SimpleSpan::new(0, 3);
+  let segments = [Ident::<&str, SimpleSpan, BareLang>::new(span, "foo")];
+  let list = IdentList::<&str, SimpleSpan, [Ident<&str, SimpleSpan, BareLang>; 1], BareLang>::new(
+    span, segments,
+  );
+
+  requires_the_six(&list);
+  assert!(list.is_valid());
+  assert_eq!(list, list.clone());
+}

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -3,6 +3,7 @@ use super::*;
 // which is the whole repair, and this line is what an ordinary consumer writes instead.
 use super::recovery::{Components, FromComponents, RecoveryState, Status};
 use std::{
+  format,
   string::{String, ToString},
   vec,
   vec::Vec,

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 // `RecoveryState` is no longer re-exported into `types`, so `use super::*` does not bring it in —
 // which is the whole repair, and this line is what an ordinary consumer writes instead.
-use super::recovery::{FromComponents, RecoveryState};
+use super::recovery::{Components, FromComponents, RecoveryState};
 use std::{
   string::{String, ToString},
   vec,
@@ -146,7 +146,11 @@ fn ident_list_of_mapped_recovery_segments_is_not_valid() {
 fn ident_into_components() {
   use crate::utils::IntoComponents;
   let ident = Ident::<&str>::new(SimpleSpan::new(0, 3), "foo");
-  let (span, source, status) = ident.into_components();
+  let Components {
+    span,
+    payload: source,
+    status,
+  } = ident.into_components();
   assert_eq!(span, SimpleSpan::new(0, 3));
   assert_eq!(source, "foo");
   assert!(status.is_valid());
@@ -200,7 +204,11 @@ fn keyword_map() {
 #[test]
 fn keyword_into_components() {
   let kw = Keyword::<&str>::new(SimpleSpan::new(0, 3), "let");
-  let (span, source, status) = kw.into_components();
+  let Components {
+    span,
+    payload: source,
+    status,
+  } = kw.into_components();
   assert!(status.is_valid());
   assert_eq!(span, SimpleSpan::new(0, 3));
   assert_eq!(source, "let");
@@ -381,7 +389,11 @@ fn lit_hex_new() {
 fn lit_into_components() {
   use crate::utils::IntoComponents;
   let lit = LitDecimal::<&str>::new(SimpleSpan::new(0, 2), "42");
-  let (span, data, status) = IntoComponents::into_components(lit);
+  let Components {
+    span,
+    payload: data,
+    status,
+  } = IntoComponents::into_components(lit);
   assert!(status.is_valid());
   assert_eq!(span, SimpleSpan::new(0, 2));
   assert_eq!(data, "42");
@@ -524,7 +536,11 @@ fn keyword_as_span() {
 fn keyword_into_components_trait() {
   use crate::utils::IntoComponents;
   let kw = Keyword::<&str>::new(SimpleSpan::new(0, 3), "let");
-  let (span, source, status) = IntoComponents::into_components(kw);
+  let Components {
+    span,
+    payload: source,
+    status,
+  } = IntoComponents::into_components(kw);
   assert!(status.is_valid());
   assert_eq!(span, SimpleSpan::new(0, 3));
   assert_eq!(source, "let");
@@ -533,7 +549,11 @@ fn keyword_into_components_trait() {
 #[test]
 fn keyword_into_components_method() {
   let kw = Keyword::<&str>::new(SimpleSpan::new(0, 3), "let");
-  let (span, source, status) = kw.into_components();
+  let Components {
+    span,
+    payload: source,
+    status,
+  } = kw.into_components();
   assert_eq!(span, SimpleSpan::new(0, 3));
   assert_eq!(source, "let");
   assert!(status.is_valid());
@@ -557,7 +577,11 @@ fn ident_as_span() {
 fn ident_into_components_trait() {
   use crate::utils::IntoComponents;
   let ident = Ident::<&str>::new(SimpleSpan::new(0, 3), "foo");
-  let (span, source, status) = IntoComponents::into_components(ident);
+  let Components {
+    span,
+    payload: source,
+    status,
+  } = IntoComponents::into_components(ident);
   assert!(status.is_valid());
   assert_eq!(span, SimpleSpan::new(0, 3));
   assert_eq!(source, "foo");
@@ -696,7 +720,11 @@ fn lit_false_new() {
 fn lit_decimal_into_components_trait() {
   use crate::utils::IntoComponents;
   let lit = LitHex::<&str>::new(SimpleSpan::new(0, 4), "0xFF");
-  let (span, data, status) = IntoComponents::into_components(lit);
+  let Components {
+    span,
+    payload: data,
+    status,
+  } = IntoComponents::into_components(lit);
   assert!(status.is_valid());
   assert_eq!(span, SimpleSpan::new(0, 4));
   assert_eq!(data, "0xFF");
@@ -756,14 +784,14 @@ macro_rules! assert_status_survives_a_round_trip {
 
       for status in [Status::Valid, Status::Error, Status::Missing] {
         let name = stringify!($carrier);
-        let original = $carrier::<&str>::from_components((span, "payload", status));
+        let original = $carrier::<&str>::from_components(Components { span, payload: "payload", status });
 
-        let (sp, payload, st) = IntoComponents::into_components(original);
+        let Components { span: sp, payload, status: st } = IntoComponents::into_components(original);
         assert_eq!(sp, span, "{name} in {status:?}: span");
         assert_eq!(payload, "payload", "{name} in {status:?}: payload");
         assert_eq!(st, status, "{name} in {status:?}: status survives the decomposition");
 
-        let rebuilt = $carrier::<&str>::from_components((sp, payload, st));
+        let rebuilt = $carrier::<&str>::from_components(Components { span: sp, payload, status: st });
         assert_eq!(rebuilt, original, "{name} in {status:?}: the round trip is the identity");
         assert_eq!(rebuilt.is_valid(), status.is_valid(), "{name} in {status:?}: is_valid");
         assert_eq!(rebuilt.is_error(), status.is_error(), "{name} in {status:?}: is_error");
@@ -810,18 +838,22 @@ fn keywords_inherent_decomposition_agrees_with_the_trait_one() {
   let span = SimpleSpan::new(1, 5);
 
   for status in [Status::Valid, Status::Error, Status::Missing] {
-    let kw = Keyword::<&str>::from_components((span, "then", status));
+    let kw = Keyword::<&str>::from_components(Components {
+      span,
+      payload: "then",
+      status,
+    });
 
     let inherent = Keyword::into_components(kw);
     let via_trait = IntoComponents::into_components(kw);
 
     assert_eq!(inherent, via_trait, "{status:?}: the two doors agree");
     assert_eq!(
-      inherent.2, status,
+      inherent.status, status,
       "{status:?}: the inherent door carries the status"
     );
     assert_eq!(
-      Keyword::<&str>::from_components((inherent.0, inherent.1, inherent.2)),
+      Keyword::<&str>::from_components(inherent),
       kw,
       "{status:?}: the inherent door's output rebuilds its input",
     );
@@ -849,16 +881,32 @@ fn an_error_node_placeholder_survives_a_decompose_and_rebuild() {
       LitDecimal::<&str>::missing(span),
     ),
   ] {
-    let (sp, src, st) = IntoComponents::into_components(kw);
-    let rebuilt = Keyword::<&str>::from_components((sp, src, st));
+    let Components {
+      span: sp,
+      payload: src,
+      status: st,
+    } = IntoComponents::into_components(kw);
+    let rebuilt = Keyword::<&str>::from_components(Components {
+      span: sp,
+      payload: src,
+      status: st,
+    });
     assert_eq!(rebuilt, kw, "{label}: keyword round trip");
     assert!(
       !rebuilt.is_valid(),
       "{label}: a rebuilt keyword is not valid syntax"
     );
 
-    let (sp, data, st) = IntoComponents::into_components(lit);
-    let rebuilt = LitDecimal::<&str>::from_components((sp, data, st));
+    let Components {
+      span: sp,
+      payload: data,
+      status: st,
+    } = IntoComponents::into_components(lit);
+    let rebuilt = LitDecimal::<&str>::from_components(Components {
+      span: sp,
+      payload: data,
+      status: st,
+    });
     assert_eq!(rebuilt, lit, "{label}: literal round trip");
     assert!(
       !rebuilt.is_valid(),
@@ -931,7 +979,7 @@ macro_rules! assert_marker_is_not_a_bound {
       use core::hash::{Hash, Hasher};
 
       let span = SimpleSpan::new(2, 8);
-      let value = $carrier::<&str, SimpleSpan, BareLang>::from_components((span, "x", Status::Error));
+      let value = $carrier::<&str, SimpleSpan, BareLang>::from_components(Components { span, payload: "x", status: Status::Error });
 
       requires_the_four(&value);
 
@@ -948,7 +996,7 @@ macro_rules! assert_marker_is_not_a_bound {
 
       // The other two, over a marker that carries them — which is what the `PartialEq` derive
       // costs and what `StructuralPartialEq` buys back.
-      let eq_marked = $carrier::<&str, SimpleSpan, EqLang>::from_components((span, "x", Status::Error));
+      let eq_marked = $carrier::<&str, SimpleSpan, EqLang>::from_components(Components { span, payload: "x", status: Status::Error });
       requires_the_other_two(&eq_marked);
       assert_eq!(eq_marked, eq_marked.clone(), concat!(stringify!($carrier), ": Eq over an Eq marker"));
     })+
@@ -1396,7 +1444,11 @@ fn a_const_carrier_is_usable_in_a_match_pattern() {
   // A recovery placeholder is a different value from a hand-spelled one, in a pattern too — the
   // status is part of what the pattern matches.
   assert_eq!(
-    classify_ident(Ident::from_components(((), "let", Status::Missing))),
+    classify_ident(Ident::from_components(Components {
+      span: (),
+      payload: "let",
+      status: Status::Missing
+    })),
     0,
     "the status participates in structural matching",
   );
@@ -1462,5 +1514,89 @@ mod second_glob {
       <LitDecimal<&str> as crate::types::recovery::RecoveryState>::status(&nonsense).is_valid(),
       "tokora's recovery status is the opposite answer, reached by naming the trait",
     );
+  }
+}
+
+// --- No pattern written against the old two-tuple may compile against the new shape ---
+
+/// **The differential for `Components` being a braced struct rather than a three-tuple.**
+///
+/// The widening from `(Span, Payload)` to `(Span, Payload, Status)` was defended as loud because
+/// it changes the arity. One line defeats that: `let (_, .., value) = literal.into_components();`
+/// binds `value` to the payload against a pair and to the status against a triple, and both
+/// compile whenever the payload also answers `is_valid`. Since `new` assigns `Status::Valid`, a
+/// payload the caller's own check rejects then reports valid. `(.., b)` and `.1` are the same
+/// defect in other spellings.
+///
+/// That was the third exemption of its kind refuted on this branch — after *the return type
+/// differs* and *the argument type is a `Status`* — and all three estimated the set of things a
+/// consumer could have written, and estimated it too small. So the repair is not a better-argued
+/// exemption but a shape no tuple pattern can match at all.
+///
+/// # How that was established
+///
+/// Ten pattern shapes were compiled against both the old pair and the new struct, as standalone
+/// programs, and the pair is the control rather than an assumption — all ten build against it:
+///
+/// | pattern | old `(Span, Payload)` | `Components` |
+/// |---|---|---|
+/// | `let (a, b)` | builds | `E0308` |
+/// | `let (_, b)` | builds | `E0308` |
+/// | `let (a, ..)` | builds | `E0308` |
+/// | `let (_, .., b)` | builds | `E0308` |
+/// | `let (.., b)` | builds | `E0308` |
+/// | `let (_, b,)` (trailing comma) | builds | `E0308` |
+/// | `let (ref a, ref b)` | builds | `E0308` |
+/// | `match .. { (_, b) => }` | builds | `E0308` |
+/// | `t.0` | builds | `E0609` |
+/// | `t.1` | builds | `E0609` |
+///
+/// The cell below is the in-tree half: it holds the shapes a consumer would have written, in the
+/// form they now have to take. Each is `compile_fail` in its tuple spelling — that half cannot be
+/// a runtime assertion, so it is a doctest on
+/// [`Components`](super::recovery::Components) rather than a `#[test]`, and this function pins the
+/// *positive* half: that the named form binds what its name says.
+#[test]
+fn the_components_struct_binds_by_name_not_by_position() {
+  use crate::utils::IntoComponents;
+
+  let span = SimpleSpan::new(1, 5);
+
+  // A payload whose own notion of validity disagrees with the recovery status, which is what
+  // makes a mis-bound third element dangerous rather than merely wrong.
+  let lit = LitDecimal::<&str>::new(span, "nope");
+  let Components {
+    span: got_span,
+    payload,
+    status,
+  } = IntoComponents::into_components(lit);
+
+  assert_eq!(got_span, span);
+  assert_eq!(payload, "nope", "the payload binds by name");
+  assert!(
+    status.is_valid(),
+    "the status binds by name, and `new` declared it valid"
+  );
+
+  // The `..` that used to move: with a struct it can only elide *named* fields, so the binding
+  // that survives is the one the author named, not the one position three happens to hold.
+  let Components { payload, .. } = IntoComponents::into_components(lit);
+  assert_eq!(
+    payload, "nope",
+    "`..` cannot slide a binding onto the status"
+  );
+
+  let Components { status, .. } = IntoComponents::into_components(lit);
+  assert!(status.is_valid());
+
+  // Round trip through the same shape, in all three states.
+  for st in [Status::Valid, Status::Error, Status::Missing] {
+    let original = LitDecimal::<&str>::from_components(Components {
+      span,
+      payload: "42",
+      status: st,
+    });
+    let rebuilt = LitDecimal::<&str>::from_components(original.into_components());
+    assert_eq!(rebuilt, original, "{st:?}: the round trip is the identity");
   }
 }

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -968,3 +968,131 @@ fn no_carrier_demands_a_trait_of_its_language_marker() {
   assert!(list.is_valid());
   assert_eq!(list, list.clone());
 }
+
+// --- A name this branch adds must not silently displace a consumer's own ---
+
+/// A downstream crate's scope, reproduced: the carriers are imported, and
+/// [`RecoveryState`](super::RecoveryState) deliberately is **not**. That is the position an
+/// upgrading consumer is in, and it is why this is a module — `use super::*` in the parent puts
+/// the trait in scope, and a trait in scope contributes its method names whatever it is bound to.
+mod consumer_scope {
+  use crate::{
+    SimpleSpan,
+    error::ErrorNode,
+    types::{LitDecimal, Status},
+  };
+
+  /// A downstream extension trait with the three names, meaning something of its own.
+  ///
+  /// This is the review's example for tokora#320: a consumer whose `is_valid` asks whether a
+  /// `LitDecimal`'s payload actually parses as a number. `LitDecimal::new` marks every payload
+  /// `Status::Valid`, so if tokora's answer displaced this one the check would be bypassed and
+  /// `"nope"` would read as a valid decimal, with nothing at the call site to say so.
+  trait ConsumerChecks {
+    fn is_valid(&self) -> bool;
+    fn is_error(&self) -> bool;
+    fn is_missing(&self) -> bool;
+  }
+
+  impl ConsumerChecks for LitDecimal<&str> {
+    /// Deliberately the opposite answer from tokora's: `<error>` does not parse as a number, and
+    /// `"12"` does, whatever either value's recovery status is.
+    fn is_valid(&self) -> bool {
+      !self.data_ref().is_empty() && self.data_ref().chars().all(|c| c.is_ascii_digit())
+    }
+
+    fn is_error(&self) -> bool {
+      !ConsumerChecks::is_valid(self)
+    }
+
+    fn is_missing(&self) -> bool {
+      self.data_ref().is_empty()
+    }
+  }
+
+  /// tokora's own answer, reached without importing the trait — which is what a fully qualified
+  /// path is for, and what the consumer would write on the rare call that wants it.
+  fn tokora_status(lit: &LitDecimal<&str>) -> Status {
+    <LitDecimal<&str> as crate::types::RecoveryState>::status(lit)
+  }
+
+  /// **The cell, and its two directions.**
+  ///
+  /// *Here*, with only the consumer's trait in scope, every unqualified `is_valid` reaches the
+  /// consumer's method — which is exactly the behaviour an upgrade must not change. Before
+  /// tokora#320 moved the three questions onto a trait they were inherent methods on all
+  /// seventeen `Lit*` types and on `Keyword`, and Rust prefers an inherent method over a trait's
+  /// at an unqualified call site, so this function kept compiling and the two assertions marked
+  /// below **reversed** — silently, with no diagnostic anywhere.
+  ///
+  /// *In the parent module*, where `use super::*` does put `RecoveryState` in scope beside a
+  /// consumer trait, the same call is `error[E0034]: multiple applicable items in scope`, naming
+  /// both candidates. That is not hypothetical: writing this cell in the parent produced exactly
+  /// that error, which is why it lives here.
+  ///
+  /// Ambiguity, or an explicit choice, or no change at all. Never a different answer.
+  #[test]
+  fn a_consumers_own_predicate_is_not_displaced_by_tokoras() {
+    let span = SimpleSpan::new(0, 4);
+
+    // A recovery placeholder. Both sides agree it is not valid, for different reasons.
+    let recovered = LitDecimal::<&str>::error(span);
+    assert!(
+      !recovered.is_valid(),
+      "the consumer's check owns the unqualified call"
+    );
+    assert!(recovered.is_error());
+
+    // The pair that reverses if the inherent methods come back: the consumer rejects this
+    // payload, tokora's status calls it valid, and the unqualified call must be the consumer's.
+    let nonsense = LitDecimal::<&str>::new(span, "nope");
+    assert!(
+      !nonsense.is_valid(),
+      "the consumer rejects a non-numeric payload"
+    );
+    assert!(
+      tokora_status(&nonsense).is_valid(),
+      "tokora's own answer is the opposite one, and naming it is how you get it",
+    );
+
+    // A digit payload the consumer accepts, so the cell is not one-sided.
+    let real = LitDecimal::<&str>::new(span, "12");
+    assert!(real.is_valid());
+    assert!(!real.is_missing());
+    assert!(tokora_status(&real).is_valid());
+  }
+
+  /// A consumer constructor with the same name and arity as the new inherent `with_status`.
+  trait ConsumerCtor {
+    fn with_status(span: SimpleSpan, data: &'static str, ok: bool) -> Self;
+  }
+
+  impl ConsumerCtor for LitDecimal<&'static str> {
+    fn with_status(span: SimpleSpan, data: &'static str, ok: bool) -> Self {
+      LitDecimal::new(span, if ok { data } else { "" })
+    }
+  }
+
+  /// `with_status` is a new inherent name on nineteen carriers, and the review grouped it with the
+  /// three questions. It is in the population but not in the *silent* half, and this is the
+  /// argument rather than the assertion.
+  ///
+  /// The three questions take no arguments and return `bool`, so a consumer's method of that name
+  /// has an identical signature and a displacement is invisible. `with_status` takes a
+  /// [`Status`](crate::types::Status) — a type that did not exist before tokora#320 — so no method
+  /// a consumer already wrote can have that parameter type. Displacing one is `error[E0308]` at
+  /// the call site: `ConsumerCtor::with_status(span, "42", false)` written unqualified now
+  /// resolves to tokora's and fails to typecheck on the `bool`.
+  #[test]
+  fn with_status_cannot_be_displaced_silently() {
+    let span = SimpleSpan::new(0, 2);
+
+    // tokora's inherent one wins the unqualified pick, and its third argument is a `Status`.
+    let ours = LitDecimal::<&str>::with_status(span, "42", Status::Missing);
+    assert!(tokora_status(&ours).is_missing());
+
+    // The consumer's is still reachable, by name.
+    let theirs = <LitDecimal<&str> as ConsumerCtor>::with_status(span, "42", false);
+    assert_eq!(theirs.data_ref(), &"");
+  }
+}

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 // `RecoveryState` is no longer re-exported into `types`, so `use super::*` does not bring it in —
 // which is the whole repair, and this line is what an ordinary consumer writes instead.
-use super::recovery::RecoveryState;
+use super::recovery::{FromComponents, RecoveryState};
 use std::{
   string::{String, ToString},
   vec,
@@ -756,14 +756,14 @@ macro_rules! assert_status_survives_a_round_trip {
 
       for status in [Status::Valid, Status::Error, Status::Missing] {
         let name = stringify!($carrier);
-        let original = $carrier::<&str>::with_status(span, "payload", status);
+        let original = $carrier::<&str>::from_components((span, "payload", status));
 
         let (sp, payload, st) = IntoComponents::into_components(original);
         assert_eq!(sp, span, "{name} in {status:?}: span");
         assert_eq!(payload, "payload", "{name} in {status:?}: payload");
         assert_eq!(st, status, "{name} in {status:?}: status survives the decomposition");
 
-        let rebuilt = $carrier::<&str>::with_status(sp, payload, st);
+        let rebuilt = $carrier::<&str>::from_components((sp, payload, st));
         assert_eq!(rebuilt, original, "{name} in {status:?}: the round trip is the identity");
         assert_eq!(rebuilt.is_valid(), status.is_valid(), "{name} in {status:?}: is_valid");
         assert_eq!(rebuilt.is_error(), status.is_error(), "{name} in {status:?}: is_error");
@@ -810,7 +810,7 @@ fn keywords_inherent_decomposition_agrees_with_the_trait_one() {
   let span = SimpleSpan::new(1, 5);
 
   for status in [Status::Valid, Status::Error, Status::Missing] {
-    let kw = Keyword::<&str>::with_status(span, "then", status);
+    let kw = Keyword::<&str>::from_components((span, "then", status));
 
     let inherent = Keyword::into_components(kw);
     let via_trait = IntoComponents::into_components(kw);
@@ -821,7 +821,7 @@ fn keywords_inherent_decomposition_agrees_with_the_trait_one() {
       "{status:?}: the inherent door carries the status"
     );
     assert_eq!(
-      Keyword::<&str>::with_status(inherent.0, inherent.1, inherent.2),
+      Keyword::<&str>::from_components((inherent.0, inherent.1, inherent.2)),
       kw,
       "{status:?}: the inherent door's output rebuilds its input",
     );
@@ -850,7 +850,7 @@ fn an_error_node_placeholder_survives_a_decompose_and_rebuild() {
     ),
   ] {
     let (sp, src, st) = IntoComponents::into_components(kw);
-    let rebuilt = Keyword::<&str>::with_status(sp, src, st);
+    let rebuilt = Keyword::<&str>::from_components((sp, src, st));
     assert_eq!(rebuilt, kw, "{label}: keyword round trip");
     assert!(
       !rebuilt.is_valid(),
@@ -858,7 +858,7 @@ fn an_error_node_placeholder_survives_a_decompose_and_rebuild() {
     );
 
     let (sp, data, st) = IntoComponents::into_components(lit);
-    let rebuilt = LitDecimal::<&str>::with_status(sp, data, st);
+    let rebuilt = LitDecimal::<&str>::from_components((sp, data, st));
     assert_eq!(rebuilt, lit, "{label}: literal round trip");
     assert!(
       !rebuilt.is_valid(),
@@ -931,7 +931,7 @@ macro_rules! assert_marker_is_not_a_bound {
       use core::hash::{Hash, Hasher};
 
       let span = SimpleSpan::new(2, 8);
-      let value = $carrier::<&str, SimpleSpan, BareLang>::with_status(span, "x", Status::Error);
+      let value = $carrier::<&str, SimpleSpan, BareLang>::from_components((span, "x", Status::Error));
 
       requires_the_four(&value);
 
@@ -948,7 +948,7 @@ macro_rules! assert_marker_is_not_a_bound {
 
       // The other two, over a marker that carries them — which is what the `PartialEq` derive
       // costs and what `StructuralPartialEq` buys back.
-      let eq_marked = $carrier::<&str, SimpleSpan, EqLang>::with_status(span, "x", Status::Error);
+      let eq_marked = $carrier::<&str, SimpleSpan, EqLang>::from_components((span, "x", Status::Error));
       requires_the_other_two(&eq_marked);
       assert_eq!(eq_marked, eq_marked.clone(), concat!(stringify!($carrier), ": Eq over an Eq marker"));
     })+
@@ -1242,38 +1242,100 @@ mod consumer_scope {
     assert!(ConsumerIdentChecks::is_valid(&missing));
   }
 
-  /// A consumer constructor with the same name and arity as the new inherent `with_status`.
+  /// A consumer's zero-valued **rejection** state, and a constructor taking it.
+  ///
+  /// The discriminants matter: theirs is `Reject = 0`, and tokora's `Status::Valid` is also at
+  /// zero. That is what turns a re-targeted argument into a semantic inversion rather than a
+  /// visible error.
+  #[derive(Debug, Copy, Clone, PartialEq)]
+  #[repr(u8)]
+  enum TheirStatus {
+    Reject = 0,
+    Accept = 1,
+  }
+
   trait ConsumerCtor {
-    fn with_status(span: SimpleSpan, data: &'static str, ok: bool) -> Self;
+    fn with_status(span: SimpleSpan, data: &'static str, status: TheirStatus) -> Self;
   }
 
   impl ConsumerCtor for LitDecimal<&'static str> {
-    fn with_status(span: SimpleSpan, data: &'static str, ok: bool) -> Self {
-      LitDecimal::new(span, if ok { data } else { "" })
+    fn with_status(span: SimpleSpan, data: &'static str, status: TheirStatus) -> Self {
+      // A rejection produces an empty payload, so the outcome is visible at runtime.
+      LitDecimal::new(
+        span,
+        if status == TheirStatus::Accept {
+          data
+        } else {
+          ""
+        },
+      )
     }
   }
 
-  /// `with_status` is a new inherent name on nineteen carriers, and the review grouped it with the
-  /// three questions. It is in the population but not in the *silent* half, and this is the
-  /// argument rather than the assertion.
+  /// **The fifth failure mode: an argument whose type the parameter chooses.**
   ///
-  /// The three questions take no arguments and return `bool`, so a consumer's method of that name
-  /// has an identical signature and a displacement is invisible. `with_status` takes a
-  /// [`Status`](crate::types::Status) — a type that did not exist before tokora#320 — so no method
-  /// a consumer already wrote can have that parameter type. Displacing one is `error[E0308]` at
-  /// the call site: `ConsumerCtor::with_status(span, "42", false)` written unqualified now
-  /// resolves to tokora's and fails to typecheck on the `bool`.
+  /// A draft of this branch shipped `with_status` as a `pub const fn` inherent on all nineteen
+  /// carriers, arguing it could not be displaced silently because its third parameter is a
+  /// [`Status`](crate::types::Status), a type no pre-upgrade expression can produce. That holds
+  /// for expressions whose type comes from the *expression* — `Default::default()`, `x.into()`,
+  /// an associated constant, a bounded generic call — all of which were measured and all of which
+  /// fail with `E0277` or `E0308`.
+  ///
+  /// It is false for expressions whose type comes from the **parameter**. Measured across the two
+  /// revisions: an unchanged `unsafe { core::mem::zeroed() }` infers as the consumer's enum
+  /// before and as tokora's `Status` after, both compile, and dispatch moves from the consumer's
+  /// trait to tokora's inherent function. `Reject = 0` becomes `Status::Valid`, so a rejection
+  /// silently becomes valid syntax. `transmute::<u8, _>(0)` does the same, and
+  /// `MaybeUninit::uninit().assume_init()` is worse — it yields whatever the stack held.
+  ///
+  /// So the constructor is not in the inherent namespace at all: it is
+  /// [`FromComponents::from_components`](crate::types::recovery::FromComponents::from_components),
+  /// a trait method, which a consumer's inherent item outranks. The call below reaches the
+  /// consumer's constructor and must keep doing so.
   #[test]
-  fn with_status_cannot_be_displaced_silently() {
+  fn a_type_directed_argument_still_reaches_the_consumers_constructor() {
     let span = SimpleSpan::new(0, 2);
 
-    // tokora's inherent one wins the unqualified pick, and its third argument is a `Status`.
-    let ours = LitDecimal::<&str>::with_status(span, "42", Status::Missing);
-    assert!(tokora_status(&ours).is_missing());
+    // The precondition that makes a re-targeted argument an inversion rather than a visible
+    // error, pinned rather than described: both zero discriminants mean opposite things.
+    assert_eq!(
+      TheirStatus::Reject as u8,
+      0,
+      "the consumer's rejection is at zero"
+    );
+    assert_eq!(Status::Valid as u8, 0, "tokora's valid is at zero too");
 
-    // The consumer's is still reachable, by name.
-    let theirs = <LitDecimal<&str> as ConsumerCtor>::with_status(span, "42", false);
-    assert_eq!(theirs.data_ref(), &"");
+    // The type-directed expression, unchanged across the upgrade, at an **unqualified** call.
+    // Naming `ConsumerCtor::` here would pin the trait and no inherent item could ever displace
+    // it — which would arrange the cell so the defect could not reach it. This is the spelling a
+    // consumer actually writes, and the one an inherent `with_status` captures.
+    let built = LitDecimal::<&str>::with_status(span, "42", unsafe { core::mem::zeroed() });
+
+    assert_eq!(
+      built.data_ref(),
+      &"",
+      "a zero-valued argument must still mean the consumer's Reject, not tokora's Valid",
+    );
+
+    // The non-vacuity control, and it has to be type-directed too. Naming `TheirStatus::Accept`
+    // here would be `error[E0308]` under the plant — the loud shape — and the build would stop
+    // before the silent line above ever ran. `1` is `Accept` for the consumer and `Error` for
+    // tokora, both valid `#[repr(u8)]` discriminants, so this line compiles and holds either way
+    // while the line above is the one that moves.
+    // The missing target annotation is the subject of this cell, not an oversight: annotating it
+    // would pin the type and remove the very inference the test is about.
+    #[allow(clippy::missing_transmute_annotations)]
+    let accepted =
+      LitDecimal::<&str>::with_status(span, "42", unsafe { core::mem::transmute::<u8, _>(1u8) });
+    assert_eq!(accepted.data_ref(), &"42");
+
+    // tokora's own status-preserving construction is still reachable, by the trait that replaced
+    // the constructor — and it is the exact inverse of the decomposition.
+    use crate::{types::recovery::FromComponents, utils::IntoComponents};
+    let placeholder = LitDecimal::<&str>::error(span);
+    let rebuilt = LitDecimal::<&str>::from_components(placeholder.into_components());
+    assert_eq!(rebuilt, placeholder);
+    assert!(!tokora_status(&rebuilt).is_valid());
   }
 }
 
@@ -1334,7 +1396,7 @@ fn a_const_carrier_is_usable_in_a_match_pattern() {
   // A recovery placeholder is a different value from a hand-spelled one, in a pattern too — the
   // status is part of what the pattern matches.
   assert_eq!(
-    classify_ident(Ident::with_status((), "let", Status::Missing)),
+    classify_ident(Ident::from_components(((), "let", Status::Missing))),
     0,
     "the status participates in structural matching",
   );

--- a/tokora/src/types/tests.rs
+++ b/tokora/src/types/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 // `RecoveryState` is no longer re-exported into `types`, so `use super::*` does not bring it in —
 // which is the whole repair, and this line is what an ordinary consumer writes instead.
-use super::{Components, FromComponents, RecoveryState};
+use super::recovery::{Components, FromComponents, RecoveryState, Status};
 use std::{
   string::{String, ToString},
   vec,
@@ -1050,14 +1050,14 @@ fn no_carrier_demands_a_trait_of_its_language_marker() {
 // --- A name this branch adds must not silently displace a consumer's own ---
 
 /// A downstream crate's scope, reproduced: the carriers are imported, and
-/// [`RecoveryState`](super::RecoveryState) deliberately is **not**. That is the position an
+/// [`RecoveryState`](super::recovery::RecoveryState) deliberately is **not**. That is the position an
 /// upgrading consumer is in, and it is why this is a module — `use super::*` in the parent puts
 /// the trait in scope, and a trait in scope contributes its method names whatever it is bound to.
 mod consumer_scope {
   use crate::{
     SimpleSpan,
     error::ErrorNode,
-    types::{Ident, LitDecimal, Status},
+    types::{Ident, LitDecimal, recovery::Status},
   };
 
   /// A downstream extension trait with the three names, meaning something of its own.
@@ -1091,7 +1091,7 @@ mod consumer_scope {
   /// tokora's own answer, reached without importing the trait — which is what a fully qualified
   /// path is for, and what the consumer would write on the rare call that wants it.
   fn tokora_status(lit: &LitDecimal<&str>) -> Status {
-    <LitDecimal<&str> as crate::types::RecoveryState>::status(lit)
+    <LitDecimal<&str> as crate::types::recovery::RecoveryState>::status(lit)
   }
 
   /// **The cell, and its two directions.**
@@ -1176,7 +1176,7 @@ mod consumer_scope {
   /// consumer whose `status()` returned something else would get a type error.
   ///
   /// A differing return type is only loud **if the caller stores the value**. The chain below
-  /// stores nothing, and [`Status`](crate::types::Status) offers `is_valid` too, so with an
+  /// stores nothing, and [`Status`](crate::types::recovery::Status) offers `is_valid` too, so with an
   /// inherent `status` in place `literal.status().is_valid()` keeps compiling and silently stops
   /// asking the consumer's question. `new` marks any caller-supplied payload `Status::Valid`, so
   /// `"999"` — which does not fit the consumer's `u8` — passes.
@@ -1324,7 +1324,7 @@ mod consumer_scope {
   ///
   /// A draft of this branch shipped `with_status` as a `pub const fn` inherent on all nineteen
   /// carriers, arguing it could not be displaced silently because its third parameter is a
-  /// [`Status`](crate::types::Status), a type no pre-upgrade expression can produce. That holds
+  /// [`Status`](crate::types::recovery::Status), a type no pre-upgrade expression can produce. That holds
   /// for expressions whose type comes from the *expression* — `Default::default()`, `x.into()`,
   /// an associated constant, a bounded generic call — all of which were measured and all of which
   /// fail with `E0277` or `E0308`.
@@ -1337,7 +1337,7 @@ mod consumer_scope {
   /// `MaybeUninit::uninit().assume_init()` is worse — it yields whatever the stack held.
   ///
   /// So the constructor is not in the inherent namespace at all: it is
-  /// [`FromComponents::from_components`](crate::types::FromComponents::from_components),
+  /// [`FromComponents::from_components`](crate::types::recovery::FromComponents::from_components),
   /// a trait method, which a consumer's inherent item outranks. The call below reaches the
   /// consumer's constructor and must keep doing so.
   #[test]
@@ -1379,7 +1379,7 @@ mod consumer_scope {
 
     // tokora's own status-preserving construction is still reachable, by the trait that replaced
     // the constructor — and it is the exact inverse of the decomposition.
-    use crate::{types::FromComponents, utils::IntoComponents};
+    use crate::{types::recovery::FromComponents, utils::IntoComponents};
     let placeholder = LitDecimal::<&str>::error(span);
     let rebuilt = LitDecimal::<&str>::from_components(placeholder.into_components());
     assert_eq!(rebuilt, placeholder);
@@ -1456,22 +1456,24 @@ fn a_const_carrier_is_usable_in_a_match_pattern() {
 
 // --- A second glob must not be able to rebind a consumer's method ---
 
-/// **The accepted residual, pinned rather than described.**
+/// A consumer crate that glob-imports **both** `tokora::types::*` and its own prelude.
 ///
-/// Round 6 moved `RecoveryState` out of `types::*` because a second glob offering the same trait
-/// name compiles, warns under the warn-by-default `ambiguous_glob_imported_traits`
-/// (rust-lang/rust#152822), and resolves to whichever glob came first. Round 9 moved it back,
-/// because the module that held it was itself a MODULE name in `types::*`, and a module is the
-/// one kind that is silent against an extern crate — a consumer with a dependency named
-/// `recovery` had every `recovery::...` path rebound to tokora, with no diagnostic at all.
+/// This is the shape that survived moving the three questions onto a trait: the trait was
+/// re-exported into `types`, so `use tokora::types::*;` put it in scope beside a same-named one of
+/// the consumer's — and that is not the hard error a same-named *type* would give.
 ///
-/// The two cannot both be closed: a public trait must live in a module, and every module is
-/// either already globbed or a new name in one. So this cell no longer asserts that the
-/// consumer's trait wins — it records what actually happens, so the trade is a fact in the test
-/// suite rather than a sentence in a doc comment.
+/// Reproduced against `rustc 1.100.0-nightly` before this was repaired, over three arrangements:
 ///
-/// If `ambiguous_glob_imported_traits` becomes the hard error its future-incompatibility note
-/// promises, this cell stops compiling and that is the signal to revisit.
+/// - two globs, same **trait** name: compiles. `ambiguous_glob_imported_traits` is warn-by-default
+///   (a future-incompatibility, rust-lang/rust#152822) and the call resolves to whichever glob was
+///   written **first**, so either side wins depending on import order.
+/// - two globs, same **type** name: `error[E0659]: ambiguous`. Hard.
+/// - two globs, same method through **differently named** traits: `error[E0034]`. Hard.
+///
+/// The repair is that `RecoveryState` is not in `types::*` at all — it lives in
+/// [`types::recovery`](super::recovery) and must be named. So the glob below contributes no
+/// competing `is_valid`, the consumer's is unopposed, and a consumer who wants tokora's writes an
+/// explicit import, which beats a glob and is a choice rather than an accident.
 mod second_glob {
   /// The consumer's own prelude, glob-exported the way a crate's prelude is.
   mod their_prelude {
@@ -1489,28 +1491,28 @@ mod second_glob {
     }
   }
 
-  /// Two globs, one of them tokora's whole `types` namespace, both offering a `RecoveryState`.
+  /// **The cell.** Two globs, one of them tokora's whole `types` namespace.
   ///
-  /// The `allow` is the residual itself: without it this is an error here, because the crate
-  /// denies warnings. A downstream crate gets the warning and the code runs.
+  /// With `pub use recovery::RecoveryState;` restored in `types/mod.rs` — the plant — this
+  /// function still compiles, emits only `ambiguous_glob_imported_traits`, and the assertion
+  /// below flips: `LitDecimal::new` marks every payload `Status::Valid`, so `"nope"` reads as
+  /// valid and the consumer's check is bypassed with no error anywhere.
   #[test]
-  #[allow(unused_imports, ambiguous_glob_imported_traits)]
-  fn two_globs_of_the_same_trait_name_resolve_to_the_first_glob() {
+  fn a_glob_of_tokora_types_does_not_rebind_the_consumers_predicate() {
     use crate::types::*;
     use their_prelude::*;
 
     let nonsense = LitDecimal::<&str>::new(SimpleSpan::new(0, 4), "nope");
-
-    // tokora's glob is written first, so tokora's trait wins — and `new` called it valid.
     assert!(
-      nonsense.is_valid(),
-      "the first glob wins: this is tokora's recovery status, not the consumer's payload check",
+      !nonsense.is_valid(),
+      "a second glob must not rebind the consumer's semantic check",
     );
 
-    // The consumer's answer is the opposite one, and is still reachable by naming their trait.
+    // Tokora's own answer is still reachable, by naming it — which is the cost of the repair and
+    // the whole of it.
     assert!(
-      !their_prelude::RecoveryState::is_valid(&nonsense),
-      "the consumer's semantic check rejects a non-numeric payload",
+      <LitDecimal<&str> as crate::types::recovery::RecoveryState>::status(&nonsense).is_valid(),
+      "tokora's recovery status is the opposite answer, reached by naming the trait",
     );
   }
 }
@@ -1552,7 +1554,7 @@ mod second_glob {
 /// The cell below is the in-tree half: it holds the shapes a consumer would have written, in the
 /// form they now have to take. Each is `compile_fail` in its tuple spelling — that half cannot be
 /// a runtime assertion, so it is a doctest on
-/// [`Components`](super::Components) rather than a `#[test]`, and this function pins the
+/// [`Components`](super::recovery::Components) rather than a `#[test]`, and this function pins the
 /// *positive* half: that the named form binds what its name says.
 #[test]
 fn the_components_struct_binds_by_name_not_by_position() {

--- a/tokora/src/utils/mod.rs
+++ b/tokora/src/utils/mod.rs
@@ -94,6 +94,21 @@ mod to_equivalent;
 /// - Ensure the decomposition is complete (no information loss)
 /// - Document the component structure clearly
 ///
+/// ### "Complete" is measured against the fields, not against what a caller usually wants
+///
+/// The completeness line above is the whole contract, and it is easy to keep in spirit and break
+/// in fact: a decomposition that returns the parts a caller normally *reaches for* is not the
+/// same as one that returns every part the value is made of. The test is whether the output can
+/// rebuild the input — if the type has a constructor the components cannot reach, the missing
+/// argument is the missing component.
+///
+/// tokora#320 is that defect: the carriers in [`types`](crate::types) returned `(Span, Payload)`
+/// while holding a recovery status too, so a parse placeholder and a real one decomposed
+/// identically and every rebuild reported the placeholder as valid syntax. Their `Components`
+/// now carries [`Status`](crate::types::Status) as well, and each carrier's `with_status`
+/// constructor is the inverse. A zero-sized marker such as `PhantomData<Lang>` is the one thing
+/// a decomposition may leave out, because the rebuild names it in its own type.
+///
 /// ## Component Ordering Convention
 ///
 /// To maintain consistency across implementations, follow this ordering:

--- a/tokora/src/utils/mod.rs
+++ b/tokora/src/utils/mod.rs
@@ -105,8 +105,8 @@ mod to_equivalent;
 /// tokora#320 is that defect: the carriers in [`types`](crate::types) returned `(Span, Payload)`
 /// while holding a recovery status too, so a parse placeholder and a real one decomposed
 /// identically and every rebuild reported the placeholder as valid syntax. Their `Components`
-/// now carries [`Status`](crate::types::Status) as well, and each carrier's `with_status`
-/// constructor is the inverse. A zero-sized marker such as `PhantomData<Lang>` is the one thing
+/// now carries [`Status`](crate::types::Status) as well, and
+/// [`FromComponents`](crate::types::recovery::FromComponents) is the inverse. A zero-sized marker such as `PhantomData<Lang>` is the one thing
 /// a decomposition may leave out, because the rebuild names it in its own type.
 ///
 /// ## Component Ordering Convention

--- a/tokora/src/utils/mod.rs
+++ b/tokora/src/utils/mod.rs
@@ -105,8 +105,8 @@ mod to_equivalent;
 /// tokora#320 is that defect: the carriers in [`types`](crate::types) returned `(Span, Payload)`
 /// while holding a recovery status too, so a parse placeholder and a real one decomposed
 /// identically and every rebuild reported the placeholder as valid syntax. Their `Components`
-/// now carries [`Status`](crate::types::Status) as well, and
-/// [`FromComponents`](crate::types::FromComponents) is the inverse. A zero-sized marker such as `PhantomData<Lang>` is the one thing
+/// now carries [`Status`](crate::types::recovery::Status) as well, and
+/// [`FromComponents`](crate::types::recovery::FromComponents) is the inverse. A zero-sized marker such as `PhantomData<Lang>` is the one thing
 /// a decomposition may leave out, because the rebuild names it in its own type.
 ///
 /// ## Component Ordering Convention

--- a/tokora/src/utils/mod.rs
+++ b/tokora/src/utils/mod.rs
@@ -106,7 +106,7 @@ mod to_equivalent;
 /// while holding a recovery status too, so a parse placeholder and a real one decomposed
 /// identically and every rebuild reported the placeholder as valid syntax. Their `Components`
 /// now carries [`Status`](crate::types::Status) as well, and
-/// [`FromComponents`](crate::types::recovery::FromComponents) is the inverse. A zero-sized marker such as `PhantomData<Lang>` is the one thing
+/// [`FromComponents`](crate::types::FromComponents) is the inverse. A zero-sized marker such as `PhantomData<Lang>` is the one thing
 /// a decomposition may leave out, because the rebuild names it in its own type.
 ///
 /// ## Component Ordering Convention

--- a/tokora/tests/keyword.rs
+++ b/tokora/tests/keyword.rs
@@ -10,7 +10,7 @@ use tokora::{
   logos::{self, Logos},
   token::{KeywordToken, PunctuatorToken},
   try_parse_input::ParseAttempt,
-  types::{Components, Keyword},
+  types::{Keyword, recovery::Components},
 };
 
 // ── Token with keywords ─────────────────────────────────────────────────────

--- a/tokora/tests/keyword.rs
+++ b/tokora/tests/keyword.rs
@@ -10,7 +10,7 @@ use tokora::{
   logos::{self, Logos},
   token::{KeywordToken, PunctuatorToken},
   try_parse_input::ParseAttempt,
-  types::{Keyword, recovery::Components},
+  types::{Components, Keyword},
 };
 
 // ── Token with keywords ─────────────────────────────────────────────────────

--- a/tokora/tests/keyword.rs
+++ b/tokora/tests/keyword.rs
@@ -313,7 +313,7 @@ fn keyword_try_parse_returns_token() {
     let result = Keyword::try_parse(inp)?;
     Ok(match result {
       ParseAttempt::Accept(kw) => {
-        let (_span, tok) = kw.into_components();
+        let (_span, tok, _status) = kw.into_components();
         Some(tok)
       }
       ParseAttempt::Decline => None,
@@ -338,7 +338,7 @@ fn keyword_try_parse_sliced_accept() {
     let result = Keyword::try_parse_sliced(inp)?;
     Ok(match result {
       ParseAttempt::Accept(kw) => Some({
-        let (_span, src) = kw.into_components();
+        let (_span, src, _status) = kw.into_components();
         src
       }),
       ParseAttempt::Decline => None,
@@ -425,7 +425,7 @@ fn keyword_try_parse_exact_returns_token() {
     let result = Keyword::try_parse_exact(&"return").try_parse_input(inp)?;
     Ok(match result {
       ParseAttempt::Accept(kw) => Some({
-        let (_span, src) = kw.into_components();
+        let (_span, src, _status) = kw.into_components();
         src
       }),
       ParseAttempt::Decline => None,
@@ -450,7 +450,7 @@ fn keyword_try_parse_exact_sliced_accept() {
     let result = Keyword::try_parse_exact_sliced(&"if").try_parse_input(inp)?;
     Ok(match result {
       ParseAttempt::Accept(kw) => Some({
-        let (_span, src) = kw.into_components();
+        let (_span, src, _status) = kw.into_components();
         src
       }),
       ParseAttempt::Decline => None,
@@ -524,7 +524,7 @@ fn keyword_try_parse_multiple() {
       let result = Keyword::try_parse(inp)?;
       match result {
         ParseAttempt::Accept(kw) => keywords.push({
-          let (_span, src) = kw.into_components();
+          let (_span, src, _status) = kw.into_components();
           src
         }),
         ParseAttempt::Decline => break,

--- a/tokora/tests/keyword.rs
+++ b/tokora/tests/keyword.rs
@@ -10,7 +10,7 @@ use tokora::{
   logos::{self, Logos},
   token::{KeywordToken, PunctuatorToken},
   try_parse_input::ParseAttempt,
-  types::Keyword,
+  types::{Keyword, recovery::Components},
 };
 
 // ── Token with keywords ─────────────────────────────────────────────────────
@@ -313,7 +313,7 @@ fn keyword_try_parse_returns_token() {
     let result = Keyword::try_parse(inp)?;
     Ok(match result {
       ParseAttempt::Accept(kw) => {
-        let (_span, tok, _status) = kw.into_components();
+        let Components { payload: tok, .. } = kw.into_components();
         Some(tok)
       }
       ParseAttempt::Decline => None,
@@ -338,7 +338,7 @@ fn keyword_try_parse_sliced_accept() {
     let result = Keyword::try_parse_sliced(inp)?;
     Ok(match result {
       ParseAttempt::Accept(kw) => Some({
-        let (_span, src, _status) = kw.into_components();
+        let Components { payload: src, .. } = kw.into_components();
         src
       }),
       ParseAttempt::Decline => None,
@@ -425,7 +425,7 @@ fn keyword_try_parse_exact_returns_token() {
     let result = Keyword::try_parse_exact(&"return").try_parse_input(inp)?;
     Ok(match result {
       ParseAttempt::Accept(kw) => Some({
-        let (_span, src, _status) = kw.into_components();
+        let Components { payload: src, .. } = kw.into_components();
         src
       }),
       ParseAttempt::Decline => None,
@@ -450,7 +450,7 @@ fn keyword_try_parse_exact_sliced_accept() {
     let result = Keyword::try_parse_exact_sliced(&"if").try_parse_input(inp)?;
     Ok(match result {
       ParseAttempt::Accept(kw) => Some({
-        let (_span, src, _status) = kw.into_components();
+        let Components { payload: src, .. } = kw.into_components();
         src
       }),
       ParseAttempt::Decline => None,
@@ -524,7 +524,7 @@ fn keyword_try_parse_multiple() {
       let result = Keyword::try_parse(inp)?;
       match result {
         ParseAttempt::Accept(kw) => keywords.push({
-          let (_span, src, _status) = kw.into_components();
+          let Components { payload: src, .. } = kw.into_components();
           src
         }),
         ParseAttempt::Decline => break,


### PR DESCRIPTION
Closes #301. Closes #280.