### PR TITLE
fix: a borrowed token keeps every capability, and a dropping emitter pays for none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -781,6 +781,37 @@ and will red until they do.
 
 ### Changed (breaking)
 
+- **`UnclosedEmitter::emit_unclosed` no longer imposes `Self::Error: FromUnclosed`, and `Fatal`
+  and `Verbose` implement the trait only where their error type carries that conversion** (#270).
+  The bound was on the trait method, so it was charged to every *caller* of the capability rather
+  than to the implementations that perform the conversion. `Silent<E>` could not call its own
+  no-op unless `E` implemented a conversion its body never performs; a generic function bounded by
+  `UnclosedEmitter` — or by `ComposableEmitter`, which advertises the member — could not call it
+  without restating the bound; and twenty delimited/list driver where-clauses restated it on the
+  error type of an emitter that might never convert anything. All of those are gone, along with
+  the restatements on `InputRef::emit_unclosed`, `EmitterView::emit_unclosed` and the `&mut U` and
+  `Sink` forwarders, which now inherit the inner capability and nothing else.
+
+  **This is `PrattEmitter`'s arrangement, not a new one.** The same defect was removed from
+  `Silent`'s pratt impl in 0.9, leaving a bound-free method with `FromPrattError` on `Fatal`'s and
+  `Verbose`'s impl blocks. The delimiter capability was the last member of the family that still
+  derived a requirement from trait surface rather than from behaviour.
+
+  **What breaks.** `Fatal<E>` and `Verbose<E, S>` used to satisfy `UnclosedEmitter` — and so
+  `ComposableEmitter` — for every `E`, while the method they advertised could not be called unless
+  `E: FromUnclosed`. They now satisfy it exactly where `E: FromUnclosed`, so the obligation is
+  reported at the bundle bound rather than at a call the consumer could never write. A downstream
+  emitter whose own body performs the conversion states `Self::Error: FromUnclosed` on its impl
+  block; one that merely repeats the bound on the method compiles unchanged wherever its error
+  type really implements the conversion. `ComposableParseContext` already required
+  `Error: FromTokenErrors`, which names `FromUnclosed`, so nothing driving through the context
+  bundle pays anything new.
+
+  **Splitting the trait was the alternative, and it relocates the defect.** A bound-free
+  `UnclosedEmitter` beside a converting sibling forces `ComposableEmitter` to include one of them:
+  the converting one fails `Silent` verbatim, and the bound-free one stops covering the delimited
+  driver the bundle exists for.
+
 - **`CachedToken::state` and `CachedToken::into_components` are crate-internal** (#311). The regime
   a cached token carries is now an opaque payload: carried, cloned and moved, never read.
 
@@ -1367,6 +1398,26 @@ and will red until they do.
   directly — to keep building.
 
 ### Fixed
+
+- **A borrowed token keeps its punctuation and pratt capabilities** (#268). `Token`,
+  `IdentifierToken`, `KeywordToken` and every `LitToken` predicate forward from `T` to `&'a T`;
+  `PunctuatorToken` and `PrattToken` did not, so a lexer or adapter whose token type is `&T`
+  passed the base bound and four capability bounds and then failed to compile on punctuation or
+  on token-level pratt, for the same semantic token. Both forwarding impls are added.
+
+  **The punctuation impl is generated from the same arm sequence that generates the trait.** Every
+  constructor there defaults to `None`, so a hand-maintained forwarding list compiles while
+  silently answering `None` for whatever arm it dropped — the same defect with the compile error
+  removed. `PunctuatorTokenExt` and `SpannedPunctuatorToken` are blanket impls over
+  `T: PunctuatorToken` and follow from it with no new impl of their own.
+
+  **The pratt impl stays generic in `Expr` and `Power`.** A token type may classify for more than
+  one expression family, and an impl pinned to the `i64` default would carry one of those
+  classifications across the borrow while the base `Token` impl carried the whole token.
+
+  `FromLogos` is the one member of the family with no reference impl and cannot have one: it
+  constructs (`fn from_logos(Self::Logos) -> Self`), and a `&'a T` cannot be built from an owned
+  logos token.
 
 - **A green tree deep enough to abort in its own destructor can no longer be materialized**
   (#316). The construction half of an uncatchable process abort reachable from safe third-party

--- a/tokora/src/cst/sink.rs
+++ b/tokora/src/cst/sink.rs
@@ -2415,7 +2415,6 @@ where
   ) -> Result<(), Self::Error>
   where
     L: Lexer<'inp>,
-    Self::Error: crate::emitter::FromUnclosed<'inp, L, Lang>,
   {
     self.forward_diag::<Lang, _>(None, |inner| inner.emit_unclosed(err))
   }

--- a/tokora/src/cst/sink/tests.rs
+++ b/tokora/src/cst/sink/tests.rs
@@ -11,7 +11,7 @@ use crate::{
     CstProfile, KindValidator,
     event::{Event, EventMark, TOMBSTONE},
   },
-  emitter::{CstEmitter, Emitter, Fatal, Verbose},
+  emitter::{CstEmitter, Emitter, Fatal, Silent, Verbose},
   error::token::{UnexpectedToken, UnexpectedTokenOf},
   input::{Balance, Cursor, Input},
   span::Spanned,
@@ -213,6 +213,18 @@ const _: () = {
 
   impl<O, Lang: ?Sized> From<NonAssociativeChain<O, Lang>> for TestErr {
     fn from(_: NonAssociativeChain<O, Lang>) -> Self {
+      Self::Unexpected
+    }
+  }
+
+  // `Verbose` and `Fatal` convert the unclosed diagnostic, so their `UnclosedEmitter` impls
+  // name `FromUnclosed` on the error type. `Silent` and `Ignored` do not, and this fixture
+  // wraps the converting ones.
+  impl<'a, L, Lang: ?Sized> crate::emitter::FromUnclosed<'a, L, Lang> for TestErr
+  where
+    L: Lexer<'a>,
+  {
+    fn from_unclosed<D>(_: crate::error::Unclosed<D, L::Span, Lang>) -> Self {
       Self::Unexpected
     }
   }
@@ -2297,10 +2309,11 @@ fn cst_composition_census_every_family_method_is_overridden() {
   //
   // Scope, stated: the *family* question — does `Sink` serve every trait the public bundles
   // name — is answered by `sink_satisfies_the_public_emitter_bundles`, bound on the bundles
-  // themselves. What this block adds is a second error type: `UnclosedEmitter`'s conversion
-  // sits on the *method* rather than the trait, so a deliberately-thin error type must still be
-  // able to satisfy it. The other capability traits require conversions `SesErr` does not
-  // carry, so asserting them here would test the fixture rather than the sink.
+  // themselves. What this block adds is a second error type, over both halves of the
+  // conversion split: `Verbose` converts the unclosed diagnostic and so demands `FromUnclosed`
+  // on its error type, while `Silent` drops it and demands nothing. `Sink` must forward the
+  // capability under both, and the dropping arm is the one that proves the forwarding impl
+  // inherits only the inner capability rather than restating a conversion.
   {
     const fn serves_unclosed<'a, L, E>()
     where
@@ -2309,6 +2322,7 @@ fn cst_composition_census_every_family_method_is_overridden() {
     {
     }
     serves_unclosed::<MiniLexer<'_>, SesSink<'_>>();
+    serves_unclosed::<MiniLexer<'_>, Sink<'_, MiniLexer<'_>, Silent<SesErr>>>();
   }
 
   for name in overridden {
@@ -6623,6 +6637,15 @@ impl<D, S, Lang: ?Sized> From<crate::error::Unclosed<D, S, Lang>> for SesErr {
 
 impl<H, O, Lang: ?Sized, Set: Clone> From<crate::error::UnexpectedEnd<H, O, Lang, Set>> for SesErr {
   fn from(_: crate::error::UnexpectedEnd<H, O, Lang, Set>) -> Self {
+    Self::Lex
+  }
+}
+
+impl<'a, L, Lang: ?Sized> crate::emitter::FromUnclosed<'a, L, Lang> for SesErr
+where
+  L: Lexer<'a>,
+{
+  fn from_unclosed<D>(_: crate::error::Unclosed<D, L::Span, Lang>) -> Self {
     Self::Lex
   }
 }

--- a/tokora/src/emitter/delimited.rs
+++ b/tokora/src/emitter/delimited.rs
@@ -148,21 +148,71 @@ pub trait UnclosedEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
   /// [`DelimiterKind`](crate::delimiter::DelimiterKind) and its name is the pair's display
   /// name.
   ///
-  /// # Why the `FromUnclosed` bound sits on the method, not on the trait
+  /// # Why there is no `FromUnclosed` bound here
   ///
-  /// This placement is **chosen**, not a leftover, and is recorded here so a later cleanup does
-  /// not "fix" it. Method-level means pay-when-you-call: an emitter that drops diagnostics and
-  /// never routes an unclosed pair costs nothing for this capability. Hoisting it to the trait
-  /// would force **every** `UnclosedEmitter` implementor's error type to carry `FromUnclosed`
-  /// unconditionally — a bound derived from trait surface rather than from behaviour, which is
-  /// the same defect this release removed from `Silent`'s pratt impl.
+  /// [`FromUnclosed`] is named by the **implementations that convert** —
+  /// [`Fatal`](crate::emitter::Fatal) returns the converted value and `Verbose` records it, so
+  /// both impl blocks carry `E: FromUnclosed` — and by nothing else.
+  /// [`Silent`](crate::emitter::Silent) and [`Ignored`](crate::utils::marker::Ignored) discard
+  /// the diagnostic and their impls are bound-free, exactly like their siblings across the
+  /// rest of the emitter family.
+  ///
+  /// This method used to carry `Self::Error: FromUnclosed` instead, on a "pay when you call"
+  /// argument. The argument does not survive contact with the dropping emitters, which is why
+  /// it is recorded here rather than removed silently: a method-level bound is paid by
+  /// **every** caller of the capability, including the ones whose implementation is `Ok(())`.
+  /// `Silent<E>` could not call its own no-op unless `E` implemented a conversion the body
+  /// never performs, `ComposableEmitter` advertised a member that its own bound could not
+  /// call, and every delimited driver restated the conversion on the error type of an emitter
+  /// that might never convert anything. A bound derived from trait surface rather than from
+  /// behaviour is the defect this crate removed from `Silent`'s pratt impl, and
+  /// `PrattEmitter` is the shape that repair left behind:
+  /// bound-free method, conversion on the converting impls.
+  ///
+  /// What it costs: an implementor whose body performs the conversion states it on its own
+  /// impl block, as the two in-crate converting emitters do. What it buys: the bound is
+  /// collected only where something is actually converted.
+  ///
+  /// A dropping emitter over an error type that implements *nothing* satisfies the capability,
+  /// and the bound alone is enough to call the method:
+  ///
+  /// ```rust
+  /// use tokora::{Lexer, emitter::{Silent, UnclosedEmitter}};
+  ///
+  /// struct Opaque;
+  ///
+  /// fn has_capability<'inp, L: Lexer<'inp>, E: UnclosedEmitter<'inp, L>>() {}
+  ///
+  /// fn probe<'inp, L: Lexer<'inp>>() {
+  ///   has_capability::<L, Silent<Opaque>>();
+  /// }
+  /// ```
+  ///
+  /// The converting emitter over the same error type does not, because its body really does
+  /// perform the conversion. `Emitter` is assumed here so the only obligation left standing is
+  /// the delimiter one:
+  ///
+  /// ```rust,compile_fail,E0277
+  /// use tokora::{Lexer, emitter::{Emitter, Fatal, UnclosedEmitter}};
+  ///
+  /// struct Opaque;
+  ///
+  /// fn has_capability<'inp, L: Lexer<'inp>, E: UnclosedEmitter<'inp, L>>() {}
+  ///
+  /// fn probe<'inp, L: Lexer<'inp>>()
+  /// where
+  ///   Fatal<Opaque>: Emitter<'inp, L>,
+  /// {
+  ///   // `Opaque` has no `FromUnclosed` impl, and `Fatal`'s body needs one.
+  ///   has_capability::<L, Fatal<Opaque>>();
+  /// }
+  /// ```
   fn emit_unclosed<Delimiter>(
     &mut self,
     err: Unclosed<Delimiter, L::Span, Lang>,
   ) -> Result<(), Self::Error>
   where
-    L: Lexer<'a>,
-    Self::Error: FromUnclosed<'a, L, Lang>;
+    L: Lexer<'a>;
 }
 
 impl<'a, L, U, Lang: ?Sized> UnclosedEmitter<'a, L, Lang> for &mut U
@@ -176,7 +226,6 @@ where
   ) -> Result<(), Self::Error>
   where
     L: Lexer<'a>,
-    Self::Error: FromUnclosed<'a, L, Lang>,
   {
     (**self).emit_unclosed(err)
   }

--- a/tokora/src/emitter/delimited.rs
+++ b/tokora/src/emitter/delimited.rs
@@ -189,8 +189,15 @@ pub trait UnclosedEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
   /// ```
   ///
   /// The converting emitter over the same error type does not, because its body really does
-  /// perform the conversion. `Emitter` is assumed here so the only obligation left standing is
-  /// the delimiter one:
+  /// perform the conversion. `Fatal`'s impl block names two things — `E: FromUnclosed` and
+  /// `Fatal<E, Lang>: Emitter<'a, L, Lang, Error = E>` — so the whole `Emitter` bound
+  /// **including its `Error` projection** is assumed here, and the missing conversion is then
+  /// the only obligation left standing. Assuming the bare `Emitter<'inp, L>` instead leaves the
+  /// `Error == Opaque` equality outstanding as a *second* unsatisfied obligation, and a cell
+  /// with two of them pins whichever the solver happens to report: it was `E0277` on one rustc
+  /// and `E0271` on the next, and under the latter the cell stayed red even once `Opaque`
+  /// implemented the conversion — red for a reason the repair does not remove, which is a cell
+  /// that witnesses nothing.
   ///
   /// ```rust,compile_fail,E0277
   /// use tokora::{Lexer, emitter::{Emitter, Fatal, UnclosedEmitter}};
@@ -201,7 +208,7 @@ pub trait UnclosedEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
   ///
   /// fn probe<'inp, L: Lexer<'inp>>()
   /// where
-  ///   Fatal<Opaque>: Emitter<'inp, L>,
+  ///   Fatal<Opaque>: Emitter<'inp, L, Error = Opaque>,
   /// {
   ///   // `Opaque` has no `FromUnclosed` impl, and `Fatal`'s body needs one.
   ///   has_capability::<L, Fatal<Opaque>>();

--- a/tokora/src/emitter/impl_/fatal/unclosed.rs
+++ b/tokora/src/emitter/impl_/fatal/unclosed.rs
@@ -2,9 +2,13 @@ use super::*;
 
 use crate::{emitter::FromUnclosed, error::Unclosed};
 
+// The conversion is named here, on the impl that performs it, and not on the trait method —
+// the same arrangement `fatal/pratt.rs` carries for `FromPrattError`. `Fatal` returns the
+// converted diagnostic, so this bound is a demand something collects on.
 impl<'a, L, E, Lang: ?Sized> UnclosedEmitter<'a, L, Lang> for Fatal<E, Lang>
 where
   L: Lexer<'a>,
+  E: FromUnclosed<'a, L, Lang>,
   Fatal<E, Lang>: Emitter<'a, L, Lang, Error = E>,
 {
   #[inline(always)]
@@ -14,7 +18,6 @@ where
   ) -> Result<(), Self::Error>
   where
     L: Lexer<'a>,
-    Self::Error: FromUnclosed<'a, L, Lang>,
   {
     Err(Self::Error::from_unclosed(err))
   }

--- a/tokora/src/emitter/impl_/ignored/unclosed.rs
+++ b/tokora/src/emitter/impl_/ignored/unclosed.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::{emitter::FromUnclosed, error::Unclosed};
+use crate::error::Unclosed;
 
 impl<'a, L, Lang: ?Sized> UnclosedEmitter<'a, L, Lang> for Ignored
 where
@@ -13,7 +13,6 @@ where
   ) -> Result<(), Self::Error>
   where
     L: Lexer<'a>,
-    Self::Error: FromUnclosed<'a, L, Lang>,
   {
     Ok(())
   }

--- a/tokora/src/emitter/impl_/silent/unclosed.rs
+++ b/tokora/src/emitter/impl_/silent/unclosed.rs
@@ -1,7 +1,10 @@
 use super::*;
 
-use crate::{emitter::FromUnclosed, error::Unclosed};
+use crate::error::Unclosed;
 
+// Bound-free, like every other `Silent` impl in this family: the body discards the payload, so
+// there is no conversion for a bound to describe. See `UnclosedEmitter::emit_unclosed` for why
+// the trait method does not impose one either.
 impl<'a, L, E, Lang: ?Sized> UnclosedEmitter<'a, L, Lang> for Silent<E, Lang>
 where
   L: Lexer<'a>,
@@ -13,7 +16,6 @@ where
   ) -> Result<(), Self::Error>
   where
     L: Lexer<'a>,
-    Self::Error: FromUnclosed<'a, L, Lang>,
   {
     Ok(())
   }

--- a/tokora/src/emitter/impl_/verbose/unclosed.rs
+++ b/tokora/src/emitter/impl_/verbose/unclosed.rs
@@ -2,10 +2,32 @@ use super::*;
 
 use crate::{emitter::FromUnclosed, error::Unclosed};
 
+/// The conversion is named here, on the impl that performs it, and not on the trait method:
+/// `Verbose` records the converted diagnostic, so this bound is a demand something collects on.
+/// A recording emitter over an error type that cannot absorb the diagnostic is therefore not an
+/// [`UnclosedEmitter`] at all, where a dropping one is (see
+/// [`UnclosedEmitter::emit_unclosed`] for that half and for why the bound is not on the method):
+///
+/// ```rust,compile_fail,E0277
+/// use tokora::{Lexer, SimpleSpan, emitter::{Emitter, UnclosedEmitter, Verbose}};
+///
+/// struct Opaque;
+///
+/// fn has_capability<'inp, L: Lexer<'inp>, E: UnclosedEmitter<'inp, L>>() {}
+///
+/// fn probe<'inp, L: Lexer<'inp, Span = SimpleSpan, Offset = usize>>()
+/// where
+///   Verbose<Opaque, SimpleSpan>: Emitter<'inp, L>,
+/// {
+///   // `Opaque` has no `FromUnclosed` impl, and `Verbose`'s body needs one.
+///   has_capability::<L, Verbose<Opaque, SimpleSpan>>();
+/// }
+/// ```
 impl<'a, L, S, E, Lang: ?Sized> UnclosedEmitter<'a, L, Lang> for Verbose<E, S, Lang>
 where
   L: Lexer<'a, Span = S, Offset = S::Offset>,
   S: Span + Ord + Clone,
+  E: FromUnclosed<'a, L, Lang>,
   Verbose<E, S, Lang>: Emitter<'a, L, Lang, Error = E>,
 {
   #[inline(always)]
@@ -15,7 +37,6 @@ where
   ) -> Result<(), Self::Error>
   where
     L: Lexer<'a>,
-    Self::Error: FromUnclosed<'a, L, Lang>,
   {
     // Record on the shared emission log (same path as `emit_error` /
     // `emit_unexpected_token`) so the diagnostic rewinds precisely with an abandoned

--- a/tokora/src/emitter/impl_/verbose/unclosed.rs
+++ b/tokora/src/emitter/impl_/verbose/unclosed.rs
@@ -6,7 +6,12 @@ use crate::{emitter::FromUnclosed, error::Unclosed};
 /// `Verbose` records the converted diagnostic, so this bound is a demand something collects on.
 /// A recording emitter over an error type that cannot absorb the diagnostic is therefore not an
 /// [`UnclosedEmitter`] at all, where a dropping one is (see
-/// [`UnclosedEmitter::emit_unclosed`] for that half and for why the bound is not on the method):
+/// [`UnclosedEmitter::emit_unclosed`] for that half and for why the bound is not on the method).
+///
+/// The assumed `Emitter` bound carries `Error = Opaque` deliberately: this impl block names
+/// `Verbose<E, S, Lang>: Emitter<'a, L, Lang, Error = E>` beside the conversion, so without the
+/// projection the cell would carry two unsatisfied obligations and pin whichever the solver
+/// reported first. See [`UnclosedEmitter::emit_unclosed`] for what that cost.
 ///
 /// ```rust,compile_fail,E0277
 /// use tokora::{Lexer, SimpleSpan, emitter::{Emitter, UnclosedEmitter, Verbose}};
@@ -17,7 +22,7 @@ use crate::{emitter::FromUnclosed, error::Unclosed};
 ///
 /// fn probe<'inp, L: Lexer<'inp, Span = SimpleSpan, Offset = usize>>()
 /// where
-///   Verbose<Opaque, SimpleSpan>: Emitter<'inp, L>,
+///   Verbose<Opaque, SimpleSpan>: Emitter<'inp, L, Error = Opaque>,
 /// {
 ///   // `Opaque` has no `FromUnclosed` impl, and `Verbose`'s body needs one.
 ///   has_capability::<L, Verbose<Opaque, SimpleSpan>>();

--- a/tokora/src/emitter/view.rs
+++ b/tokora/src/emitter/view.rs
@@ -475,7 +475,6 @@ where
   ) -> Result<(), E::Error>
   where
     E: UnclosedEmitter<'inp, L, Lang>,
-    E::Error: crate::emitter::FromUnclosed<'inp, L, Lang>,
   {
     self.emitter.emit_unclosed(err)
   }

--- a/tokora/src/input/input_ref/emit.rs
+++ b/tokora/src/input/input_ref/emit.rs
@@ -437,7 +437,6 @@ where
   ) -> Result<(), <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
   where
     Ctx::Emitter: UnclosedEmitter<'inp, L, Lang>,
-    <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: crate::emitter::FromUnclosed<'inp, L, Lang>,
   {
     self.emitter_view().emit_unclosed(err)
   }

--- a/tokora/src/parser/many/delim/repeated.rs
+++ b/tokora/src/parser/many/delim/repeated.rs
@@ -2,7 +2,7 @@ use crate::{
   TryParseInput,
   container::Container as ContainerT,
   delimiter::Delimiter,
-  emitter::{FromUnclosed, FullContainerEmitter, UnclosedEmitter},
+  emitter::{FullContainerEmitter, UnclosedEmitter},
   error::Unclosed,
   try_parse_input::{Accept, Decline},
 };
@@ -37,8 +37,7 @@ impl<'inp, L, P, O, Ctx, Delim, Lang: ?Sized, Cmpl>
     Ctx: ParseContext<'inp, L, Lang>,
     Cmpl: crate::input::SurfaceIncomplete<'inp, L, Ctx, Lang>,
     Ctx::Emitter: FullContainerEmitter<'inp, L, Lang> + UnclosedEmitter<'inp, L, Lang>,
-    <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-      From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+    <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
     Container: ContainerT<O> + DelimiterHandler<'inp, L>,
   {
     // Sync the input to the next token boundary, any lexer errors will be emitted during this process.

--- a/tokora/src/parser/many/delim/repeated/at_least.rs
+++ b/tokora/src/parser/many/delim/repeated/at_least.rs
@@ -28,8 +28,7 @@ where
     + TooFewEmitter<'inp, L, Lang>
     + UnclosedEmitter<'inp, L, Lang>,
   Ctx: ParseContext<'inp, L, Lang>,
-  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-    From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
   Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
 {
   fn parse_input(

--- a/tokora/src/parser/many/delim/repeated/at_most.rs
+++ b/tokora/src/parser/many/delim/repeated/at_most.rs
@@ -28,8 +28,7 @@ where
     + TooManyEmitter<'inp, L, Lang>
     + UnclosedEmitter<'inp, L, Lang>,
   Ctx: ParseContext<'inp, L, Lang>,
-  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-    From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
   Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
 {
   fn parse_input(

--- a/tokora/src/parser/many/delim/repeated/bounded.rs
+++ b/tokora/src/parser/many/delim/repeated/bounded.rs
@@ -33,8 +33,7 @@ where
     + TooFewEmitter<'inp, L, Lang>
     + UnclosedEmitter<'inp, L, Lang>,
   Ctx: ParseContext<'inp, L, Lang>,
-  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-    From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
   Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
 {
   fn parse_input(

--- a/tokora/src/parser/many/delim/repeated/unbounded.rs
+++ b/tokora/src/parser/many/delim/repeated/unbounded.rs
@@ -20,8 +20,7 @@ where
   P: TryParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
   Ctx: ParseContext<'inp, L, Lang>,
   Ctx::Emitter: FullContainerEmitter<'inp, L, Lang> + UnclosedEmitter<'inp, L, Lang>,
-  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-    From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
   Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
 {
   fn parse_input(

--- a/tokora/src/parser/many/delim/repeated_while.rs
+++ b/tokora/src/parser/many/delim/repeated_while.rs
@@ -1,7 +1,7 @@
 use crate::{
   container::Container as ContainerT,
   delimiter::Delimiter,
-  emitter::{FromUnclosed, FullContainerEmitter, UnclosedEmitter},
+  emitter::{FullContainerEmitter, UnclosedEmitter},
   error::Unclosed,
 };
 
@@ -35,8 +35,7 @@ impl<'inp, L, P, O, Condition, Ctx, Delim, W, Lang: ?Sized>
     W: Window,
     Ctx: ParseContext<'inp, L, Lang>,
     Ctx::Emitter: FullContainerEmitter<'inp, L, Lang> + UnclosedEmitter<'inp, L, Lang>,
-    <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-      From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+    <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
     Container: ContainerT<O> + DelimiterHandler<'inp, L>,
   {
     // Sync the input to the next token boundary, any lexer errors will be emitted during this process.

--- a/tokora/src/parser/many/delim/repeated_while/at_least.rs
+++ b/tokora/src/parser/many/delim/repeated_while/at_least.rs
@@ -25,8 +25,7 @@ where
     + TooFewEmitter<'inp, L, Lang>
     + UnclosedEmitter<'inp, L, Lang>,
   Ctx: ParseContext<'inp, L, Lang>,
-  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-    From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
   Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
 {
   fn parse_input(

--- a/tokora/src/parser/many/delim/repeated_while/at_most.rs
+++ b/tokora/src/parser/many/delim/repeated_while/at_most.rs
@@ -20,8 +20,7 @@ where
     + TooManyEmitter<'inp, L, Lang>
     + UnclosedEmitter<'inp, L, Lang>,
   Ctx: ParseContext<'inp, L, Lang>,
-  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-    From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
   Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
 {
   fn parse_input(

--- a/tokora/src/parser/many/delim/repeated_while/bounded.rs
+++ b/tokora/src/parser/many/delim/repeated_while/bounded.rs
@@ -25,8 +25,7 @@ where
     + TooFewEmitter<'inp, L, Lang>
     + UnclosedEmitter<'inp, L, Lang>,
   Ctx: ParseContext<'inp, L, Lang>,
-  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-    From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
   Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
 {
   fn parse_input(

--- a/tokora/src/parser/many/delim/repeated_while/unbounded.rs
+++ b/tokora/src/parser/many/delim/repeated_while/unbounded.rs
@@ -18,8 +18,7 @@ where
   W: Window,
   Ctx: ParseContext<'inp, L, Lang>,
   Ctx::Emitter: FullContainerEmitter<'inp, L, Lang> + UnclosedEmitter<'inp, L, Lang>,
-  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-    From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
   Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
 {
   fn parse_input(

--- a/tokora/src/parser/many/macros.rs
+++ b/tokora/src/parser/many/macros.rs
@@ -616,7 +616,7 @@ macro_rules! impl_separated_delim {
         + UnclosedEmitter<'inp, L, Lang>
         $($emitters)*,
       <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-        From<UnexpectedEot<L::Offset, Lang>> + crate::emitter::FromUnclosed<'inp, L, Lang>,
+        From<UnexpectedEot<L::Offset, Lang>>,
       Ctx: ParseContext<'inp, L, Lang>,
       Container: Default + ContainerT<O> + SeparatorHandler<'inp, L> + DelimiterHandler<'inp, L>,
       Delim: Delimiter<'inp, L, Lang>,
@@ -645,7 +645,7 @@ macro_rules! impl_separated_delim {
         + UnclosedEmitter<'inp, L, Lang>
         $($emitters)*,
       <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-        From<UnexpectedEot<L::Offset, Lang>> + crate::emitter::FromUnclosed<'inp, L, Lang>,
+        From<UnexpectedEot<L::Offset, Lang>>,
       Ctx: ParseContext<'inp, L, Lang>,
       Container: Default + ContainerT<O> + SeparatorHandler<'inp, L> + DelimiterHandler<'inp, L>,
       Delim: Delimiter<'inp, L, Lang>,
@@ -675,7 +675,7 @@ macro_rules! impl_separated_delim {
         + UnclosedEmitter<'inp, L, Lang>
         $($emitters)*,
       <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-        From<UnexpectedEot<L::Offset, Lang>> + crate::emitter::FromUnclosed<'inp, L, Lang>,
+        From<UnexpectedEot<L::Offset, Lang>>,
       Ctx: ParseContext<'inp, L, Lang>,
       Container: ContainerT<O> + SeparatorHandler<'inp, L> + DelimiterHandler<'inp, L>,
       Delim: Delimiter<'inp, L, Lang>,
@@ -709,7 +709,7 @@ macro_rules! impl_separated_delim {
         + UnclosedEmitter<'inp, L, Lang>
         $($emitters)*,
       <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-        From<UnexpectedEot<L::Offset, Lang>> + crate::emitter::FromUnclosed<'inp, L, Lang>,
+        From<UnexpectedEot<L::Offset, Lang>>,
       Ctx: ParseContext<'inp, L, Lang>,
       Container: ContainerT<O> + SeparatorHandler<'inp, L> + DelimiterHandler<'inp, L>,
       Delim: Delimiter<'inp, L, Lang>,
@@ -1342,7 +1342,7 @@ macro_rules! impl_separated_while_delim {
         + UnclosedEmitter<'inp, L, Lang>
         $($emitters)*,
       <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-        From<UnexpectedEot<L::Offset, Lang>> + crate::emitter::FromUnclosed<'inp, L, Lang>,
+        From<UnexpectedEot<L::Offset, Lang>>,
       Ctx: ParseContext<'inp, L, Lang>,
       Container: Default + ContainerT<O> + SeparatorHandler<'inp, L> + DelimiterHandler<'inp, L>,
       Delim: Delimiter<'inp, L, Lang>,
@@ -1373,7 +1373,7 @@ macro_rules! impl_separated_while_delim {
         + UnclosedEmitter<'inp, L, Lang>
         $($emitters)*,
       <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-        From<UnexpectedEot<L::Offset, Lang>> + crate::emitter::FromUnclosed<'inp, L, Lang>,
+        From<UnexpectedEot<L::Offset, Lang>>,
       Ctx: ParseContext<'inp, L, Lang>,
       Container: Default + ContainerT<O> + SeparatorHandler<'inp, L> + DelimiterHandler<'inp, L>,
       Delim: Delimiter<'inp, L, Lang>,
@@ -1405,7 +1405,7 @@ macro_rules! impl_separated_while_delim {
         + UnclosedEmitter<'inp, L, Lang>
         $($emitters)*,
       <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-        From<UnexpectedEot<L::Offset, Lang>> + crate::emitter::FromUnclosed<'inp, L, Lang>,
+        From<UnexpectedEot<L::Offset, Lang>>,
       Ctx: ParseContext<'inp, L, Lang>,
       Container: ContainerT<O> + SeparatorHandler<'inp, L> + DelimiterHandler<'inp, L>,
       Delim: Delimiter<'inp, L, Lang>,
@@ -1441,7 +1441,7 @@ macro_rules! impl_separated_while_delim {
         + UnclosedEmitter<'inp, L, Lang>
         $($emitters)*,
       <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-        From<UnexpectedEot<L::Offset, Lang>> + crate::emitter::FromUnclosed<'inp, L, Lang>,
+        From<UnexpectedEot<L::Offset, Lang>>,
       Ctx: ParseContext<'inp, L, Lang>,
       Container: ContainerT<O> + SeparatorHandler<'inp, L> + DelimiterHandler<'inp, L>,
       Delim: Delimiter<'inp, L, Lang>,

--- a/tokora/src/parser/many/sep/delim/mod.rs
+++ b/tokora/src/parser/many/sep/delim/mod.rs
@@ -2,7 +2,7 @@ use crate::{
   TryParseInput,
   container::Container as ContainerT,
   delimiter::Delimiter,
-  emitter::{FromUnclosed, FullContainerEmitter, SeparatedEmitter, UnclosedEmitter},
+  emitter::{FullContainerEmitter, SeparatedEmitter, UnclosedEmitter},
   error::Unclosed,
   punct::Punctuator,
   try_parse_input::{Accept, Decline},
@@ -49,8 +49,7 @@ impl<'inp, L, P, Sep, O, Ctx, Delim, Lang: ?Sized, Cmpl>
       + UnclosedEmitter<'inp, L, Lang>,
     Ctx: ParseContext<'inp, L, Lang>,
     Cmpl: crate::input::SurfaceIncomplete<'inp, L, Ctx, Lang>,
-    <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-      From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+    <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
     Container: DelimiterHandler<'inp, L> + SeparatorHandler<'inp, L> + ContainerT<O>,
     EH: EndStateHandler<'inp, 'closure, Sep, O, L, Ctx, Lang, Cmpl>,
     CH: ContinueStateHandler<'inp, 'closure, Sep, O, L, Ctx, Lang, Cmpl>,

--- a/tokora/src/parser/many/sep_while/delim/mod.rs
+++ b/tokora/src/parser/many/sep_while/delim/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
   container::Container as ContainerT,
-  emitter::{FromUnclosed, FullContainerEmitter, SeparatedEmitter, UnclosedEmitter},
+  emitter::{FullContainerEmitter, SeparatedEmitter, UnclosedEmitter},
   error::Unclosed,
 };
 
@@ -45,8 +45,7 @@ impl<'c, 'inp, L, P, Sep, O, Condition, Ctx, Delim, W, Lang: ?Sized>
       + FullContainerEmitter<'inp, L, Lang>
       + UnclosedEmitter<'inp, L, Lang>,
     Ctx: ParseContext<'inp, L, Lang>,
-    <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error:
-      From<UnexpectedEot<L::Offset, Lang>> + FromUnclosed<'inp, L, Lang>,
+    <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
     Container: DelimiterHandler<'inp, L> + SeparatorHandler<'inp, L> + ContainerT<O>,
     EH: EndStateHandler<'inp, 'closure, Sep, O, L, Ctx, Lang>,
     CH: ContinueStateHandler<'inp, 'closure, Sep, O, L, Ctx, Lang>,

--- a/tokora/src/token/pratt.rs
+++ b/tokora/src/token/pratt.rs
@@ -16,3 +16,25 @@ pub trait PrattToken<'a, Expr: ?Sized, Power = i64>: Token<'a> {
   /// `None` is the spelling to prefer, since it is the one the signature already offers.
   fn try_pratt_rhs(&self) -> Option<PrattRHS<(), (), (), (), Power>>;
 }
+
+/// Pratt classification forwards across the borrow, like every other token capability.
+///
+/// Generic in `Expr` and `Power`, not pinned to the `i64` default: a token type is free to
+/// implement `PrattToken` once per expression family it classifies for, and a forwarding impl
+/// that fixed either parameter would carry only one of those implementations across the
+/// borrow while the base [`Token`] impl carried the whole token.
+impl<'a, T, Expr, Power> PrattToken<'a, Expr, Power> for &'a T
+where
+  T: PrattToken<'a, Expr, Power>,
+  Expr: ?Sized,
+{
+  #[inline(always)]
+  fn try_pratt_lhs(&self) -> Option<PrattLHS<(), (), Power>> {
+    <T as PrattToken<'a, Expr, Power>>::try_pratt_lhs(self)
+  }
+
+  #[inline(always)]
+  fn try_pratt_rhs(&self) -> Option<PrattRHS<(), (), (), (), Power>> {
+    <T as PrattToken<'a, Expr, Power>>::try_pratt_rhs(self)
+  }
+}

--- a/tokora/src/token/punct/mod.rs
+++ b/tokora/src/token/punct/mod.rs
@@ -128,6 +128,24 @@ macro_rules! define_punctuator_token_traits {
         )*
       }
 
+      /// Punctuation forwards across the borrow, like every other token capability.
+      ///
+      /// Every constructor defaults to `None`, so a *partial* forwarding impl would compile and
+      /// silently answer `None` for the arms it forgot — the same failure mode as no impl at
+      /// all, minus the compile error. The list is therefore generated from the same
+      /// `$punct` sequence that generates the trait, and cannot drift from it.
+      impl<'a, T> PunctuatorToken<'a> for &'a T
+      where
+        T: PunctuatorToken<'a>,
+      {
+        $(
+          #[inline(always)]
+          fn $punct() -> Option<Self::Kind> {
+            <T as PunctuatorToken<'a>>::$punct()
+          }
+        )*
+      }
+
       $(
         impl<'inp, T, S, C, Lang> $crate::__private::Check<T, ::core::primitive::bool> for $crate::punct::$name<S, C, Lang>
         where

--- a/tokora/tests/dropping_emitter_unclosed.rs
+++ b/tokora/tests/dropping_emitter_unclosed.rs
@@ -1,0 +1,238 @@
+#![cfg(all(feature = "std", feature = "combinators", feature = "logos_0_16"))]
+
+//! A dropping emitter pays nothing for the capability it drops.
+//!
+//! `UnclosedEmitter::emit_unclosed` used to carry `Self::Error: FromUnclosed` on the method, so
+//! the conversion was charged to every *caller* of the capability — including the ones whose
+//! implementation is `Ok(())`. The bound now sits on the two implementations that convert
+//! (`Fatal`, `Verbose`), which is where something collects on it.
+//!
+//! The witness error type here, [`Opaque`], deliberately implements the *one* conversion the
+//! delimited driver genuinely performs — `From<UnexpectedEot<..>>`, which the driver builds
+//! itself — and no delimiter conversion at all. There is no `FromUnclosed` impl for `Opaque`
+//! anywhere in this file, which is the whole point: everything below compiles without one.
+//!
+//! `Ignored` is not used as the no-op oracle. Its error type is `()`, and `()` has a blanket
+//! `FromUnclosed` impl, so an `Ignored`-only test would pass under the old arrangement too.
+
+mod common;
+
+use common::{TestLexer, Token};
+
+use tokora::{
+  Accumulator, ComposableEmitter, InputRef, Lexer, Parse, ParseContext, ParseInput, Parser,
+  ParserContext, SimpleSpan, TryParseInput,
+  delimiter::DelimiterKind,
+  emitter::{Emitter, Fatal, FromUnclosed, FullContainerEmitter, UnclosedEmitter, Verbose},
+  error::{
+    Unclosed, UnexpectedEot,
+    syntax::{FullContainer, MissingSyntaxOf, TooFew},
+    token::{UnexpectedToken, UnexpectedTokenOf},
+  },
+  try_parse_input::ParseAttempt,
+  utils::CowStr,
+};
+
+// ── The witness error: no delimiter conversion, anywhere ─────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Opaque;
+
+impl From<()> for Opaque {
+  fn from(_: ()) -> Self {
+    Opaque
+  }
+}
+
+impl<'a, T, Kind: Clone, S, Lang: ?Sized> From<UnexpectedToken<'a, T, Kind, S, Lang>> for Opaque {
+  fn from(_: UnexpectedToken<'a, T, Kind, S, Lang>) -> Self {
+    Opaque
+  }
+}
+
+// The driver *constructs* this one, so it is a demand something collects on and it stays.
+impl<O, Lang: ?Sized, Set: Clone + 'static> From<UnexpectedEot<O, Lang, Set>> for Opaque {
+  fn from(_: UnexpectedEot<O, Lang, Set>) -> Self {
+    Opaque
+  }
+}
+
+type SilentOpaque = tokora::emitter::Silent<Opaque>;
+
+fn silent_ctx() -> ParserContext<'static, TestLexer<'static>, SilentOpaque> {
+  ParserContext::new(SilentOpaque::default())
+}
+
+fn unclosed_paren() -> Unclosed<char, SimpleSpan> {
+  Unclosed::new(
+    SimpleSpan::new(0usize, 1usize),
+    DelimiterKind::Custom("paren"),
+    CowStr::from_static("("),
+  )
+}
+
+// ── 1. The capability is callable from the capability bound ──────────────────
+
+#[test]
+fn silent_over_an_opaque_error_calls_its_own_no_op() {
+  let mut emitter = SilentOpaque::default();
+  let out = <SilentOpaque as UnclosedEmitter<'_, TestLexer<'_>>>::emit_unclosed(
+    &mut emitter,
+    unclosed_paren(),
+  );
+  assert_eq!(out, Ok(()));
+}
+
+/// Generic over the capability rather than over the concrete emitter: the bound alone has to
+/// be enough to call the method, which is the property `ComposableEmitter` advertises.
+fn drive_unclosed<'inp, E>(emitter: &mut E) -> Result<(), E::Error>
+where
+  E: UnclosedEmitter<'inp, TestLexer<'inp>>,
+{
+  emitter.emit_unclosed::<char>(unclosed_paren())
+}
+
+#[test]
+fn the_capability_bound_alone_can_call_the_capability() {
+  let mut emitter = SilentOpaque::default();
+  assert_eq!(drive_unclosed::<SilentOpaque>(&mut emitter), Ok(()));
+}
+
+// ── 2. The bundle unlocks every member, with no extra conversion ─────────────
+
+/// One bound, and every member method of the bundle is called through it. Before the repair
+/// this function could not be written: `emit_unclosed` needed `E::Error: FromUnclosed` on top
+/// of the bundle bound, which is precisely what "the bundle unlocks every member capability"
+/// denies.
+fn drive_every_bundle_member<'inp, E>(
+  emitter: &mut E,
+  token_err: UnexpectedTokenOf<'inp, TestLexer<'inp>>,
+  missing: MissingSyntaxOf<'inp, TestLexer<'inp>, ()>,
+) -> Result<(), E::Error>
+where
+  E: ComposableEmitter<'inp, TestLexer<'inp>>,
+{
+  let span = SimpleSpan::new(0usize, 1usize);
+  emitter.emit_unexpected_token(token_err.clone())?;
+  emitter.emit_full_container(FullContainer::new(span, 4, 4))?;
+  emitter.emit_too_few(TooFew::new(span, 2, 1))?;
+  emitter.emit_missing_element(missing)?;
+  emitter.emit_unexpected_leading_separator(CowStr::from_static(","), token_err.clone())?;
+  emitter.emit_unexpected_trailing_separator(CowStr::from_static(","), token_err)?;
+  emitter.emit_unclosed::<char>(unclosed_paren())
+}
+
+// ── 3. A delimited driver instantiated with the dropping emitter ─────────────
+
+fn try_num<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, TestLexer<'inp>, Ctx>,
+) -> Result<ParseAttempt<i64>, Opaque>
+where
+  Ctx: ParseContext<'inp, TestLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, TestLexer<'inp>, Error = Opaque>,
+{
+  inp
+    .try_expect(|t| matches!(t.data(), Token::Num(_)))
+    .map(|opt| match opt {
+      None => ParseAttempt::Decline,
+      Some(tok) => ParseAttempt::Accept(match tok.into_data() {
+        Token::Num(n) => n,
+        _ => unreachable!(),
+      }),
+    })
+}
+
+fn bracketed_numbers<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, TestLexer<'inp>, Ctx>,
+) -> Result<Vec<i64>, Opaque>
+where
+  Ctx: ParseContext<'inp, TestLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, TestLexer<'inp>, Error = Opaque>
+    + FullContainerEmitter<'inp, TestLexer<'inp>>
+    + UnclosedEmitter<'inp, TestLexer<'inp>>,
+{
+  try_num
+    .repeated()
+    .delimited_by_brackets()
+    .collect()
+    .parse_input(inp)
+}
+
+#[test]
+fn a_delimited_driver_runs_under_the_dropping_emitter() {
+  let parsed: Result<Vec<i64>, Opaque> = Parser::with_context(silent_ctx())
+    .apply(bracketed_numbers)
+    .parse_str("[1 2 3]");
+  assert_eq!(parsed, Ok(vec![1, 2, 3]));
+}
+
+/// The unterminated list is the arm that actually reaches `emit_unclosed`. The dropping
+/// emitter discards the diagnostic, so the elements collected so far come back as `Ok`.
+#[test]
+fn the_dropping_emitter_absorbs_an_unclosed_list() {
+  let parsed: Result<Vec<i64>, Opaque> = Parser::with_context(silent_ctx())
+    .apply(bracketed_numbers)
+    .parse_str("[1 2 3");
+  assert_eq!(parsed, Ok(vec![1, 2, 3]));
+}
+
+#[test]
+fn the_bundle_driver_runs_under_the_dropping_emitter() {
+  let mut emitter = SilentOpaque::default();
+  let span = SimpleSpan::new(0usize, 1usize);
+  let token_err = UnexpectedToken::expected_one(span, common::TokenKind::Num);
+  let missing = MissingSyntaxOf::<TestLexer<'_>, ()>::new(0usize);
+  assert_eq!(
+    drive_every_bundle_member::<SilentOpaque>(&mut emitter, token_err, missing),
+    Ok(())
+  );
+}
+
+// ── 4. The converting emitters still convert ─────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Converting;
+
+impl From<()> for Converting {
+  fn from(_: ()) -> Self {
+    Converting
+  }
+}
+
+impl<'a, T, Kind: Clone, S, Lang: ?Sized> From<UnexpectedToken<'a, T, Kind, S, Lang>>
+  for Converting
+{
+  fn from(_: UnexpectedToken<'a, T, Kind, S, Lang>) -> Self {
+    Converting
+  }
+}
+
+impl<'inp, L, Lang: ?Sized> FromUnclosed<'inp, L, Lang> for Converting
+where
+  L: Lexer<'inp>,
+{
+  fn from_unclosed<D>(_: Unclosed<D, L::Span, Lang>) -> Self {
+    Converting
+  }
+}
+
+#[test]
+fn fatal_over_a_converting_error_still_fails_fast() {
+  let mut emitter = Fatal::<Converting>::default();
+  let out = <Fatal<Converting> as UnclosedEmitter<'_, TestLexer<'_>>>::emit_unclosed(
+    &mut emitter,
+    unclosed_paren(),
+  );
+  assert_eq!(out, Err(Converting));
+}
+
+#[test]
+fn verbose_over_a_converting_error_still_records() {
+  let mut emitter = Verbose::<Converting, SimpleSpan>::new();
+  let out = <Verbose<Converting, SimpleSpan> as UnclosedEmitter<'_, TestLexer<'_>>>::emit_unclosed(
+    &mut emitter,
+    unclosed_paren(),
+  );
+  assert_eq!(out, Ok(()));
+  assert_eq!(emitter.errors().len(), 1);
+}

--- a/tokora/tests/token_ref_capabilities.rs
+++ b/tokora/tests/token_ref_capabilities.rs
@@ -1,0 +1,348 @@
+//! The token capability family, censused over the two representations `Token` admits.
+//!
+//! `&'a T` is a first-class token representation: `impl<'a, T: Token<'a>> Token<'a> for &'a T`
+//! is in the crate, so a downstream lexer or adapter may legally hand out references. This
+//! suite is the compile-time census that every *capability* crosses that borrow too, and it is
+//! built to discriminate rather than merely to go red:
+//!
+//! * one assertion helper per capability, so a missing forwarding impl names the capability it
+//!   is missing for rather than a bundle;
+//! * a `Token` control beside every specialized assertion, so a base-trait failure cannot be
+//!   misread as a capability failure;
+//! * runtime parity over the punctuation constructors, because every one of them defaults to
+//!   `None` — a *partial* forwarding impl compiles and answers `None` for the arms it forgot,
+//!   which no compile assertion can see;
+//! * two `PrattToken` instantiations, because that trait is generic in `Expr` and `Power` and a
+//!   forwarding impl that pinned either would still satisfy a single-instantiation assertion.
+
+use core::fmt;
+
+use tokora::{
+  Token,
+  token::{IdentifierToken, KeywordToken, LitToken, PunctuatorToken, PunctuatorTokenExt},
+};
+
+#[cfg(feature = "pratt")]
+use tokora::{
+  parser::{PrattLHS, PrattRHS},
+  token::PrattToken,
+};
+
+// ── A downstream token, written only against the public API ──────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Kind {
+  Ident,
+  If,
+  Int,
+  OpenParen,
+  Comma,
+  Dot,
+  Arrow,
+  LogicalAnd,
+  ShlEqual,
+  Newline,
+  Other,
+}
+
+impl fmt::Display for Kind {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{self:?}")
+  }
+}
+
+#[derive(Debug, Clone)]
+struct Tok {
+  kind: Kind,
+}
+
+impl Tok {
+  const fn new(kind: Kind) -> Self {
+    Self { kind }
+  }
+}
+
+impl Token<'_> for Tok {
+  type Kind = Kind;
+  type Error = ();
+
+  const SCAN_LOOKAHEAD: tokora::ScanLookahead = tokora::ScanLookahead::Unbounded;
+
+  fn kind(&self) -> Self::Kind {
+    self.kind
+  }
+
+  fn is_trivia(&self) -> bool {
+    matches!(self.kind, Kind::Newline)
+  }
+}
+
+impl IdentifierToken<'_> for Tok {
+  fn is_identifier(&self) -> bool {
+    matches!(self.kind, Kind::Ident)
+  }
+}
+
+impl KeywordToken<'_> for Tok {
+  fn keyword(&self) -> Option<&'static str> {
+    match self.kind {
+      Kind::If => Some("if"),
+      _ => None,
+    }
+  }
+}
+
+impl LitToken<'_> for Tok {
+  fn is_decimal_literal(&self) -> bool {
+    matches!(self.kind, Kind::Int)
+  }
+}
+
+// One override per declaration group of the punctuation macro — delimiters, ASCII
+// punctuation, multi-character, equal-related, shift-assignment and trivia — so a forwarding
+// impl generated from a truncated arm list is caught wherever the truncation falls.
+impl PunctuatorToken<'_> for Tok {
+  fn open_paren() -> Option<Self::Kind> {
+    Some(Kind::OpenParen)
+  }
+
+  fn comma() -> Option<Self::Kind> {
+    Some(Kind::Comma)
+  }
+
+  fn dot() -> Option<Self::Kind> {
+    Some(Kind::Dot)
+  }
+
+  fn arrow() -> Option<Self::Kind> {
+    Some(Kind::Arrow)
+  }
+
+  fn logical_and() -> Option<Self::Kind> {
+    Some(Kind::LogicalAnd)
+  }
+
+  fn shl_equal() -> Option<Self::Kind> {
+    Some(Kind::ShlEqual)
+  }
+
+  fn newline() -> Option<Self::Kind> {
+    Some(Kind::Newline)
+  }
+}
+
+// Two instantiations that differ in *both* type parameters, and disagree on the same token, so
+// neither can stand in for the other.
+#[cfg(feature = "pratt")]
+impl PrattToken<'_, i64, i64> for Tok {
+  fn try_pratt_lhs(&self) -> Option<PrattLHS<(), (), i64>> {
+    match self.kind {
+      Kind::Int => Some(PrattLHS::Operand(())),
+      _ => None,
+    }
+  }
+
+  fn try_pratt_rhs(&self) -> Option<PrattRHS<(), (), (), (), i64>> {
+    match self.kind {
+      Kind::Dot => Some(PrattRHS::Postfix(tokora::parser::Precedenced::new((), 7))),
+      _ => None,
+    }
+  }
+}
+
+#[cfg(feature = "pratt")]
+impl PrattToken<'_, str, i8> for Tok {
+  fn try_pratt_lhs(&self) -> Option<PrattLHS<(), (), i8>> {
+    match self.kind {
+      Kind::Ident => Some(PrattLHS::Operand(())),
+      _ => None,
+    }
+  }
+
+  fn try_pratt_rhs(&self) -> Option<PrattRHS<(), (), (), (), i8>> {
+    match self.kind {
+      Kind::Comma => Some(PrattRHS::Postfix(tokora::parser::Precedenced::new((), 3))),
+      _ => None,
+    }
+  }
+}
+
+// ── Compile-time census: one helper per capability ───────────────────────────
+//
+// Each block asserts the base `Token` capability for `&'static Tok` beside the specialized
+// one, so a failure of the borrow representation *as such* is distinguishable from a failure
+// of the one capability under test.
+
+const fn assert_token<'a, T: Token<'a>>() {}
+const fn assert_identifier<'a, T: IdentifierToken<'a>>() {}
+const fn assert_keyword<'a, T: KeywordToken<'a>>() {}
+const fn assert_lit<'a, T: LitToken<'a>>() {}
+const fn assert_punctuator<'a, T: PunctuatorToken<'a>>() {}
+const fn assert_punctuator_ext<'a, T: PunctuatorTokenExt<'a>>() {}
+
+#[cfg(feature = "pratt")]
+const fn assert_pratt<'a, Expr: ?Sized, Power, T: PrattToken<'a, Expr, Power>>() {}
+
+const _: () = {
+  assert_token::<Tok>();
+  assert_token::<&'static Tok>();
+};
+
+const _: () = {
+  assert_token::<&'static Tok>();
+  assert_identifier::<Tok>();
+  assert_identifier::<&'static Tok>();
+};
+
+const _: () = {
+  assert_token::<&'static Tok>();
+  assert_keyword::<Tok>();
+  assert_keyword::<&'static Tok>();
+};
+
+const _: () = {
+  assert_token::<&'static Tok>();
+  assert_lit::<Tok>();
+  assert_lit::<&'static Tok>();
+};
+
+const _: () = {
+  assert_token::<&'static Tok>();
+  assert_punctuator::<Tok>();
+  assert_punctuator::<&'static Tok>();
+  assert_punctuator_ext::<Tok>();
+  assert_punctuator_ext::<&'static Tok>();
+};
+
+#[cfg(feature = "pratt")]
+const _: () = {
+  assert_token::<&'static Tok>();
+  assert_pratt::<i64, i64, Tok>();
+  assert_pratt::<i64, i64, &'static Tok>();
+};
+
+// The second instantiation is a separate block: pinning `Power` in a forwarding impl leaves
+// the block above green and reds only this one.
+#[cfg(feature = "pratt")]
+const _: () = {
+  assert_token::<&'static Tok>();
+  assert_pratt::<str, i8, Tok>();
+  assert_pratt::<str, i8, &'static Tok>();
+};
+
+// ── Runtime discrimination ───────────────────────────────────────────────────
+//
+// `<&Tok as Trait>::method(&&tok)` forces dispatch through the `&'a T` impl rather than
+// auto-derefing to `Tok`.
+
+/// Every punctuation constructor is an associated function with a `None` default, so parity
+/// with the referent is the only thing that separates a complete forwarding impl from one that
+/// silently drops arms. The name in the message is the arm.
+#[test]
+fn ref_punctuator_constructors_match_the_referent() {
+  macro_rules! parity {
+    ($($ctor:ident),+ $(,)?) => {
+      $(
+        assert_eq!(
+          <&Tok as PunctuatorToken>::$ctor(),
+          <Tok as PunctuatorToken>::$ctor(),
+          concat!("`", stringify!($ctor), "` does not forward across the borrow"),
+        );
+      )+
+    };
+  }
+
+  // The seven the referent overrides…
+  parity!(
+    open_paren,
+    comma,
+    dot,
+    arrow,
+    logical_and,
+    shl_equal,
+    newline
+  );
+  // …and arms it does not, so "forwards" is not satisfied by a constant `None`.
+  parity!(
+    close_paren,
+    semicolon,
+    fat_arrow,
+    logical_or,
+    sar_equal,
+    space
+  );
+}
+
+#[test]
+fn ref_punctuator_predicates_delegate() {
+  let dot = Tok::new(Kind::Dot);
+  assert!(<&Tok as PunctuatorTokenExt>::is_dot(&&dot));
+  assert!(<&Tok as PunctuatorTokenExt>::is_punctuator(&&dot));
+
+  let other = Tok::new(Kind::Other);
+  assert!(!<&Tok as PunctuatorTokenExt>::is_dot(&&other));
+  assert!(!<&Tok as PunctuatorTokenExt>::is_punctuator(&&other));
+}
+
+#[test]
+fn ref_punctuator_aliases_delegate() {
+  let arrow = Tok::new(Kind::Arrow);
+  assert!(<&Tok as PunctuatorTokenExt>::is_thin_arrow(&&arrow));
+
+  let shl = Tok::new(Kind::ShlEqual);
+  assert!(<&Tok as PunctuatorTokenExt>::is_shl_assign(&&shl));
+}
+
+#[test]
+fn ref_base_and_neighbour_capabilities_delegate() {
+  let ident = Tok::new(Kind::Ident);
+  assert_eq!(<&Tok as Token>::kind(&&ident), Kind::Ident);
+  assert!(<&Tok as IdentifierToken>::is_identifier(&&ident));
+
+  let kw = Tok::new(Kind::If);
+  assert_eq!(<&Tok as KeywordToken>::keyword(&&kw), Some("if"));
+  assert!(<&Tok as KeywordToken>::is_keyword(&&kw));
+
+  let int = Tok::new(Kind::Int);
+  assert!(<&Tok as LitToken>::is_decimal_literal(&&int));
+
+  let nl = Tok::new(Kind::Newline);
+  assert!(<&Tok as Token>::is_trivia(&&nl));
+}
+
+#[cfg(feature = "pratt")]
+#[test]
+fn ref_pratt_delegates_on_the_default_power() {
+  let int = Tok::new(Kind::Int);
+  assert!(matches!(
+    <&Tok as PrattToken<i64, i64>>::try_pratt_lhs(&&int),
+    Some(PrattLHS::Operand(()))
+  ));
+  assert!(<&Tok as PrattToken<i64, i64>>::try_pratt_rhs(&&int).is_none());
+
+  let dot = Tok::new(Kind::Dot);
+  assert!(<&Tok as PrattToken<i64, i64>>::try_pratt_lhs(&&dot).is_none());
+  assert!(matches!(
+    <&Tok as PrattToken<i64, i64>>::try_pratt_rhs(&&dot),
+    Some(PrattRHS::Postfix(_))
+  ));
+}
+
+/// The second instantiation classifies *different* tokens, so an impl that forwarded to the
+/// wrong one would answer `None` here where the referent answers `Some`.
+#[cfg(feature = "pratt")]
+#[test]
+fn ref_pratt_delegates_on_a_non_default_expr_and_power() {
+  let ident = Tok::new(Kind::Ident);
+  assert!(matches!(
+    <&Tok as PrattToken<str, i8>>::try_pratt_lhs(&&ident),
+    Some(PrattLHS::Operand(()))
+  ));
+
+  let comma = Tok::new(Kind::Comma);
+  assert!(matches!(
+    <&Tok as PrattToken<str, i8>>::try_pratt_rhs(&&comma),
+    Some(PrattRHS::Postfix(_))
+  ));
+  assert!(<&Tok as PrattToken<str, i8>>::try_pratt_rhs(&&ident).is_none());
+}


### PR DESCRIPTION
Closes #268. Closes #270.

