### PR TITLE
fix(conformance)!: the kit compares the item, and a payload that will not equal itself is not the lexer's fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1832,6 +1832,24 @@ and will red until they do.
   in item **count** is now terminal, because none of those is a partial equality that could fail
   against itself.
 
+  **And no site collapses those comparisons into a `bool` before deciding.** That rule was applied
+  inside each comparison and not to the composition above them, and the cache kit's prefilled
+  purity law is composed: it compares the prefix `peek` was handed *and* the run `peek` appended
+  behind that prefix. `||` over the two answers a `bool` that does not record which half fired, so
+  the failure path re-ran both refusals — and the half that decided nothing was probed too. A
+  prefix impurity settled by a span or by a length says nothing, and a `NaN` the second peek
+  fabricated in the *appended* run then withheld a verdict the kit had established. That is the
+  same `bool` one level up. The comparison now answers which half failed to reproduce, that half's
+  two runs and what decided them — a **length** included, which an `Option<(position, component)>`
+  could not distinguish from agreement — and the branch condition and the failure path consume
+  that one result. The four purity sites take the same shape, so no `!=` over two peeked runs is
+  left in the kit to compose.
+
+  The failure names the half, and that is the one thing it can no longer say: it prints the
+  deciding half's two runs where it used to print both pairs. A cache impure in *both* halves is
+  reported at the prefix and its appended defect is seen on the next run — the same cost
+  "span first, always" already pays at the entry comparison, and for the same reason.
+
   **The sweep is the population and not the reported site.** Six comparisons: `assert_run_eq` and
   `check_resume` in the trait tier, `assert_partial_stream_eq` and `assert_partial_prefix_of` in
   the partial tier, the committed-stream comparison in the integration tier, and the cache kit's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1815,25 +1815,43 @@ and will red until they do.
   The obligation is unchanged and is the caller's: `run_partial`'s documentation has said since
   0.10.0 that such a type must hand-write the impl that says what equality means for it, and value
   equality is deliberate. What moves is the **diagnosis**. Every comparison any tier draws a
-  verdict from asks, once it has already failed, whether either side is equal to itself, and a
-  side that is not gets a refusal tagged `non-reflexive-payload` naming the component — the token
-  payload, the error payload, the `Kind`, the `L::State`, the span — and the obligation.
+  verdict from now answers with the **component that decided it** rather than with a `bool`, and
+  asks, once it has already failed, whether *that* operation is equal to itself; a side whose is
+  not gets a refusal tagged `non-reflexive-payload` naming the component — the token payload, the
+  error payload, the `Kind`, the `L::State`, the span, the slice — and the obligation.
+
+  **The refusal is asked about the comparison that ran, and about nothing else.** The first draft
+  of this repair answered `bool` and then scanned the whole item for a non-reflexive value, which
+  is a different question: the scan runs afterwards and knows nothing about *why*. So a divergence
+  settled at the **discriminant** — an item that is a lexer error on the truncated buffer and a
+  committed token on the full one, where no caller equality is consulted at all — still turned up
+  a `NaN` in the payload beside it and was refused, and the refusal said the kit had convicted the
+  lexer of nothing. It had: that is precisely the truncation nonconformance the partial tier
+  exists to report, and the panic one line below says so. The fix for a false red had produced a
+  false green. A difference at the discriminant, at a component bounded to a *total* equality, or
+  in item **count** is now terminal, because none of those is a partial equality that could fail
+  against itself.
 
   **The sweep is the population and not the reported site.** Six comparisons: `assert_run_eq` and
   `check_resume` in the trait tier, `assert_partial_stream_eq` and `assert_partial_prefix_of` in
   the partial tier, the committed-stream comparison in the integration tier, and the cache kit's
   entry and purity comparisons, whose observable is the `(span, token, state)` triple and which
   asks `PartialEq` of two of the three. A guard at one and not the others is the same defect one
-  relocation away. `Token::Kind` is bounded `Eq` and `Lexer::Span` is bounded `Ord`, so a failure
-  from those two is a broken *total*-equality promise rather than a partial one; both are scanned
-  anyway, because a component left out of the scan is a component whose failure is reported as a
-  defect of the thing under test.
+  relocation away — and so is a component-aware rule at one and a whole-item scan at another, so
+  all of them decide from what failed at that site. `Token::Kind` is bounded `Eq`, `Lexer::Span`
+  is bounded `Ord` and `Source::Slice` is bounded `Eq`, so a refusal drawn from any of those three
+  is a broken *total*-equality promise rather than a partial one; each still gets a probe when it
+  is the component that decided, because a component that can decide a verdict and cannot be
+  refused is a component whose failure is reported as a defect of the thing under test.
 
   **It can only ever re-label a failure, never create one.** Every guard sits on a path its own
   comparison has already taken to failure, so a reflexive value never reaches one. That is what
-  keeps the repair from trading a false red for a false green, and it is pinned by a control: a
-  genuinely non-conforming lexer over the same float payload type, never `NaN`, still reds
-  `partial-equivalence` with two distinguishable values in the message.
+  keeps the repair from trading a false red for a false green, and it is pinned by two controls
+  that pull in opposite directions: a genuinely non-conforming lexer over the same float payload
+  type, never `NaN`, still reds `partial-equivalence` with two distinguishable values in the
+  message; and a `NaN` payload that is what decided its comparison is still refused. The
+  discriminant counterexample is a third: the same truncation defect with a `NaN` error payload
+  and with a reflexive one now report identically.
 
 - **A borrowed token keeps its punctuation and pratt capabilities** (#268). `Token`,
   `IdentifierToken`, `KeywordToken` and every `LitToken` predicate forward from `T` to `&'a T`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -969,6 +969,30 @@ and will red until they do.
 
 ### Changed (breaking)
 
+- **`conformance::Harness::run` requires `L::Token: PartialEq` and `<L::Token as Token>::Error:
+  PartialEq`** (#269). It required nothing beyond `Lexer` before, and that is what the defect was:
+  check 1 is documented as identity of the *item*, and with no equality to call the kit
+  substituted the two things it could reach — the error's `Debug` rendering and the token's
+  `kind`. `run_partial` has asked for both bounds since 0.10.0, so this is the same obligation on
+  the other entry point rather than a new one, and the two tiers now differ only in `Offset =
+  usize`, a prefix-sliceable source and `State: Clone`.
+
+  **Who this excludes.** A vocabulary whose token or error type genuinely cannot be `PartialEq` —
+  one holding an `Arc<dyn Error>`, a closure, a handle — loses the kit, since every tier runs from
+  `run` or `run_partial`. Recovering it costs a `#[derive(PartialEq)]`, a hand-written impl where
+  derivation is wrong, or a newtype whose equality is the one the vocabulary means; nothing about
+  the lexer changes. There is no in-tree vocabulary among the excluded — this crate ships no
+  concrete `Token` implementation at all — and the bundled logos adapter is transparent:
+  `LogosLexer<T>` takes its `Token` and `Error` from the caller and constrains neither.
+
+  The alternative to a bound is a caller-supplied comparator or key, and `run_partial` settled
+  that trade already: a hand-written projection is silently escaped by the next field added, which
+  is the failure mode the rendering had.
+
+  `Item`'s private fields move with it — the kit keeps the `Result` `lex()` already handed it
+  instead of a `kind` plus a `format!("{err:?}")` `String`, so the repair costs an allocation per
+  error item less than what it replaces.
+
 - **`PrattRHS` gains a variant, so an exhaustive `match` on it stops compiling** (#274). The new
   arm is `Adjacent(Precedenced<L, Power>)` — see **Added**. Every in-tree `match` on `PrattRHS`
   was a driver's; grammar code builds these values rather than reading them, so the expected
@@ -1759,6 +1783,57 @@ and will red until they do.
   lookahead while every one of them consumes what it reports.
 
 ### Fixed
+
+- **`conformance::Harness::run` compares the item and not a rendering of it** (#269). Two fresh
+  runs were held to agree on the error's `Debug` string and the token's `kind`, which the module
+  header called identity of the token/error sequence. `Debug` is neither **injective** — two
+  unequal error variants may render identically, and a hand-written `Debug` printing one label for
+  a family of variants is legal and not rare, so a lexer whose error *value* changed between fresh
+  runs was certified — nor **stable**: a rendering carrying an address or a counter differs
+  between the two separately constructed lexers and reddened a lexer with no defect at all. The
+  two run in opposite directions, so no amount of care with the rendering fixes both, and
+  correcting the documentation to describe rendering-equality would have kept the false red.
+  `kind` had the third failure of the same shape: a payload that moved between fresh runs kept its
+  kind, its span and its slice, which was the whole comparison.
+
+  The partial tier made this repair in 0.10.0 and the trait tier did not, so the argument, the
+  bound and now the cells are the same on both. Three plants: an alternating error value behind one
+  `Debug` spelling, an alternating token payload behind one kind, and the same error drift through
+  a `with_state` resume, which is `check_resume`'s own comparison and not `assert_run_eq`'s. The
+  control is `TickingErrLexer` — conforming, unstable `Debug` — now driven through `run` as well
+  as `run_partial`.
+
+- **The conformance kits diagnose a payload that is not equal to itself instead of convicting the
+  lexer or the cache** (#295). `PartialEq` promises symmetry and transitivity and **not**
+  reflexivity, so a token payload holding an `f64` that can be `NaN` is not equal to itself. The
+  partial tier's final leg compares the complete stream against a final drain of the *same*
+  source, so such a payload failed a stream against itself: the kit raised `partial-equivalence`
+  — a red naming the consumer's lexer — with an expected-vs-got in which both sides render
+  `FTok(NaN)`. Two things that look the same, and a verdict about the wrong thing. 38 corpus
+  queries in one downstream reached it.
+
+  The obligation is unchanged and is the caller's: `run_partial`'s documentation has said since
+  0.10.0 that such a type must hand-write the impl that says what equality means for it, and value
+  equality is deliberate. What moves is the **diagnosis**. Every comparison any tier draws a
+  verdict from asks, once it has already failed, whether either side is equal to itself, and a
+  side that is not gets a refusal tagged `non-reflexive-payload` naming the component — the token
+  payload, the error payload, the `Kind`, the `L::State`, the span — and the obligation.
+
+  **The sweep is the population and not the reported site.** Six comparisons: `assert_run_eq` and
+  `check_resume` in the trait tier, `assert_partial_stream_eq` and `assert_partial_prefix_of` in
+  the partial tier, the committed-stream comparison in the integration tier, and the cache kit's
+  entry and purity comparisons, whose observable is the `(span, token, state)` triple and which
+  asks `PartialEq` of two of the three. A guard at one and not the others is the same defect one
+  relocation away. `Token::Kind` is bounded `Eq` and `Lexer::Span` is bounded `Ord`, so a failure
+  from those two is a broken *total*-equality promise rather than a partial one; both are scanned
+  anyway, because a component left out of the scan is a component whose failure is reported as a
+  defect of the thing under test.
+
+  **It can only ever re-label a failure, never create one.** Every guard sits on a path its own
+  comparison has already taken to failure, so a reflexive value never reaches one. That is what
+  keeps the repair from trading a false red for a false green, and it is pinned by a control: a
+  genuinely non-conforming lexer over the same float payload type, never `NaN`, still reds
+  `partial-equivalence` with two distinguishable values in the message.
 
 - **A borrowed token keeps its punctuation and pratt capabilities** (#268). `Token`,
   `IdentifierToken`, `KeywordToken` and every `LitToken` predicate forward from `T` to `&'a T`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1841,6 +1841,71 @@ and will red until they do.
   a token payload and an error payload, each keyed to the `Lexer::new` instance the drive was
   seeded from, so every trait-tier check passes and the straight drain and `peek-heavy` disagree.
 
+- **The conformance kits report exactly what they established — no more and no less** (#324).
+  #295 gave the kits one half of that rule: never state a diagnosis you did not establish. This is
+  the other half, and the two are one rule. Every verdict-drawing comparison settled at the
+  **first** difference it happened to reach, so an inconclusive one reached first buried every
+  conclusive one behind it.
+
+  Two instances, at two of the shared functions. `assert_run_eq` inspected shared items before
+  checking stream length, so two fresh runs producing `[Tok(NaN)]` and `[Tok(NaN), Tok(0.0)]` —
+  identical kind, span and slice at position 0 — reported `non-reflexive-payload` at position 0
+  and never reached the length check, while the **extra item** proves replay divergence with no
+  caller equality consulted at all. And `triple_compare` returned at the token, so a cache that
+  accepts a push, hands back the correct span and the correct token and corrupts a perfectly
+  **reflexive** `L::State` was called INCONCLUSIVE because `NaN != NaN` came first in its order,
+  while the unexamined state mismatch convicts the cache on its own.
+
+  **A conclusive difference outranks an inconclusive one, wherever both are available.** The first
+  inconclusive difference is retained as a fallback and the search continues — into the remaining
+  components of the same item, the later positions of the same stream, the item **count**, and the
+  second arm of a two-arm law — and it is reported only if nothing conclusive is found anywhere.
+  What counts as conclusive is a question about the two values the comparison ran on and not about
+  the bound the component carries: a difference at the discriminant or in item count consults no
+  caller equality at all, and a component comparison over two values that **each equal themselves**
+  is sound — which is the ordinary case, the whole population of honest failures, and is not
+  demoted by any of this.
+
+  The rule lives in one place. `Ranking` carries it, `Comparison::ranked` spells it over a
+  component list and `diverge` over two item streams; the cache kit's `PurityDecided` is gone,
+  because it said exactly what `Divergence` says and two spellings of one answer are two places for
+  the ordering between a position and a count to be decided wrongly — it was wrong in both.
+  `Ranking` is generic over what a step answers, so the same rule composes over whole answers a
+  level up: the integration tier's committed and raised-error arms were two `assert` calls in a
+  fixed order, and `prefilled_purity` took the first half that diverged, and both carried the
+  finding again. Nine plants, one per decision point.
+
+  **What it costs.** On the passing path, nothing: every step short-circuits at the first
+  conclusive difference, so a comparison whose components agree runs exactly what it ran before,
+  and so does one that fails the ordinary way. On a **failure** path the kit runs more of the
+  caller's `PartialEq` — the components behind an inconclusive one, the positions after it, the
+  other arm — which is the same code the same run would have called had the earlier component
+  agreed, over values the kit is already holding. A caller `eq` that panics can therefore panic
+  where it was previously unreachable; that run was already going to abort, and no comparison here
+  can turn a passing run red. `check_resume` is the one place where more of the *subject* runs: it
+  collects its suffix before comparing, so a divergent resume lexes on to exhaustion under the same
+  budget the passing path is already bounded by.
+
+- **The kits owe a broken `Eq` the same answer they owe a broken `PartialEq`** (#324). A second
+  population of verdict-drawing comparisons had no refusal at all — span/slice coherence,
+  read-frontier purity, the span after exhaustion, gap-free tiling, and the cache kit's eleven
+  span-valued laws — classified as settled by *total* equalities and therefore outside the guarded
+  population. But `Eq` and `Ord` are markers and nothing checks the promise they make, so a lexer
+  over a `Slice` whose `PartialEq` answers `false` to everything, itself included, got
+  `span/slice-coherence`: a red naming their lexer, with `source LyingSlice("a"), slice()
+  LyingSlice("a")` — two values that render identically. That is #295 verbatim at a site called
+  exempt, and the exemption was not even self-consistent, since the same lying `L::Span` reaches an
+  entry comparison a few lines below several of the cache sites and is refused there. Breaking `Eq`
+  is a **stronger** caller defect than a `NaN`-capable `PartialEq`, not a defect outside this kit's
+  reach; either way the comparison that failed was the caller's and the kit convicted nobody.
+
+  Every equality any tier draws a verdict from is now built by one function, so the guarded
+  population is a matter of construction rather than of a count in a comment: a comparison that
+  does not come through it cannot produce the answer a verdict or a refusal is drawn from. The
+  refusal keeps the `non-reflexive-payload` tag whatever the component, because the tag names the
+  diagnosis #295 established and every cell and downstream grep keys on it; the component it names
+  is what says whether a total or a partial promise was the one broken.
+
 - **The conformance kits diagnose a payload that is not equal to itself instead of convicting the
   lexer or the cache** (#295). `PartialEq` promises symmetry and transitivity and **not**
   reflexivity, so a token payload holding an `f64` that can be `NaN` is not equal to itself. The
@@ -1866,9 +1931,10 @@ and will red until they do.
   a `NaN` in the payload beside it and was refused, and the refusal said the kit had convicted the
   lexer of nothing. It had: that is precisely the truncation nonconformance the partial tier
   exists to report, and the panic one line below says so. The fix for a false red had produced a
-  false green. A difference at the discriminant, at a component bounded to a *total* equality, or
-  in item **count** is now terminal, because none of those is a partial equality that could fail
-  against itself.
+  false green. A difference at the discriminant or in item **count** is now terminal, because
+  neither consults a caller equality at all. A component bounded to a *total* equality is terminal
+  too whenever its own comparison is sound, which is every case a kept `Eq` promise produces — and
+  the entry below is what the kit does when the promise is not kept.
 
   **And no site collapses those comparisons into a `bool` before deciding.** That rule was applied
   inside each comparison and not to the composition above them, and the cache kit's prefilled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1803,6 +1803,44 @@ and will red until they do.
   control is `TickingErrLexer` — conforming, unstable `Debug` — now driven through `run` as well
   as `run_partial`.
 
+- **The integration tier compares the committed item, and it compares both of its arms** (#269).
+  The last tier still holding the key #269 removed. Its five schedules reduced every committed
+  token to `(kind, span)` and threw the `L::Token` the drain loop had just been handed away, and
+  they ran under `Silent`, which discards a lexer error outright. So a token payload that moved
+  between two schedules of the same input — same kind, same span, same item count — was certified,
+  and the whole error arm of the committed stream sat outside all five comparisons: a refusal
+  leaves no token behind, so a lexer whose refusal payload moved between schedules produced five
+  identical (empty) token streams.
+
+  Both halves are the same defect the trait tier had, at the one tier neither #269 nor #295
+  reached, and the fix is to stop projecting rather than to compare harder: the streams now hold
+  `StreamItem` — the partial tier's own item type, renamed because it now serves both tiers that
+  drive an `Input` — and every verdict is drawn from `StreamItem::compare`, the component-aware,
+  reflexivity-aware path that already existed. The tier's local `(kind, span)` comparison is gone;
+  a second implementation of one rule is what let the two drift in the first place. **This costs
+  no new bound.** `run` already asks for the two `PartialEq`s, and retention is free: `Token` is
+  bounded `Clone` and `Token::Error` is bounded `Clone`, both by the `Token` trait, so the tier
+  excludes nobody it did not already exclude.
+
+  **The two arms are compared as two sequences, not as one interleaved stream, and the error arm
+  is not cross-checked against the raw lexer.** Both are facts about the input layer that a
+  stronger-looking check would have gotten wrong, and both were written, run, and rejected by an
+  existing positive cell rather than reasoned about. A `peek` reports a refusal the moment it
+  lexes the region, so on `"a?b"` the straight drain observes `token, error, token` and
+  `peek-heavy` observes `error, token, token` — both conforming, and an interleaved comparison
+  reds `error_yielding_lexer_passes_every_check`. The layer also reports each refused region
+  exactly once, keyed on a high-water mark, while the raw lexer may error over one span
+  repeatedly: `RepeatErrLexer<80>` raises eighty and the layer raises one, and requiring equality
+  there reds three positive cells. What survives both is what the tier now asserts — each arm's
+  own sequence, per schedule, against the straight drain's.
+
+  The emitter is now the partial tier's `ItemRecorder` rather than `Silent`, which is what puts a
+  refusal in front of a comparison at all; its `checkpoint`/`rewind` was written for "a later
+  schedule that does backtrack" and three of these five are it, so a restore rewinds the recorded
+  errors in the same operation that rewinds the layer's dedup watermark. Two plants, one per arm:
+  a token payload and an error payload, each keyed to the `Lexer::new` instance the drive was
+  seeded from, so every trait-tier check passes and the straight drain and `peek-heavy` disagree.
+
 - **The conformance kits diagnose a payload that is not equal to itself instead of convicting the
   lexer or the cache** (#295). `PartialEq` promises symmetry and transitivity and **not**
   reflexivity, so a token payload holding an `f64` that can be `NaN` is not equal to itself. The

--- a/tokora/src/conformance/cache.rs
+++ b/tokora/src/conformance/cache.rs
@@ -439,30 +439,119 @@ where
   None
 }
 
-/// [`triple_compare`] over two whole peeked runs: the **first position they actually disagree
-/// at**, and the component that decided that disagreement — what the purity laws, which compare
-/// two runs as vectors rather than entry by entry, need in order to say *where*.
+/// What a purity comparison over two peeked runs was decided by — the answer [`runs_decided`]
+/// gives when the two runs differ at all.
 ///
-/// `None` when every shared position agrees, and that includes two runs which differ only in
-/// **length**: a count is not a comparison of caller values, so there is nothing there that could
-/// fail to equal itself and nothing to refuse. A scan of one run had neither property — it
-/// answered from an entry the two runs might well agree on, at a position the divergence is not
-/// at, and it answered at all when a length settled the verdict.
+/// **Total over the ways two runs can differ, and the totality is the point.** An `Option<(usize,
+/// Decided)>` could not say "they differ, and a *length* decided it": it said `None`, which is
+/// also what it says about two runs that agree. A caller needing both answers therefore had to
+/// ask a second question — `first != second` — and compose the two by hand, and that composition
+/// is where a `bool` that does not record what fired came back one level up (#324). One
+/// comparison, one answer, consumed by the branch and by the failure path alike.
+pub(super) enum PurityDecided {
+  /// Every shared position agrees and the two runs differ in **length**.
+  ///
+  /// A count is not a comparison of caller values, so there is nothing here that could fail to
+  /// equal itself and nothing to refuse — see [`refuse_runs`](CacheHarness::refuse_runs).
+  Length,
+  /// They disagree at a position, and [`Decided`] names the component that decided it.
+  At(usize, Decided),
+}
+
+/// [`triple_compare`] over two whole peeked runs: whether they differ, and when they do, **what
+/// decided it** — the first position they actually disagree at with the component that settled
+/// it, or their length. That is what the purity laws, which compare two runs as vectors rather
+/// than entry by entry, need in order to say *where*.
+///
+/// A scan of one run had neither property: it answered from an entry the two runs might well
+/// agree on, at a position the divergence is not at, and it answered at all when a length settled
+/// the verdict.
 pub(super) fn runs_decided<'inp, L>(
   first: &[PeekedTriple<'inp, L>],
   second: &[PeekedTriple<'inp, L>],
-) -> Option<(usize, Decided)>
+) -> Option<PurityDecided>
 where
   L: Lexer<'inp>,
   L::Token: PartialEq,
   L::State: PartialEq,
 {
-  first
+  let diverged = first
     .iter()
     .zip(second)
     .enumerate()
     .find_map(|(i, (a, b))| {
-      triple_compare::<L>((&a.0, &a.1, &a.2), (&b.0, &b.1, &b.2)).map(|(_, decided)| (i, decided))
+      triple_compare::<L>((&a.0, &a.1, &a.2), (&b.0, &b.1, &b.2))
+        .map(|(_, decided)| PurityDecided::At(i, decided))
+    });
+  diverged.or_else(|| (first.len() != second.len()).then_some(PurityDecided::Length))
+}
+
+/// Which half of a prefilled `peek`'s buffer a purity comparison was decided by: the prefix
+/// `peek` was handed, or the run it appended behind that prefix.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum PeekHalf {
+  /// The entries the buffer already held when `peek` was called.
+  Prefix,
+  /// The entries `peek` wrote behind them.
+  Appended,
+}
+
+impl PeekHalf {
+  /// How the refusal names this half's two runs — the first peek's and the second's.
+  const fn sides(self) -> (&'static str, &'static str) {
+    match self {
+      Self::Prefix => ("first prefix", "second prefix"),
+      Self::Appended => ("first appended", "second appended"),
+    }
+  }
+
+  /// How the failure names this half.
+  const fn noun(self) -> &'static str {
+    match self {
+      Self::Prefix => "the prefix the buffer already held",
+      Self::Appended => "the run it appended behind that prefix",
+    }
+  }
+}
+
+/// The **one** comparison a prefilled peek's purity law is decided by: which half of the buffer
+/// failed to reproduce, the two runs of that half, and what decided them.
+struct PrefilledPurity<'r, 'inp, L>
+where
+  L: Lexer<'inp>,
+{
+  half: PeekHalf,
+  first: &'r [PeekedTriple<'inp, L>],
+  second: &'r [PeekedTriple<'inp, L>],
+  decided: PurityDecided,
+}
+
+/// [`runs_decided`] over the two halves of a prefilled peek, in buffer order, answering with the
+/// **first** half that a second peek did not reproduce.
+///
+/// Prefix before appended because the two halves are the two halves of one buffer in order: the
+/// first position the whole buffer diverges at is in the prefix whenever the prefix diverges at
+/// all. This is [`triple_compare`]'s "span first, always" one level up, and it costs the same
+/// thing — a cache impure in both halves is reported at the first, and the second is seen on the
+/// next run.
+fn prefilled_purity<'r, 'inp, L>(
+  prefix: (&'r [PeekedTriple<'inp, L>], &'r [PeekedTriple<'inp, L>]),
+  appended: (&'r [PeekedTriple<'inp, L>], &'r [PeekedTriple<'inp, L>]),
+) -> Option<PrefilledPurity<'r, 'inp, L>>
+where
+  L: Lexer<'inp>,
+  L::Token: PartialEq,
+  L::State: PartialEq,
+{
+  [(PeekHalf::Prefix, prefix), (PeekHalf::Appended, appended)]
+    .into_iter()
+    .find_map(|(half, (first, second))| {
+      runs_decided::<L>(first, second).map(|decided| PrefilledPurity {
+        half,
+        first,
+        second,
+        decided,
+      })
     })
 }
 
@@ -1427,25 +1516,23 @@ where
     }
   }
 
-  /// The reflexivity guard for a purity comparison over two whole peeked runs — what the purity
-  /// laws, which compare two runs as vectors rather than entry by entry, need in order to say
-  /// *where*.
+  /// The reflexivity refusal for a purity comparison over two whole peeked runs, asked about the
+  /// operation [`runs_decided`] says decided it — and about no other.
   ///
-  /// The question is asked at the first position the two runs actually disagree at, about the
-  /// component that decided that disagreement, and nowhere else. Two runs that agree
-  /// position-for-position and differ only in **length** reach this and are refused nothing: see
-  /// [`runs_decided`]. Called with a pair that turns out to be equal — which the prefilled law
-  /// does, since either half of its condition can be the one that fired — it likewise says
-  /// nothing.
-  fn guard_runs(
+  /// **It does not compare.** The comparison ran at the branch that reached here and its answer
+  /// arrives as an argument, so the refusal cannot come to be asked about a pair the verdict does
+  /// not rest on. A [`PurityDecided::Length`] refuses nothing: a count consults no caller
+  /// equality, so there is nothing there that could fail to equal itself.
+  fn refuse_runs(
     &self,
     site: &str,
+    decided: &PurityDecided,
     first_label: &str,
     first: &[PeekedTriple<'inp, L>],
     second_label: &str,
     second: &[PeekedTriple<'inp, L>],
   ) {
-    let Some((i, decided)) = runs_decided::<L>(first, second) else {
+    let PurityDecided::At(i, decided) = decided else {
       return;
     };
     let at = format!("{site}, position {i}");
@@ -1453,13 +1540,55 @@ where
       &at,
       first_label,
       decided.expected(),
-      &format!("{:?}", first[i]),
+      &format!("{:?}", first[*i]),
     );
     self.refuse_non_reflexive(
       &at,
       second_label,
       decided.got(),
-      &format!("{:?}", second[i]),
+      &format!("{:?}", second[*i]),
+    );
+  }
+
+  /// Check 6's purity law on the **prefilled** path: two peeks over the same cache and the same
+  /// prefill land the same buffer, in both of its halves.
+  ///
+  /// **No site may collapse comparisons into a boolean before deciding: the branch condition and
+  /// the failure path consume the same single result.** This one is composed of two comparisons —
+  /// the prefix `peek` was handed and the run it appended behind that prefix — and `||` over them
+  /// answers a `bool` that does not record which half fired. A failure path that then re-runs
+  /// both asks the half that did *not* decide, whose own probe can fire over a value the verdict
+  /// does not rest on: a prefix impurity settled by a span or a length says nothing, and a
+  /// fabricated `NaN` in the appended run withholds a verdict the kit had established (#324).
+  /// That is `sig_eq`'s `bool` one level up. [`prefilled_purity`] answers once, naming the half,
+  /// and the refusal below is asked about that half's own runs.
+  pub(super) fn assert_prefilled_peek_pure(
+    &self,
+    tag: &str,
+    depth: usize,
+    state: &str,
+    prefix: (&[PeekedTriple<'inp, L>], &[PeekedTriple<'inp, L>]),
+    appended: (&[PeekedTriple<'inp, L>], &[PeekedTriple<'inp, L>]),
+  ) {
+    let Some(purity) = prefilled_purity::<L>(prefix, appended) else {
+      return;
+    };
+    let name = self.label();
+    let site = format!("pure-peek/{tag} at depth {depth} against {state}");
+    let (first_label, second_label) = purity.half.sides();
+    self.refuse_runs(
+      &site,
+      &purity.decided,
+      first_label,
+      purity.first,
+      second_label,
+      purity.second,
+    );
+    panic!(
+      "tokora cache conformance [{name} pure-peek/{tag} at depth {depth}] against {state}: two prefilled peeks on an unchanged cache disagreed in {}: {:?} then {:?}. `peek` takes &self and must be logically pure against every shape of buffer, not only against an empty one.",
+      purity.half.noun(),
+      purity.first,
+      purity.second
     );
   }
 
@@ -2621,9 +2750,9 @@ where
     // Purity: the cache is unchanged, and a second peek reads the same.
     self.assert_resident(cache, cap, want, &format!("after peek() against {state}"));
     let second = self.peeked_entries(cache);
-    if second != first {
+    if let Some(decided) = runs_decided::<L>(&first, &second) {
       let site = format!("pure-peek against {state}");
-      self.guard_runs(&site, "first", &first, "second", &second);
+      self.refuse_runs(&site, &decided, "first", &first, "second", &second);
       panic!(
         "tokora cache conformance [{name} pure-peek] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure. The comparison is over whole (span, token, state) entries, so a peek that is stable in its spans and unstable in the tokens or the states behind them disagrees here too."
       );
@@ -2665,10 +2794,11 @@ where
       (None, None) => {}
     }
     let one_second: Option<PeekedTriple<'inp, L>> = self.peeked_one(cache);
-    if one_second != one_first {
+    if let Some(decided) = runs_decided::<L>(one_first.as_slice(), one_second.as_slice()) {
       let site = format!("pure-peek-one against {state}");
-      self.guard_runs(
+      self.refuse_runs(
         &site,
+        &decided,
         "first",
         one_first.as_slice(),
         "second",
@@ -2768,9 +2898,9 @@ where
       &format!("bounded-peek/window {window} against {state}"),
     );
     let second = self.peeked_entries_through::<W>(cache);
-    if second != first {
+    if let Some(decided) = runs_decided::<L>(&first, &second) {
       let site = format!("pure-peek/window {window} against {state}");
-      self.guard_runs(&site, "first", &first, "second", &second);
+      self.refuse_runs(&site, &decided, "first", &first, "second", &second);
       panic!(
         "tokora cache conformance [{name} pure-peek/window {window}] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure at every window, not only at the kit's own."
       );
@@ -2850,29 +2980,15 @@ where
     );
     let (prefix_again, appended_again) =
       self.peeked_entries_after_prefill(cache, self.prefill(cap, depth, from));
-    if prefix_again != prefix_after || appended_again != appended {
-      // Either half of the condition above can be the one that fired, so both pairs are asked and
-      // the pair that agrees says nothing — which is the component-aware rule and not a
-      // convenience: a run scanned on its own answers about an entry the two runs may agree on.
-      let site = format!("pure-peek/{tag} at depth {depth} against {state}");
-      self.guard_runs(
-        &site,
-        "first prefix",
-        &prefix_after,
-        "second prefix",
-        &prefix_again,
-      );
-      self.guard_runs(
-        &site,
-        "first appended",
-        &appended,
-        "second appended",
-        &appended_again,
-      );
-      panic!(
-        "tokora cache conformance [{name} pure-peek/{tag} at depth {depth}] against {state}: two prefilled peeks on an unchanged cache disagreed: prefix {prefix_after:?} then {prefix_again:?}, appended {appended:?} then {appended_again:?}. `peek` takes &self and must be logically pure against every shape of buffer, not only against an empty one."
-      );
-    }
+    // No site may collapse comparisons into a boolean before deciding: the branch condition and
+    // the failure path consume the same single result. See `assert_prefilled_peek_pure`.
+    self.assert_prefilled_peek_pure(
+      tag,
+      depth,
+      state,
+      (&prefix_after, &prefix_again),
+      (&appended, &appended_again),
+    );
     self.assert_resident(
       cache,
       cap,

--- a/tokora/src/conformance/cache.rs
+++ b/tokora/src/conformance/cache.rs
@@ -266,6 +266,7 @@ use generic_arraydeque::{
 };
 use mayber::Maybe;
 
+use super::{Decided, NON_REFLEXIVE_BODY, decided_by};
 use crate::{
   Lexer, Slice, Source, Span, Window,
   cache::{
@@ -364,50 +365,105 @@ where
   (*tok.token().span_ref()).clone()
 }
 
-/// The first component of a cached entry that fails to compare equal to **itself**, named for a
-/// reader. `None` when all three are reflexive.
+/// Which third of a cached entry a comparison of two of them was decided by.
+///
+/// Each third fails with its own message and its own tag (#183), so the component the reflexivity
+/// refusal is asked about and the message the reader gets are chosen from the **same** answer.
+/// Nothing pairs them by hand.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum EntryPart {
+  /// The span — bounded `Ord`, and always reported first. See
+  /// [`assert_entry_eq`](CacheHarness::assert_entry_eq).
+  Span,
+  /// The token payload — the caller's [`PartialEq`], where reflexivity is promised by nothing.
+  Token,
+  /// The [`Lexer::State`] — likewise.
+  State,
+}
+
+impl EntryPart {
+  /// The component's name, as the refusal names it. The trait and partial tiers spell the same
+  /// three components, and both read the spelling from the same constants.
+  pub(super) const fn component(self) -> &'static str {
+    match self {
+      Self::Span => Decided::SPAN,
+      Self::Token => Decided::TOKEN_PAYLOAD,
+      Self::State => Decided::STATE,
+    }
+  }
+}
+
+/// Compares two cached entries component by component — **span first, always** — and answers with
+/// the component that decided a difference, `None` when all three agree.
 ///
 /// The cache kit's observable is the whole `(span, token, state)` triple, and two of the three are
 /// caller values the harness only asks [`PartialEq`] of — so this tier draws its verdicts from
 /// exactly the population `conformance`'s trait and partial tiers do, and needs the same guard for
-/// the same reason (#295). [`Lexer::Span`] is bounded `Ord` and so is reflexive by contract; it is
-/// scanned anyway, because a component left out of the scan is a component whose failure is
-/// reported as a cache defect.
+/// the same reason (#295). [`Lexer::Span`] is bounded `Ord` and so is reflexive by contract; it
+/// gets a probe anyway, because a component whose comparison can decide a verdict and cannot be
+/// refused is a component whose failure is reported as a cache defect.
 ///
-/// See [`refuse_non_reflexive`](CacheHarness::refuse_non_reflexive).
-fn entry_non_reflexive<'inp, L>(
-  span: &L::Span,
-  token: &L::Token,
-  state: &L::State,
-) -> Option<&'static str>
+/// What it is **not** is a scan of the entry. That was the shape the trait and partial tiers
+/// carried until the discriminant counterexample, and it answers a different question from the
+/// one the comparison asked: a permuted cache diverges at the *span*, and an entry scan that
+/// found a `NaN` in the token beside it refused, hiding a real cache defect behind a diagnosis
+/// nothing had established. See [`refuse_non_reflexive`](CacheHarness::refuse_non_reflexive) and
+/// [`Decided`].
+pub(super) fn triple_compare<'inp, L>(
+  want: (&L::Span, &L::Token, &L::State),
+  got: (&L::Span, &L::Token, &L::State),
+) -> Option<(EntryPart, Decided)>
 where
   L: Lexer<'inp>,
   L::Token: PartialEq,
   L::State: PartialEq,
 {
-  if !super::self_equal(token) {
-    return Some("the token payload");
+  if want.0 != got.0 {
+    return Some((
+      EntryPart::Span,
+      decided_by(EntryPart::Span.component(), want.0, got.0),
+    ));
   }
-  if !super::self_equal(state) {
-    return Some("the `L::State`");
+  if want.1 != got.1 {
+    return Some((
+      EntryPart::Token,
+      decided_by(EntryPart::Token.component(), want.1, got.1),
+    ));
   }
-  if !super::self_equal(span) {
-    return Some("the span");
+  if want.2 != got.2 {
+    return Some((
+      EntryPart::State,
+      decided_by(EntryPart::State.component(), want.2, got.2),
+    ));
   }
   None
 }
 
-/// [`entry_non_reflexive`] over a whole peeked run, with the position of the offending entry —
-/// what the purity laws, which compare two runs as vectors, need to say *where*.
-fn run_non_reflexive<'inp, L>(run: &[PeekedTriple<'inp, L>]) -> Option<(usize, &'static str)>
+/// [`triple_compare`] over two whole peeked runs: the **first position they actually disagree
+/// at**, and the component that decided that disagreement — what the purity laws, which compare
+/// two runs as vectors rather than entry by entry, need in order to say *where*.
+///
+/// `None` when every shared position agrees, and that includes two runs which differ only in
+/// **length**: a count is not a comparison of caller values, so there is nothing there that could
+/// fail to equal itself and nothing to refuse. A scan of one run had neither property — it
+/// answered from an entry the two runs might well agree on, at a position the divergence is not
+/// at, and it answered at all when a length settled the verdict.
+pub(super) fn runs_decided<'inp, L>(
+  first: &[PeekedTriple<'inp, L>],
+  second: &[PeekedTriple<'inp, L>],
+) -> Option<(usize, Decided)>
 where
   L: Lexer<'inp>,
   L::Token: PartialEq,
   L::State: PartialEq,
 {
-  run.iter().enumerate().find_map(|(i, entry)| {
-    entry_non_reflexive::<L>(&entry.0, &entry.1, &entry.2).map(|component| (i, component))
-  })
+  first
+    .iter()
+    .zip(second)
+    .enumerate()
+    .find_map(|(i, (a, b))| {
+      triple_compare::<L>((&a.0, &a.1, &a.2), (&b.0, &b.1, &b.2)).map(|(_, decided)| (i, decided))
+    })
 }
 
 /// The `L::State` a peeked entry carries, whichever arm of [`Maybe`] it arrived on.
@@ -1345,38 +1401,66 @@ where
        {component} of the {side} entry {rendered} is not equal to ITSELF, so the comparison that \
        just failed was decided by the value type and not by the cache, which this kit has \
        therefore not convicted of anything. {}",
-      super::NON_REFLEXIVE_BODY
+      NON_REFLEXIVE_BODY
     )
   }
 
-  /// The reflexivity guard for one entry comparison, asked of both sides.
+  /// The reflexivity guard for one entry comparison, asked of both sides about the component
+  /// [`triple_compare`] says decided it — and about no other.
   fn guard_entry(
     &self,
     site: &str,
+    decided: &Decided,
     got: (&L::Span, &L::Token, &L::State),
     want: (&L::Span, &L::Token, &L::State),
   ) {
-    for (side, (span, token, state)) in [("got", got), ("expected", want)] {
+    for (side, component, (span, token, state)) in [
+      ("got", decided.got(), got),
+      ("expected", decided.expected(), want),
+    ] {
       self.refuse_non_reflexive(
         site,
         side,
-        entry_non_reflexive::<L>(span, token, state),
+        component,
         &format!("({span:?}, {token:?}, {state:?})"),
       );
     }
   }
 
-  /// The reflexivity guard for a whole peeked run — what the purity laws, which compare two runs
-  /// as vectors rather than entry by entry, need in order to say *where*.
-  fn guard_run(&self, site: &str, side: &str, run: &[PeekedTriple<'inp, L>]) {
-    if let Some((i, component)) = run_non_reflexive::<L>(run) {
-      self.refuse_non_reflexive(
-        &format!("{site}, position {i}"),
-        side,
-        Some(component),
-        &format!("{:?}", run[i]),
-      );
-    }
+  /// The reflexivity guard for a purity comparison over two whole peeked runs — what the purity
+  /// laws, which compare two runs as vectors rather than entry by entry, need in order to say
+  /// *where*.
+  ///
+  /// The question is asked at the first position the two runs actually disagree at, about the
+  /// component that decided that disagreement, and nowhere else. Two runs that agree
+  /// position-for-position and differ only in **length** reach this and are refused nothing: see
+  /// [`runs_decided`]. Called with a pair that turns out to be equal — which the prefilled law
+  /// does, since either half of its condition can be the one that fired — it likewise says
+  /// nothing.
+  fn guard_runs(
+    &self,
+    site: &str,
+    first_label: &str,
+    first: &[PeekedTriple<'inp, L>],
+    second_label: &str,
+    second: &[PeekedTriple<'inp, L>],
+  ) {
+    let Some((i, decided)) = runs_decided::<L>(first, second) else {
+      return;
+    };
+    let at = format!("{site}, position {i}");
+    self.refuse_non_reflexive(
+      &at,
+      first_label,
+      decided.expected(),
+      &format!("{:?}", first[i]),
+    );
+    self.refuse_non_reflexive(
+      &at,
+      second_label,
+      decided.got(),
+      &format!("{:?}", second[i]),
+    );
   }
 
   /// The kit's fundamental comparison: a cached entry is the triple (span, token, state), and a
@@ -1406,32 +1490,31 @@ where
     state_note: &str,
   ) {
     let name = self.label();
-    let (got_span, got_token, got_state) = got;
+    let (_, got_token, got_state) = got;
     // Bound rather than chained: `token()` builds a `Spanned<&T, &Span>` by value, so reading
     // through it in the assertion below would borrow from a temporary that is gone by the time
     // the message is formatted.
     let want_entry = want.token();
     let want_span: &L::Span = want_entry.span_ref();
     let want_token: &L::Token = want_entry.data();
-    // Each comparison keeps its own message and its own tag, and each is now written as an `if`
-    // rather than an `assert!` so that the reflexivity guard sits on the failure path and only
-    // there. See `refuse_non_reflexive`.
-    if got_span != want_span {
-      self.guard_entry(site, got, (want_span, want_token, want.state()));
-      panic!("{span_msg}");
-    }
-    if got_token != want_token {
-      self.guard_entry(site, got, (want_span, want_token, want.state()));
-      panic!(
+    // One comparison, one answer. `triple_compare` names the component it actually compared, and
+    // the message below is chosen from the same answer — so the reflexivity guard and the verdict
+    // cannot come to speak about different operations. Each third keeps its own message and its
+    // own tag, and the guard sits on the failure path and only there. See `refuse_non_reflexive`.
+    let want_triple = (want_span, want_token, want.state());
+    let Some((part, decided)) = triple_compare::<L>(want_triple, got) else {
+      return;
+    };
+    self.guard_entry(site, &decided, got, want_triple);
+    match part {
+      EntryPart::Span => panic!("{span_msg}"),
+      EntryPart::Token => panic!(
         "tokora cache conformance [{name} entry-token] {site}: the entry at {want_span:?} is a DIFFERENT token from the one stored there — expected {want_token:?}, got {got_token:?}. A cached entry is the triple (span, token, state); a right span with someone else's token beside it is a permuted cache, not a conforming one."
-      );
-    }
-    if got_state != want.state() {
-      self.guard_entry(site, got, (want_span, want_token, want.state()));
-      panic!(
+      ),
+      EntryPart::State => panic!(
         "tokora cache conformance [{name} entry-state] {site}: the entry at {want_span:?} carries a DIFFERENT L::State from the one stored there — expected {:?}, got {got_state:?}.{state_note}",
         want.state()
-      );
+      ),
     }
   }
 
@@ -2540,8 +2623,7 @@ where
     let second = self.peeked_entries(cache);
     if second != first {
       let site = format!("pure-peek against {state}");
-      self.guard_run(&site, "first", &first);
-      self.guard_run(&site, "second", &second);
+      self.guard_runs(&site, "first", &first, "second", &second);
       panic!(
         "tokora cache conformance [{name} pure-peek] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure. The comparison is over whole (span, token, state) entries, so a peek that is stable in its spans and unstable in the tokens or the states behind them disagrees here too."
       );
@@ -2585,8 +2667,13 @@ where
     let one_second: Option<PeekedTriple<'inp, L>> = self.peeked_one(cache);
     if one_second != one_first {
       let site = format!("pure-peek-one against {state}");
-      self.guard_run(&site, "first", one_first.as_slice());
-      self.guard_run(&site, "second", one_second.as_slice());
+      self.guard_runs(
+        &site,
+        "first",
+        one_first.as_slice(),
+        "second",
+        one_second.as_slice(),
+      );
       panic!(
         "tokora cache conformance [{name} pure-peek-one] against {state}: two peek_one() calls on an unchanged cache disagreed: {one_first:?} then {one_second:?}. `peek_one` takes &self and must be logically pure, exactly as `peek` must."
       );
@@ -2683,8 +2770,7 @@ where
     let second = self.peeked_entries_through::<W>(cache);
     if second != first {
       let site = format!("pure-peek/window {window} against {state}");
-      self.guard_run(&site, "first", &first);
-      self.guard_run(&site, "second", &second);
+      self.guard_runs(&site, "first", &first, "second", &second);
       panic!(
         "tokora cache conformance [{name} pure-peek/window {window}] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure at every window, not only at the kit's own."
       );
@@ -2765,15 +2851,24 @@ where
     let (prefix_again, appended_again) =
       self.peeked_entries_after_prefill(cache, self.prefill(cap, depth, from));
     if prefix_again != prefix_after || appended_again != appended {
+      // Either half of the condition above can be the one that fired, so both pairs are asked and
+      // the pair that agrees says nothing — which is the component-aware rule and not a
+      // convenience: a run scanned on its own answers about an entry the two runs may agree on.
       let site = format!("pure-peek/{tag} at depth {depth} against {state}");
-      for (side, run) in [
-        ("first prefix", prefix_after.as_slice()),
-        ("second prefix", prefix_again.as_slice()),
-        ("first appended", appended.as_slice()),
-        ("second appended", appended_again.as_slice()),
-      ] {
-        self.guard_run(&site, side, run);
-      }
+      self.guard_runs(
+        &site,
+        "first prefix",
+        &prefix_after,
+        "second prefix",
+        &prefix_again,
+      );
+      self.guard_runs(
+        &site,
+        "first appended",
+        &appended,
+        "second appended",
+        &appended_again,
+      );
       panic!(
         "tokora cache conformance [{name} pure-peek/{tag} at depth {depth}] against {state}: two prefilled peeks on an unchanged cache disagreed: prefix {prefix_after:?} then {prefix_again:?}, appended {appended:?} then {appended_again:?}. `peek` takes &self and must be logically pure against every shape of buffer, not only against an empty one."
       );

--- a/tokora/src/conformance/cache.rs
+++ b/tokora/src/conformance/cache.rs
@@ -436,15 +436,15 @@ where
   // caller's `L::Token` and `L::State` equalities exactly as rarely as it did before.
   let mut ranking = Ranking::new();
   let span = compare_by(EntryPart::Span.component(), want.0, got.0);
-  if let Some(hit) = ranking.settle(EntryPart::Span, span) {
+  if let Some(hit) = ranking.settle(EntryPart::Span, span.differs()) {
     return Some(hit);
   }
   let token = compare_by(EntryPart::Token.component(), want.1, got.1);
-  if let Some(hit) = ranking.settle(EntryPart::Token, token) {
+  if let Some(hit) = ranking.settle(EntryPart::Token, token.differs()) {
     return Some(hit);
   }
   let state = compare_by(EntryPart::State.component(), want.2, got.2);
-  if let Some(hit) = ranking.settle(EntryPart::State, state) {
+  if let Some(hit) = ranking.settle(EntryPart::State, state.differs()) {
     return Some(hit);
   }
   ranking.refusal()
@@ -524,13 +524,19 @@ where
 }
 
 /// [`runs_decided`] over the two halves of a prefilled peek, in buffer order, answering with the
-/// **first** half that a second peek did not reproduce.
+/// half the verdict rests on.
 ///
 /// Prefix before appended because the two halves are the two halves of one buffer in order: the
 /// first position the whole buffer diverges at is in the prefix whenever the prefix diverges at
 /// all. This is [`triple_compare`]'s "span first, always" one level up, and it costs the same
 /// thing — a cache impure in both halves is reported at the first, and the second is seen on the
 /// next run.
+///
+/// **And the order is a preference among CONCLUSIVE answers, not an unconditional first-wins.**
+/// It was `find_map`, so a prefix divergence a `NaN` decided withheld an appended divergence a
+/// span or a length had settled — round 5's finding at the composition of two whole
+/// [`Divergence`]s. [`Ranking`] is generic over what a step answers precisely so this level reads
+/// the same rule as the two below it.
 fn prefilled_purity<'r, 'inp, L>(
   prefix: (&'r [PeekedTriple<'inp, L>], &'r [PeekedTriple<'inp, L>]),
   appended: (&'r [PeekedTriple<'inp, L>], &'r [PeekedTriple<'inp, L>]),
@@ -540,15 +546,25 @@ where
   L::Token: PartialEq,
   L::State: PartialEq,
 {
-  [(PeekHalf::Prefix, prefix), (PeekHalf::Appended, appended)]
-    .into_iter()
-    .find_map(|(half, (first, second))| {
-      runs_decided::<L>(first, second).map(|decided| PrefilledPurity {
+  let mut ranking = Ranking::new();
+  for (half, (first, second)) in [(PeekHalf::Prefix, prefix), (PeekHalf::Appended, appended)] {
+    let found = runs_decided::<L>(first, second);
+    if let Some(((half, first, second), decided)) = ranking.settle((half, first, second), found) {
+      return Some(PrefilledPurity {
         half,
         first,
         second,
         decided,
-      })
+      });
+    }
+  }
+  ranking
+    .refusal()
+    .map(|((half, first, second), decided)| PrefilledPurity {
+      half,
+      first,
+      second,
+      decided,
     })
 }
 
@@ -1626,7 +1642,9 @@ where
   /// three components at once, and it is an *ordering* violation; reporting it as a token
   /// mismatch would bury the diagnosis and break every existing expectation. The token and state
   /// halves therefore only ever speak about an entry the span half has already agreed is the
-  /// right one.
+  /// right one — or about one whose span comparison the kit cannot convict on, which is the one
+  /// case [`Ranking`] moves an answer past a step, and there the span half has agreed to nothing
+  /// because it could not.
   ///
   /// `state_note` is [`RESTORE_NOTE`] at the `back()`/`pop_back` sites and [`NO_NOTE`] everywhere
   /// else.

--- a/tokora/src/conformance/cache.rs
+++ b/tokora/src/conformance/cache.rs
@@ -364,6 +364,52 @@ where
   (*tok.token().span_ref()).clone()
 }
 
+/// The first component of a cached entry that fails to compare equal to **itself**, named for a
+/// reader. `None` when all three are reflexive.
+///
+/// The cache kit's observable is the whole `(span, token, state)` triple, and two of the three are
+/// caller values the harness only asks [`PartialEq`] of — so this tier draws its verdicts from
+/// exactly the population `conformance`'s trait and partial tiers do, and needs the same guard for
+/// the same reason (#295). [`Lexer::Span`] is bounded `Ord` and so is reflexive by contract; it is
+/// scanned anyway, because a component left out of the scan is a component whose failure is
+/// reported as a cache defect.
+///
+/// See [`refuse_non_reflexive`](CacheHarness::refuse_non_reflexive).
+fn entry_non_reflexive<'inp, L>(
+  span: &L::Span,
+  token: &L::Token,
+  state: &L::State,
+) -> Option<&'static str>
+where
+  L: Lexer<'inp>,
+  L::Token: PartialEq,
+  L::State: PartialEq,
+{
+  if !super::self_equal(token) {
+    return Some("the token payload");
+  }
+  if !super::self_equal(state) {
+    return Some("the `L::State`");
+  }
+  if !super::self_equal(span) {
+    return Some("the span");
+  }
+  None
+}
+
+/// [`entry_non_reflexive`] over a whole peeked run, with the position of the offending entry —
+/// what the purity laws, which compare two runs as vectors, need to say *where*.
+fn run_non_reflexive<'inp, L>(run: &[PeekedTriple<'inp, L>]) -> Option<(usize, &'static str)>
+where
+  L: Lexer<'inp>,
+  L::Token: PartialEq,
+  L::State: PartialEq,
+{
+  run.iter().enumerate().find_map(|(i, entry)| {
+    entry_non_reflexive::<L>(&entry.0, &entry.1, &entry.2).map(|component| (i, component))
+  })
+}
+
 /// The `L::State` a peeked entry carries, whichever arm of [`Maybe`] it arrived on.
 ///
 /// [`PeekedTokenExt`] reaches the token and the span arm-blind and deliberately does not reach the
@@ -1272,6 +1318,67 @@ where
 
   // ── the entry comparison every oracle reads its answers through ─────────────────
 
+  /// Refuses to draw a cache verdict from a comparison that a value decided by failing to equal
+  /// **itself**, and returns without a word when there is nothing to refuse.
+  ///
+  /// The trait-tier twin is `conformance::refuse_non_reflexive`, and both interpolate the same
+  /// `NON_REFLEXIVE_BODY` so the diagnosis cannot come to mean one thing in one tier and
+  /// something else in the other.
+  ///
+  /// Like it, every call site reaches this **after** its own comparison has already failed, so it
+  /// can re-label a failure and can never manufacture one: a genuinely non-conforming cache whose
+  /// token and state values *are* reflexive never reaches this line and still fails the ordinary
+  /// way, with the ordinary tag.
+  fn refuse_non_reflexive(
+    &self,
+    site: &str,
+    side: &str,
+    component: Option<&'static str>,
+    rendered: &str,
+  ) {
+    let Some(component) = component else {
+      return;
+    };
+    let name = self.label();
+    panic!(
+      "tokora cache conformance [{name} non-reflexive-payload] {site}: INCONCLUSIVE — \
+       {component} of the {side} entry {rendered} is not equal to ITSELF, so the comparison that \
+       just failed was decided by the value type and not by the cache, which this kit has \
+       therefore not convicted of anything. {}",
+      super::NON_REFLEXIVE_BODY
+    )
+  }
+
+  /// The reflexivity guard for one entry comparison, asked of both sides.
+  fn guard_entry(
+    &self,
+    site: &str,
+    got: (&L::Span, &L::Token, &L::State),
+    want: (&L::Span, &L::Token, &L::State),
+  ) {
+    for (side, (span, token, state)) in [("got", got), ("expected", want)] {
+      self.refuse_non_reflexive(
+        site,
+        side,
+        entry_non_reflexive::<L>(span, token, state),
+        &format!("({span:?}, {token:?}, {state:?})"),
+      );
+    }
+  }
+
+  /// The reflexivity guard for a whole peeked run — what the purity laws, which compare two runs
+  /// as vectors rather than entry by entry, need in order to say *where*.
+  fn guard_run(&self, site: &str, side: &str, run: &[PeekedTriple<'inp, L>]) {
+    if let Some((i, component)) = run_non_reflexive::<L>(run) {
+      self.refuse_non_reflexive(
+        &format!("{site}, position {i}"),
+        side,
+        Some(component),
+        &format!("{:?}", run[i]),
+      );
+    }
+  }
+
   /// The kit's fundamental comparison: a cached entry is the triple (span, token, state), and a
   /// cache that hands one back has to hand back all three of them (#183).
   ///
@@ -1306,16 +1413,26 @@ where
     let want_entry = want.token();
     let want_span: &L::Span = want_entry.span_ref();
     let want_token: &L::Token = want_entry.data();
-    assert!(got_span == want_span, "{span_msg}");
-    assert!(
-      got_token == want_token,
-      "tokora cache conformance [{name} entry-token] {site}: the entry at {want_span:?} is a DIFFERENT token from the one stored there — expected {want_token:?}, got {got_token:?}. A cached entry is the triple (span, token, state); a right span with someone else's token beside it is a permuted cache, not a conforming one."
-    );
-    assert!(
-      got_state == want.state(),
-      "tokora cache conformance [{name} entry-state] {site}: the entry at {want_span:?} carries a DIFFERENT L::State from the one stored there — expected {:?}, got {got_state:?}.{state_note}",
-      want.state()
-    );
+    // Each comparison keeps its own message and its own tag, and each is now written as an `if`
+    // rather than an `assert!` so that the reflexivity guard sits on the failure path and only
+    // there. See `refuse_non_reflexive`.
+    if got_span != want_span {
+      self.guard_entry(site, got, (want_span, want_token, want.state()));
+      panic!("{span_msg}");
+    }
+    if got_token != want_token {
+      self.guard_entry(site, got, (want_span, want_token, want.state()));
+      panic!(
+        "tokora cache conformance [{name} entry-token] {site}: the entry at {want_span:?} is a DIFFERENT token from the one stored there — expected {want_token:?}, got {got_token:?}. A cached entry is the triple (span, token, state); a right span with someone else's token beside it is a permuted cache, not a conforming one."
+      );
+    }
+    if got_state != want.state() {
+      self.guard_entry(site, got, (want_span, want_token, want.state()));
+      panic!(
+        "tokora cache conformance [{name} entry-state] {site}: the entry at {want_span:?} carries a DIFFERENT L::State from the one stored there — expected {:?}, got {got_state:?}.{state_note}",
+        want.state()
+      );
+    }
   }
 
   /// [`assert_entry_eq`](Self::assert_entry_eq) against an **owned** entry — what `pop_front`,
@@ -2421,10 +2538,14 @@ where
     // Purity: the cache is unchanged, and a second peek reads the same.
     self.assert_resident(cache, cap, want, &format!("after peek() against {state}"));
     let second = self.peeked_entries(cache);
-    assert!(
-      second == first,
-      "tokora cache conformance [{name} pure-peek] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure. The comparison is over whole (span, token, state) entries, so a peek that is stable in its spans and unstable in the tokens or the states behind them disagrees here too."
-    );
+    if second != first {
+      let site = format!("pure-peek against {state}");
+      self.guard_run(&site, "first", &first);
+      self.guard_run(&site, "second", &second);
+      panic!(
+        "tokora cache conformance [{name} pure-peek] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure. The comparison is over whole (span, token, state) entries, so a peek that is stable in its spans and unstable in the tokens or the states behind them disagrees here too."
+      );
+    }
 
     // `peek_one` is the single-slot case: it names the front, and it names nothing where a
     // drained cache has no front left to name.
@@ -2462,10 +2583,14 @@ where
       (None, None) => {}
     }
     let one_second: Option<PeekedTriple<'inp, L>> = self.peeked_one(cache);
-    assert!(
-      one_second == one_first,
-      "tokora cache conformance [{name} pure-peek-one] against {state}: two peek_one() calls on an unchanged cache disagreed: {one_first:?} then {one_second:?}. `peek_one` takes &self and must be logically pure, exactly as `peek` must."
-    );
+    if one_second != one_first {
+      let site = format!("pure-peek-one against {state}");
+      self.guard_run(&site, "first", one_first.as_slice());
+      self.guard_run(&site, "second", one_second.as_slice());
+      panic!(
+        "tokora cache conformance [{name} pure-peek-one] against {state}: two peek_one() calls on an unchanged cache disagreed: {one_first:?} then {one_second:?}. `peek_one` takes &self and must be logically pure, exactly as `peek` must."
+      );
+    }
 
     // ── the same law against a buffer that is NOT empty ───────────────────────────
     //
@@ -2556,10 +2681,14 @@ where
       &format!("bounded-peek/window {window} against {state}"),
     );
     let second = self.peeked_entries_through::<W>(cache);
-    assert!(
-      second == first,
-      "tokora cache conformance [{name} pure-peek/window {window}] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure at every window, not only at the kit's own."
-    );
+    if second != first {
+      let site = format!("pure-peek/window {window} against {state}");
+      self.guard_run(&site, "first", &first);
+      self.guard_run(&site, "second", &second);
+      panic!(
+        "tokora cache conformance [{name} pure-peek/window {window}] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure at every window, not only at the kit's own."
+      );
+    }
   }
 
   /// Check 6's prefilled half at one prefill depth: `peek` into a buffer that already holds
@@ -2635,10 +2764,20 @@ where
     );
     let (prefix_again, appended_again) =
       self.peeked_entries_after_prefill(cache, self.prefill(cap, depth, from));
-    assert!(
-      prefix_again == prefix_after && appended_again == appended,
-      "tokora cache conformance [{name} pure-peek/{tag} at depth {depth}] against {state}: two prefilled peeks on an unchanged cache disagreed: prefix {prefix_after:?} then {prefix_again:?}, appended {appended:?} then {appended_again:?}. `peek` takes &self and must be logically pure against every shape of buffer, not only against an empty one."
-    );
+    if prefix_again != prefix_after || appended_again != appended {
+      let site = format!("pure-peek/{tag} at depth {depth} against {state}");
+      for (side, run) in [
+        ("first prefix", prefix_after.as_slice()),
+        ("second prefix", prefix_again.as_slice()),
+        ("first appended", appended.as_slice()),
+        ("second appended", appended_again.as_slice()),
+      ] {
+        self.guard_run(&site, side, run);
+      }
+      panic!(
+        "tokora cache conformance [{name} pure-peek/{tag} at depth {depth}] against {state}: two prefilled peeks on an unchanged cache disagreed: prefix {prefix_after:?} then {prefix_again:?}, appended {appended:?} then {appended_again:?}. `peek` takes &self and must be logically pure against every shape of buffer, not only against an empty one."
+      );
+    }
     self.assert_resident(
       cache,
       cap,

--- a/tokora/src/conformance/cache.rs
+++ b/tokora/src/conformance/cache.rs
@@ -266,7 +266,7 @@ use generic_arraydeque::{
 };
 use mayber::Maybe;
 
-use super::{Decided, NON_REFLEXIVE_BODY, decided_by};
+use super::{Comparison, Decided, Divergence, NON_REFLEXIVE_BODY, Ranking, compare_by, diverge};
 use crate::{
   Lexer, Slice, Source, Span, Window,
   cache::{
@@ -409,6 +409,19 @@ impl EntryPart {
 /// found a `NaN` in the token beside it refused, hiding a real cache defect behind a diagnosis
 /// nothing had established. See [`refuse_non_reflexive`](CacheHarness::refuse_non_reflexive) and
 /// [`Decided`].
+///
+/// # Why the three thirds are one ranked search and not three returns
+///
+/// It returned at the first third that differed, and "first" is a fixed order while
+/// *conclusiveness* is not: a cache that accepts a push, hands back the correct span and the
+/// correct token, and corrupts a perfectly **reflexive** `L::State` was called INCONCLUSIVE,
+/// because a `NaN` token selected the token third and the state was never examined. The state
+/// difference convicts the cache on its own and no caller equality it could not trust decided it.
+/// So an inconclusive third is retained as a fallback and the search continues into the thirds
+/// behind it — see [`Ranking`], where that rule and its cost live.
+///
+/// "Span first, always" is unchanged for every entry whose span comparison is sound, which is
+/// every entry a conforming `L::Span: Ord` produces.
 pub(super) fn triple_compare<'inp, L>(
   want: (&L::Span, &L::Token, &L::State),
   got: (&L::Span, &L::Token, &L::State),
@@ -418,44 +431,23 @@ where
   L::Token: PartialEq,
   L::State: PartialEq,
 {
-  if want.0 != got.0 {
-    return Some((
-      EntryPart::Span,
-      decided_by(EntryPart::Span.component(), want.0, got.0),
-    ));
+  // Written out rather than folded over an array, so that each third's comparison is only
+  // reached when the search is still open: an entry whose span settles it conclusively runs the
+  // caller's `L::Token` and `L::State` equalities exactly as rarely as it did before.
+  let mut ranking = Ranking::new();
+  let span = compare_by(EntryPart::Span.component(), want.0, got.0);
+  if let Some(hit) = ranking.settle(EntryPart::Span, span) {
+    return Some(hit);
   }
-  if want.1 != got.1 {
-    return Some((
-      EntryPart::Token,
-      decided_by(EntryPart::Token.component(), want.1, got.1),
-    ));
+  let token = compare_by(EntryPart::Token.component(), want.1, got.1);
+  if let Some(hit) = ranking.settle(EntryPart::Token, token) {
+    return Some(hit);
   }
-  if want.2 != got.2 {
-    return Some((
-      EntryPart::State,
-      decided_by(EntryPart::State.component(), want.2, got.2),
-    ));
+  let state = compare_by(EntryPart::State.component(), want.2, got.2);
+  if let Some(hit) = ranking.settle(EntryPart::State, state) {
+    return Some(hit);
   }
-  None
-}
-
-/// What a purity comparison over two peeked runs was decided by — the answer [`runs_decided`]
-/// gives when the two runs differ at all.
-///
-/// **Total over the ways two runs can differ, and the totality is the point.** An `Option<(usize,
-/// Decided)>` could not say "they differ, and a *length* decided it": it said `None`, which is
-/// also what it says about two runs that agree. A caller needing both answers therefore had to
-/// ask a second question — `first != second` — and compose the two by hand, and that composition
-/// is where a `bool` that does not record what fired came back one level up (#324). One
-/// comparison, one answer, consumed by the branch and by the failure path alike.
-pub(super) enum PurityDecided {
-  /// Every shared position agrees and the two runs differ in **length**.
-  ///
-  /// A count is not a comparison of caller values, so there is nothing here that could fail to
-  /// equal itself and nothing to refuse — see [`refuse_runs`](CacheHarness::refuse_runs).
-  Length,
-  /// They disagree at a position, and [`Decided`] names the component that decided it.
-  At(usize, Decided),
+  ranking.refusal()
 }
 
 /// [`triple_compare`] over two whole peeked runs: whether they differ, and when they do, **what
@@ -466,24 +458,29 @@ pub(super) enum PurityDecided {
 /// A scan of one run had neither property: it answered from an entry the two runs might well
 /// agree on, at a position the divergence is not at, and it answered at all when a length settled
 /// the verdict.
+///
+/// **The answer is `conformance`'s own [`Divergence`], not a type of this module's.** It was one:
+/// a `Length | At(usize, Decided)` pair that said exactly what `Divergence` says, written here
+/// because the trait tier's loops had not been factored yet. Two spellings of one answer are two
+/// places for the ordering between a position and a count to be decided, and this round's finding
+/// is that the ordering was wrong in every one of them — so the ranking, the length step and the
+/// answer are all [`diverge`]'s now, and the purity law reads them the way the four stream
+/// comparisons do.
 pub(super) fn runs_decided<'inp, L>(
   first: &[PeekedTriple<'inp, L>],
   second: &[PeekedTriple<'inp, L>],
-) -> Option<PurityDecided>
+) -> Option<Divergence>
 where
   L: Lexer<'inp>,
   L::Token: PartialEq,
   L::State: PartialEq,
 {
-  let diverged = first
-    .iter()
-    .zip(second)
-    .enumerate()
-    .find_map(|(i, (a, b))| {
-      triple_compare::<L>((&a.0, &a.1, &a.2), (&b.0, &b.1, &b.2))
-        .map(|(_, decided)| PurityDecided::At(i, decided))
-    });
-  diverged.or_else(|| (first.len() != second.len()).then_some(PurityDecided::Length))
+  diverge(first, second, first.len() != second.len(), |a, b| {
+    triple_compare::<L>((&a.0, &a.1, &a.2), (&b.0, &b.1, &b.2))
+      .map_or(Comparison::Equal, |(_, decided)| {
+        Comparison::Differs(decided)
+      })
+  })
 }
 
 /// Which half of a prefilled `peek`'s buffer a purity comparison was decided by: the prefix
@@ -523,7 +520,7 @@ where
   half: PeekHalf,
   first: &'r [PeekedTriple<'inp, L>],
   second: &'r [PeekedTriple<'inp, L>],
-  decided: PurityDecided,
+  decided: Divergence,
 }
 
 /// [`runs_decided`] over the two halves of a prefilled peek, in buffer order, answering with the
@@ -1474,10 +1471,16 @@ where
   /// can re-label a failure and can never manufacture one: a genuinely non-conforming cache whose
   /// token and state values *are* reflexive never reaches this line and still fails the ordinary
   /// way, with the ordinary tag.
+  /// `noun` is what the side being refused *is* — an `entry` at every comparison of a cached
+  /// triple, a `run` where a whole peeked vector was compared as one value. It is a parameter
+  /// rather than the constant it used to be because the span-valued laws draw verdicts from
+  /// values that are not entries, and a refusal that called a span vector an entry would be
+  /// describing something the comparison never held.
   fn refuse_non_reflexive(
     &self,
     site: &str,
     side: &str,
+    noun: &str,
     component: Option<&'static str>,
     rendered: &str,
   ) {
@@ -1487,7 +1490,7 @@ where
     let name = self.label();
     panic!(
       "tokora cache conformance [{name} non-reflexive-payload] {site}: INCONCLUSIVE — \
-       {component} of the {side} entry {rendered} is not equal to ITSELF, so the comparison that \
+       {component} of the {side} {noun} {rendered} is not equal to ITSELF, so the comparison that \
        just failed was decided by the value type and not by the cache, which this kit has \
        therefore not convicted of anything. {}",
       NON_REFLEXIVE_BODY
@@ -1510,10 +1513,25 @@ where
       self.refuse_non_reflexive(
         site,
         side,
+        "entry",
         component,
         &format!("({span:?}, {token:?}, {state:?})"),
       );
     }
+  }
+
+  /// The reflexivity guard for one **single-component** comparison — the span-valued laws, where
+  /// there is no triple to rank and the component that decided it is the only one there was.
+  ///
+  /// These comparisons draw a cache verdict from `L::Span` and `L::Offset`, both bounded `Ord`.
+  /// Round 4 read that bound as settling them and left them unguarded; `Ord` is a marker and
+  /// nothing checks its promise, so a caller whose span equality answers `false` to everything
+  /// — itself included — got a red naming their cache. The same lying `L::Span` reaches
+  /// [`triple_compare`] three lines further down at several of these sites and is refused there,
+  /// which is the whole argument: one answer to a broken total equality, not two.
+  fn guard_component(&self, site: &str, noun: &str, decided: &Decided, expected: &str, got: &str) {
+    self.refuse_non_reflexive(site, "expected", noun, decided.expected(), expected);
+    self.refuse_non_reflexive(site, "got", noun, decided.got(), got);
   }
 
   /// The reflexivity refusal for a purity comparison over two whole peeked runs, asked about the
@@ -1521,30 +1539,32 @@ where
   ///
   /// **It does not compare.** The comparison ran at the branch that reached here and its answer
   /// arrives as an argument, so the refusal cannot come to be asked about a pair the verdict does
-  /// not rest on. A [`PurityDecided::Length`] refuses nothing: a count consults no caller
+  /// not rest on. A [`Divergence::Count`] refuses nothing: a count consults no caller
   /// equality, so there is nothing there that could fail to equal itself.
   fn refuse_runs(
     &self,
     site: &str,
-    decided: &PurityDecided,
+    decided: &Divergence,
     first_label: &str,
     first: &[PeekedTriple<'inp, L>],
     second_label: &str,
     second: &[PeekedTriple<'inp, L>],
   ) {
-    let PurityDecided::At(i, decided) = decided else {
+    let Divergence::At(i, decided) = decided else {
       return;
     };
     let at = format!("{site}, position {i}");
     self.refuse_non_reflexive(
       &at,
       first_label,
+      "entry",
       decided.expected(),
       &format!("{:?}", first[*i]),
     );
     self.refuse_non_reflexive(
       &at,
       second_label,
+      "entry",
       decided.got(),
       &format!("{:?}", second[*i]),
     );
@@ -2065,23 +2085,45 @@ where
     // The two span accessors, against the spans of the entries the kit is tracking. These are
     // span-valued by signature — `front_span`/`back_span` return `&L::Span` and nothing else — so
     // the entry comparison has no purchase here; it belongs to the `front()`/`back()` reads below.
+    // The reflexivity guard does apply, and for the reason it applies to every other verdict this
+    // kit draws: see `guard_component`.
     let want_front_span = want.first().map(span_of::<L>);
     let want_back_span = want.last().map(span_of::<L>);
     match (want_front_span.as_ref(), cache.front_span()) {
-      (Some(expected), Some(got)) => assert!(
-        got == expected,
-        "tokora cache conformance [{name} fifo-append] {when}: front is {got:?}, expected the OLDEST resident entry {expected:?}"
-      ),
+      (Some(expected), Some(got)) => {
+        if let Comparison::Differs(decided) = compare_by(Decided::SPAN, expected, got) {
+          self.guard_component(
+            &format!("{when} front_span()"),
+            "entry",
+            &decided,
+            &format!("{expected:?}"),
+            &format!("{got:?}"),
+          );
+          panic!(
+            "tokora cache conformance [{name} fifo-append] {when}: front is {got:?}, expected the OLDEST resident entry {expected:?}"
+          );
+        }
+      }
       (None, None) => {}
       (a, b) => panic!(
         "tokora cache conformance [{name} fifo-append] {when}: front presence disagrees — expected {a:?}, got {b:?}"
       ),
     }
     match (want_back_span.as_ref(), cache.back_span()) {
-      (Some(expected), Some(got)) => assert!(
-        got == expected,
-        "tokora cache conformance [{name} fifo-append] {when}: back is {got:?}, expected the NEWEST resident entry {expected:?}. `push_back` appends after every resident entry."
-      ),
+      (Some(expected), Some(got)) => {
+        if let Comparison::Differs(decided) = compare_by(Decided::SPAN, expected, got) {
+          self.guard_component(
+            &format!("{when} back_span()"),
+            "entry",
+            &decided,
+            &format!("{expected:?}"),
+            &format!("{got:?}"),
+          );
+          panic!(
+            "tokora cache conformance [{name} fifo-append] {when}: back is {got:?}, expected the NEWEST resident entry {expected:?}. `push_back` appends after every resident entry."
+          );
+        }
+      }
       (None, None) => {}
       (a, b) => panic!(
         "tokora cache conformance [{name} fifo-append] {when}: back presence disagrees — expected {a:?}, got {b:?}"
@@ -2135,10 +2177,18 @@ where
         " `pop_front` removes the OLDEST resident entry.",
       );
       let got = span_of::<L>(&popped);
-      assert!(
-        viewed == got,
-        "tokora cache conformance [{name} order]: front() viewed {viewed:?} but pop_front() removed {got:?}; they must name the same entry"
-      );
+      if let Comparison::Differs(decided) = compare_by(Decided::SPAN, &viewed, &got) {
+        self.guard_component(
+          &format!("order pop_front #{i} against the front() that named it"),
+          "entry",
+          &decided,
+          &format!("{viewed:?}"),
+          &format!("{got:?}"),
+        );
+        panic!(
+          "tokora cache conformance [{name} order]: front() viewed {viewed:?} but pop_front() removed {got:?}; they must name the same entry"
+        );
+      }
     }
     // Presence-only, and the law: after a full drain there is no entry left for a pop to return,
     // so absence is the whole observable. (Documented exception — see `checked_push`.)
@@ -2166,10 +2216,18 @@ where
         " `pop_back` removes the NEWEST resident entry. The input layer drops an abandoned continuation's entries with a run of pop_back calls, so a pop_back that is not newest-first drops the wrong tokens.",
       );
       let got = span_of::<L>(&popped);
-      assert!(
-        viewed == got,
-        "tokora cache conformance [{name} order]: back() viewed {viewed:?} but pop_back() removed {got:?}; they must name the same entry"
-      );
+      if let Comparison::Differs(decided) = compare_by(Decided::SPAN, &viewed, &got) {
+        self.guard_component(
+          &format!("order pop_back #{i} against the back() that named it"),
+          "entry",
+          &decided,
+          &format!("{viewed:?}"),
+          &format!("{got:?}"),
+        );
+        panic!(
+          "tokora cache conformance [{name} order]: back() viewed {viewed:?} but pop_back() removed {got:?}; they must name the same entry"
+        );
+      }
     }
     // Presence-only, and the law — see the `pop_front` twin above.
     assert!(
@@ -2231,10 +2289,20 @@ where
           // The prepend law itself, before the generic residency check: the entry just pushed
           // must be the one `front` names.
           match cache.front_span() {
-            Some(got) => assert!(
-              *got == span,
-              "tokora cache conformance [{name} push-front]: after push_front the front is {got:?}, expected the token just pushed, {span:?}. `push_front` places a token BEFORE every resident entry."
-            ),
+            Some(got) => {
+              if let Comparison::Differs(decided) = compare_by(Decided::SPAN, &span, got) {
+                self.guard_component(
+                  &format!("push_front #{i} against the front() it must have become"),
+                  "entry",
+                  &decided,
+                  &format!("{span:?}"),
+                  &format!("{got:?}"),
+                );
+                panic!(
+                  "tokora cache conformance [{name} push-front]: after push_front the front is {got:?}, expected the token just pushed, {span:?}. `push_front` places a token BEFORE every resident entry."
+                );
+              }
+            }
             None => panic!(
               "tokora cache conformance [{name} push-front]: front() is empty right after an accepted push_front"
             ),
@@ -2732,11 +2800,21 @@ where
     // that violates it and nothing else, which `DUPLICATING_PEEK` in `cache_tests.rs` now is: the
     // right count, the right first entry, the front served `bound` times over.
     let first_spans: Vec<L::Span> = first.iter().map(|e| e.0.clone()).collect();
-    assert!(
-      first_spans == want_spans[..bound],
-      "tokora cache conformance [{name} bounded-peek] against {state}: peek() appended {first_spans:?}, expected the resident prefix OLDEST FIRST {:?}",
-      &want_spans[..bound]
-    );
+    if let Comparison::Differs(decided) =
+      compare_by(Decided::SPANS, &want_spans[..bound], &first_spans[..])
+    {
+      self.guard_component(
+        &format!("bounded-peek against {state}"),
+        "run",
+        &decided,
+        &format!("{:?}", &want_spans[..bound]),
+        &format!("{first_spans:?}"),
+      );
+      panic!(
+        "tokora cache conformance [{name} bounded-peek] against {state}: peek() appended {first_spans:?}, expected the resident prefix OLDEST FIRST {:?}",
+        &want_spans[..bound]
+      );
+    }
     // …and the other two thirds of every entry the run just landed. The vector comparison above
     // is the ORDER law and keeps its own wording; this is the entry law (#183), and it is what
     // separates a `peek` that serves the right run from one that serves the right spans with
@@ -2887,11 +2965,21 @@ where
       first.len()
     );
     let first_spans: Vec<L::Span> = first.iter().map(|e| e.0.clone()).collect();
-    assert!(
-      first_spans == want_spans[..bound],
-      "tokora cache conformance [{name} bounded-peek/window {window}] against {state}: peek() appended {first_spans:?}, expected the resident prefix OLDEST FIRST {:?}. A cache may not read W::CAPACITY and answer differently for it.",
-      &want_spans[..bound]
-    );
+    if let Comparison::Differs(decided) =
+      compare_by(Decided::SPANS, &want_spans[..bound], &first_spans[..])
+    {
+      self.guard_component(
+        &format!("bounded-peek/window {window} against {state}"),
+        "run",
+        &decided,
+        &format!("{:?}", &want_spans[..bound]),
+        &format!("{first_spans:?}"),
+      );
+      panic!(
+        "tokora cache conformance [{name} bounded-peek/window {window}] against {state}: peek() appended {first_spans:?}, expected the resident prefix OLDEST FIRST {:?}. A cache may not read W::CAPACITY and answer differently for it.",
+        &want_spans[..bound]
+      );
+    }
     self.assert_peeked_run_eq(
       &first,
       &want[..bound],
@@ -2940,10 +3028,20 @@ where
     let prefilled_bound = remaining_at_prefill.min(want.len());
     let (prefix_after, appended) = self.peeked_entries_after_prefill(cache, prefill);
     let prefix_spans: Vec<L::Span> = prefix_after.iter().map(|e| e.0.clone()).collect();
-    assert!(
-      prefix_spans == prefill_spans,
-      "tokora cache conformance [{name} bounded-peek/{tag} at depth {depth}] against {state}: peek() changed the {depth} entr(ies) already in the buffer ahead of it — got {prefix_spans:?}, expected them untouched, {prefill_spans:?}. `peek` appends BEHIND what the buffer already holds; it neither overwrites nor reorders it."
-    );
+    if let Comparison::Differs(decided) =
+      compare_by(Decided::SPANS, &prefill_spans[..], &prefix_spans[..])
+    {
+      self.guard_component(
+        &format!("bounded-peek/{tag} at depth {depth} untouched prefix against {state}"),
+        "run",
+        &decided,
+        &format!("{prefill_spans:?}"),
+        &format!("{prefix_spans:?}"),
+      );
+      panic!(
+        "tokora cache conformance [{name} bounded-peek/{tag} at depth {depth}] against {state}: peek() changed the {depth} entr(ies) already in the buffer ahead of it — got {prefix_spans:?}, expected them untouched, {prefill_spans:?}. `peek` appends BEHIND what the buffer already holds; it neither overwrites nor reorders it."
+      );
+    }
     self.assert_peeked_run_eq(
       &prefix_after,
       &prefill_want,
@@ -2955,11 +3053,23 @@ where
       appended.len()
     );
     let appended_spans: Vec<L::Span> = appended.iter().map(|e| e.0.clone()).collect();
-    assert!(
-      appended_spans == want_spans[..prefilled_bound],
-      "tokora cache conformance [{name} bounded-peek/{tag} at depth {depth}] against {state}: peek() appended {appended_spans:?}, expected the resident prefix OLDEST FIRST {:?}. Every resident entry is served, whatever the buffer already holds: `peek` is not entitled to decide the caller has one of them already.",
-      &want_spans[..prefilled_bound]
-    );
+    if let Comparison::Differs(decided) = compare_by(
+      Decided::SPANS,
+      &want_spans[..prefilled_bound],
+      &appended_spans[..],
+    ) {
+      self.guard_component(
+        &format!("bounded-peek/{tag} at depth {depth} against {state}"),
+        "run",
+        &decided,
+        &format!("{:?}", &want_spans[..prefilled_bound]),
+        &format!("{appended_spans:?}"),
+      );
+      panic!(
+        "tokora cache conformance [{name} bounded-peek/{tag} at depth {depth}] against {state}: peek() appended {appended_spans:?}, expected the resident prefix OLDEST FIRST {:?}. Every resident entry is served, whatever the buffer already holds: `peek` is not entitled to decide the caller has one of them already.",
+        &want_spans[..prefilled_bound]
+      );
+    }
     self.assert_peeked_run_eq(
       &appended,
       &want[..prefilled_bound],
@@ -3215,12 +3325,28 @@ where
   fn assert_span_at(&self, cache: &C, want: &[L::Span], state: &str) {
     let name = self.label();
     match (want.first(), want.last(), cache.span()) {
-      (Some(first), Some(last), Some(combined)) => assert!(
-        combined.start_ref() == first.start_ref() && combined.end_ref() == last.end_ref(),
-        "tokora cache conformance [{name} combined-span] against {state}: span() is {combined:?}, expected {:?}..{:?} — the front entry's start to the back entry's end",
-        first.start_ref(),
-        last.end_ref()
-      ),
+      // Two endpoint comparisons and ONE answer: `&&` over them is a `bool` that does not record
+      // which end fired, which is the shape #324 kept finding one level up. `Comparison::ranked`
+      // consumes both, ranks them, and hands the refusal below the endpoint the verdict rests on.
+      (Some(first), Some(last), Some(combined)) => {
+        if let Comparison::Differs(decided) = Comparison::ranked(&[
+          &|| compare_by(Decided::OFFSET, first.start_ref(), combined.start_ref()),
+          &|| compare_by(Decided::OFFSET, last.end_ref(), combined.end_ref()),
+        ]) {
+          self.guard_component(
+            &format!("combined-span against {state}"),
+            "span",
+            &decided,
+            &format!("{:?}..{:?}", first.start_ref(), last.end_ref()),
+            &format!("{combined:?}"),
+          );
+          panic!(
+            "tokora cache conformance [{name} combined-span] against {state}: span() is {combined:?}, expected {:?}..{:?} — the front entry's start to the back entry's end",
+            first.start_ref(),
+            last.end_ref()
+          );
+        }
+      }
       (None, None, None) => {}
       (_, _, got) => panic!(
         "tokora cache conformance [{name} combined-span] against {state}: span() presence disagrees with the {} resident entr(ies) it should be built from — got {got:?}",
@@ -3655,12 +3781,22 @@ where
     // CACHE_CALL_CENSUS: compared-in-place
     let overflow: Vec<_> = cache.push_many(corpus.into_iter()).collect();
     let overflow_spans: Vec<L::Span> = overflow.iter().map(span_of::<L>).collect();
-    assert!(
-      overflow_spans == all_spans[cap..],
-      "tokora cache conformance [{name} push-many]: push_many()'s overflow iterator yielded {overflow_spans:?}, expected exactly the {} refused entr(ies) {:?}, unchanged and in order",
-      all_spans.len() - cap,
-      &all_spans[cap..]
-    );
+    if let Comparison::Differs(decided) =
+      compare_by(Decided::SPANS, &all_spans[cap..], &overflow_spans[..])
+    {
+      self.guard_component(
+        "push-many overflow run",
+        "run",
+        &decided,
+        &format!("{:?}", &all_spans[cap..]),
+        &format!("{overflow_spans:?}"),
+      );
+      panic!(
+        "tokora cache conformance [{name} push-many]: push_many()'s overflow iterator yielded {overflow_spans:?}, expected exactly the {} refused entr(ies) {:?}, unchanged and in order",
+        all_spans.len() - cap,
+        &all_spans[cap..]
+      );
+    }
     // "Unchanged" is the whole entry: a `push_many` that hands back the right spans in the right
     // order with re-associated tokens or states behind them has changed what it refused (#183).
     for (i, (got, expected)) in overflow.iter().zip(&all[cap..]).enumerate() {

--- a/tokora/src/conformance/cache_tests.rs
+++ b/tokora/src/conformance/cache_tests.rs
@@ -2119,10 +2119,30 @@ fn cache_kit_catches_a_peek_that_drains_only_on_the_prefilled_path() {
   run_queue::<PREFILL_DRAINS_RESIDENCY>();
 }
 
+/// The prefilled purity law end to end, and #324's control 3 on a real cache: this defect leaves
+/// the prefix it was handed untouched and appends one entry fewer on every call after the first,
+/// so the APPENDED half is what decided — by a length, which consults no caller equality. The
+/// failure has to name that half. A repair that always blamed the prefix would keep the tag and
+/// misattribute the defect.
 #[test]
-#[should_panic(expected = "pure-peek/prefilled")]
 fn cache_kit_catches_a_peek_that_is_impure_only_on_the_prefilled_path() {
-  run_queue::<PREFILL_IMPURE_PEEK>();
+  let panicked = std::panic::catch_unwind(run_queue::<PREFILL_IMPURE_PEEK>)
+    .expect_err("an impure prefilled peek must be caught");
+  let msg = panicked
+    .downcast_ref::<String>()
+    .expect("the kit panics with a formatted message");
+  assert!(
+    msg.contains("pure-peek/prefilled"),
+    "the prefilled purity law owns this defect, got: {msg}"
+  );
+  assert!(
+    msg.contains("disagreed in the run it appended behind that prefix"),
+    "the appended half is what this cache failed to reproduce, got: {msg}"
+  );
+  assert!(
+    !msg.contains("the prefix the buffer already held"),
+    "the prefix is handed back untouched here and must not be blamed, got: {msg}"
+  );
 }
 
 #[test]

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -2717,7 +2717,7 @@ fn check_integration<'inp, L>(
   // refills cost.
   //
   // Wrapping is invisible to the comparison: `Bud<'inp, L>` carries L's `Token`, `Span` and error
-  // type, so the streams collected here are the same type as `raw` below.
+  // type, so the streams collected here are the same type as `raw_tokens` below.
   let units = src.slice(..).map(|s| s.len()).unwrap_or(0);
   let tally = LexTally::new(
     idx,

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -113,30 +113,40 @@
 //! contract), surfaced loudly. The kit never mutates the lexer's behavior; it only
 //! observes and asserts.
 //!
-//! **And it never reports a failure that is a fact about a payload type rather than about the
-//! lexer.** Value equality is drawn from caller [`PartialEq`] implementations, and `PartialEq`
-//! promises symmetry and transitivity but **not** reflexivity: a payload holding an `f64` that can
-//! be `NaN` is not equal to itself. Every comparison any tier draws a verdict from — the two in
-//! the trait tier, the two in the partial tier, the committed-token and raised-error ones in the
-//! integration tier, and the entry and purity comparisons in [`cache`] — therefore answers with
-//! the **component
-//! that decided it**, and asks, once it has already failed, whether *that* operation is equal to
-//! itself. A side whose is not gets a refusal tagged `non-reflexive-payload` naming the component
-//! and the obligation, instead of a conformance verdict whose expected-vs-got renders identically
-//! on both sides (#295). The obligation itself is unchanged and is the caller's: such a type
-//! hand-writes the impl that says what equality means for it.
+//! **The kit reports exactly what it established — no more and no less.** Those are one rule with
+//! two halves, and both halves are enforced in the machinery every comparison is built from
+//! rather than at the sites that draw verdicts from it.
 //!
-//! **The converse is the same rule, and it is what a `bool` could not express.** A comparison
-//! settled by something other than a caller's `PartialEq` is reported directly and terminally: a
-//! difference at the **discriminant** — an item that is a lexer error on one side and a committed
-//! token on the other — or at a component bounded to a *total* equality, or a difference in item
-//! **count**, consults no partial equality at all, so there is nothing there to refuse. Answering
-//! `false` and then scanning the whole item for a non-reflexive value asked a different question
-//! from the one the comparison had asked, and it hid the truncation nonconformance the partial
-//! tier exists to report behind a refusal saying the kit had convicted the lexer of nothing. The
-//! kit never reports an identity it did not check, and it never withholds a verdict it did
-//! establish; those are one rule, and the comparison's own answer is where it is enforced
-//! rather than remembered.
+//! **No more: it never reports a failure that is a fact about a value type rather than about the
+//! lexer.** Every verdict here rests on an equality the kit does not own. [`PartialEq`] promises
+//! symmetry and transitivity but **not** reflexivity, so a payload holding an `f64` that can be
+//! `NaN` is not equal to itself — and [`Eq`] and [`Ord`] *do* promise reflexivity while nothing
+//! checks the promise, so a `Kind`, a span, an offset or a source slice can break it too. The
+//! guarded population is therefore **every** equality any tier draws a verdict from, and it is
+//! defined by construction rather than by a list: a comparison is built by `compare_by`, its
+//! answer names the **component that decided it**, and building it is the only way to reach either
+//! a verdict or a refusal. Once such a comparison has already failed, the kit asks whether *that*
+//! operation is equal to itself, and a side whose is not gets a refusal tagged
+//! `non-reflexive-payload` naming the component and the obligation, instead of a verdict whose
+//! expected-vs-got renders identically on both sides (#295). The obligation is unchanged and is
+//! the caller's: such a type hand-writes the impl that says what equality means for it.
+//!
+//! **No less: it never withholds a verdict it did establish.** Some differences rest on no caller
+//! equality at all — a difference at the **discriminant** (an item that is a lexer error on one
+//! side and a committed token on the other) or in item **count** — and a component comparison over
+//! two values that each equal themselves is sound too, which is the ordinary case and the whole
+//! population of honest failures. All of those are **conclusive**, and a conclusive difference
+//! outranks an inconclusive one wherever both are available: the first inconclusive difference is
+//! retained as a fallback while the search continues into the remaining components of the item,
+//! the later positions of the stream, and the item count, and it is reported only if nothing
+//! conclusive is found anywhere. `Ranking` carries that rule and the argument for it.
+//!
+//! Both halves were learned from the same failure, one direction at a time. Answering `false` and
+//! then scanning the whole item for a non-reflexive value asked a different question from the one
+//! the comparison had asked, and hid the truncation nonconformance the partial tier exists to
+//! report behind a refusal saying the kit had convicted the lexer of nothing. Stopping at the
+//! first difference reached hid a decisive item count behind a `NaN` at position 0, and a
+//! corrupted `L::State` behind a `NaN` in the token beside it.
 
 pub mod cache;
 pub mod emitter;
@@ -1390,14 +1400,21 @@ where
   ///
   /// Discriminant, then the components bounded to a *total* equality ([`kind`](Token::kind) is
   /// `Eq`, the span is `Ord`), then the payload, whose [`PartialEq`] promises no reflexivity.
-  /// Two sides can differ in several components at once, and this names the first one in that
-  /// order: a divergence a total equality can settle is never attributed to a partial one, and
-  /// the answer is a true statement about a comparison that really failed either way.
+  /// Two sides can differ in several components at once, and this names the first **conclusive**
+  /// one in that order — the first whose own comparison the kit can convict on. A divergence a
+  /// sound total equality settles is therefore never attributed to a partial one, and the answer
+  /// is a true statement about a comparison that really failed either way.
+  ///
+  /// The word doing the work is *conclusive*. `Eq` promises reflexivity and nothing checks the
+  /// promise, so a `Kind` or a span can be as unusable as a `NaN`; when the earlier component is
+  /// the unusable one, [`Ranking`] holds it as a fallback and the payload behind it gets to
+  /// speak. That is not the order failing — it is the order applying to the evidence the kit
+  /// actually has.
   ///
   /// Nothing about **correctness** rests on the order, which is the point of stating it. The
-  /// refusal asks its question of whichever component is named, so it fires exactly when the
-  /// operation that produced the verdict is unsound — under this order or any other. What the
-  /// order buys is a *diagnosis*: the strongest evidence available gets to speak.
+  /// refusal asks its question of whichever component is named, so it fires exactly when nothing
+  /// the kit could convict on was found — under this order or any other. What the order buys is a
+  /// *diagnosis*: the strongest evidence available gets to speak.
   ///
   /// # Semantically, never by rendering
   ///
@@ -1862,11 +1879,13 @@ fn assert_partial_prefix_of<'inp, L>(
 /// diagnosis means or on what it asks the caller to do about it.
 const NON_REFLEXIVE_BODY: &str = "`PartialEq` is partial: it promises symmetry and transitivity, \
    never reflexivity, and a payload holding an `f64` that can be `NaN` is the case that reaches \
-   this kit. Such a type must hand-write the impl that says what equality means for it — \
-   `Harness::run_partial`'s documentation has carried that obligation since the value comparison \
-   landed. Until it does, this kit cannot tell a value that will not compare from an \
-   implementation that diverges, and the failure it would otherwise report renders expected and \
-   got identically.";
+   this kit. `Eq` and `Ord` DO promise it, and nothing checks that promise — so a component \
+   bounded to a TOTAL equality reaches this line too, and a refusal naming one reports a broken \
+   total-equality promise rather than the partial one a payload carries. Either way, such a type \
+   must hand-write the impl that says what equality means for it — `Harness::run_partial`'s \
+   documentation has carried that obligation since the value comparison landed. Until it does, \
+   this kit cannot tell a value that will not compare from an implementation that diverges, and \
+   the failure it would otherwise report renders expected and got identically.";
 
 /// Whether `value` compares equal to **itself**.
 ///
@@ -1913,13 +1932,22 @@ impl Comparison {
   fn ranked(steps: &[&dyn Fn() -> Self]) -> Self {
     let mut ranking = Ranking::new();
     for step in steps {
-      if let Some(((), decided)) = ranking.settle((), step()) {
+      if let Some(((), decided)) = ranking.settle((), step().differs()) {
         return Self::Differs(decided);
       }
     }
     ranking
       .refusal()
       .map_or(Self::Equal, |((), decided)| Self::Differs(decided))
+  }
+
+  /// The difference, when there is one — [`Ranking`]'s input shape. `Equal` and "nothing to
+  /// rank" are the same fact, and this is where the two spellings meet.
+  const fn differs(self) -> Option<Decided> {
+    match self {
+      Self::Equal => None,
+      Self::Differs(decided) => Some(decided),
+    }
   }
 }
 
@@ -1986,41 +2014,70 @@ where
 /// *conclusive* difference speaks — `triple_compare`'s "span first, always" is unchanged for
 /// every entry whose span comparison is sound. Ranking only ever moves an answer past a step the
 /// kit could not have drawn a verdict from.
-struct Ranking<T> {
+struct Ranking<T, D = Decided> {
   /// The first inconclusive difference seen, and what the caller calls the step that produced
   /// it. Never overwritten: "first" is in the site's own declared order.
-  inconclusive: Option<(T, Decided)>,
+  inconclusive: Option<(T, D)>,
 }
 
-impl<T> Ranking<T> {
+impl<T, D> Ranking<T, D>
+where
+  D: Conclusive,
+{
   /// A search with nothing found yet.
   const fn new() -> Self {
     Self { inconclusive: None }
   }
 
-  /// Feeds the next comparison, tagged with whatever the caller needs back to render its own
-  /// message — which component of an entry, which position in a stream, or `()` where the
-  /// [`Decided`] already says everything.
+  /// Feeds the next step's answer, tagged with whatever the caller needs back to render its own
+  /// message — which component of an entry, which position in a stream, which half of a buffer,
+  /// or `()` where the answer already says everything.
   ///
   /// `Some` ends the search: this step is conclusive and outranks anything held. `None` means
-  /// keep going, either because the step agreed or because it is now the fallback.
-  fn settle(&mut self, tag: T, comparison: Comparison) -> Option<(T, Decided)> {
-    let Comparison::Differs(decided) = comparison else {
-      return None;
-    };
-    if decided.is_conclusive() {
-      return Some((tag, decided));
+  /// keep going, either because the step found nothing or because it is now the fallback.
+  fn settle(&mut self, tag: T, answer: Option<D>) -> Option<(T, D)> {
+    let found = answer?;
+    if found.is_conclusive() {
+      return Some((tag, found));
     }
     if self.inconclusive.is_none() {
-      self.inconclusive = Some((tag, decided));
+      self.inconclusive = Some((tag, found));
     }
     None
   }
 
   /// The answer once every step has run without one of them being conclusive: the retained
-  /// fallback, which is what the refusal is drawn from, or `None` when the two sides agreed.
-  fn refusal(self) -> Option<(T, Decided)> {
+  /// fallback, which is what the refusal is drawn from, or `None` when nothing differed.
+  fn refusal(self) -> Option<(T, D)> {
     self.inconclusive
+  }
+}
+
+/// What [`Ranking`] needs of a step's answer, and the only thing it needs: whether the kit may
+/// convict on it.
+///
+/// A trait rather than a method on [`Decided`] because the rule composes. A whole stream's
+/// [`Divergence`] is a step of a bigger search — the two arms of one integration observation, the
+/// two halves of one prefilled peek — and those compositions were the two extra instances round
+/// 5's header audit turned up. One rule, one place, three levels.
+trait Conclusive {
+  /// Whether this difference rests on no equality the kit cannot trust.
+  fn is_conclusive(&self) -> bool;
+}
+
+impl Conclusive for Decided {
+  fn is_conclusive(&self) -> bool {
+    Self::is_conclusive(self)
+  }
+}
+
+impl Conclusive for Divergence {
+  fn is_conclusive(&self) -> bool {
+    match self {
+      // A count is the kit's own `len()`; see [`Divergence::Count`].
+      Self::Count => true,
+      Self::At(_, decided) => decided.is_conclusive(),
+    }
   }
 }
 
@@ -2055,7 +2112,7 @@ where
 {
   let mut ranking = Ranking::new();
   for i in 0..expected.len().min(got.len()) {
-    if let Some((i, decided)) = ranking.settle(i, compare(&expected[i], &got[i])) {
+    if let Some((i, decided)) = ranking.settle(i, compare(&expected[i], &got[i]).differs()) {
       return Some(Divergence::At(i, decided));
     }
   }
@@ -2195,8 +2252,26 @@ where
 /// that decided it. Shared by the four item-comparing sites so the rule cannot come to hold at
 /// one of them and not at another.
 fn refuse_decided(idx: usize, op: &str, at: &str, decided: &Decided, expected: &str, got: &str) {
-  refuse_non_reflexive(idx, op, at, "expected", decided.expected(), expected);
-  refuse_non_reflexive(idx, op, at, "got", decided.got(), got);
+  refuse_component(idx, op, at, "item", decided, expected, got);
+}
+
+/// [`refuse_decided`] where the two sides are not items: one `slice()` against the source, one
+/// `read_frontier()` reading against the next, one span endpoint against another.
+///
+/// `noun` is what the side being refused *is*, and it is a parameter rather than the constant it
+/// used to be because these comparisons draw verdicts from values no item holds. A refusal that
+/// called a source slice an "item" would be describing something the comparison never had.
+fn refuse_component(
+  idx: usize,
+  op: &str,
+  at: &str,
+  noun: &str,
+  decided: &Decided,
+  expected: &str,
+  got: &str,
+) {
+  refuse_non_reflexive(idx, op, at, "expected", noun, decided.expected(), expected);
+  refuse_non_reflexive(idx, op, at, "got", noun, decided.got(), got);
 }
 
 /// Refuses to draw a conformance verdict from a comparison that a value decided by failing to
@@ -2204,11 +2279,21 @@ fn refuse_decided(idx: usize, op: &str, at: &str, decided: &Decided, expected: &
 ///
 /// # Why the kit refuses instead of reporting the failure it found
 ///
-/// Every tier here decides pass/fail with `PartialEq` on values it does not own — the token, the
-/// lexer's error payload, and in the cache kit the lexer state. Reflexivity is the one law of an
-/// equivalence relation that `PartialEq` does not promise, and when a payload breaks it the
-/// comparison fails for a reason that is a **fact about the payload type** and not about the
-/// lexer, the cache or the input layer under test.
+/// Every tier here decides pass/fail with equality on values it does not own — the token, the
+/// lexer's error payload, the cache kit's lexer state, and, no differently, the token's `Kind`,
+/// the span, the source slice, the span offsets and the read frontier. Reflexivity is the one law
+/// of an equivalence relation that `PartialEq` does not promise, and when a payload breaks it the
+/// comparison fails for a reason that is a **fact about the value type** and not about the lexer,
+/// the cache or the input layer under test.
+///
+/// The components bounded to a *total* equality reach this line too, and that is the round-5
+/// residue rather than an oversight. `Eq` and `Ord` do promise reflexivity — but they are markers,
+/// nothing verifies the promise, and a caller who breaks one has broken a **stronger** contract,
+/// not put themselves outside this kit's reach. Refusing there says the same true thing: the
+/// comparison that failed was the caller's and the kit convicted nobody. The tag stays
+/// `non-reflexive-payload` for every component, because the tag names the *diagnosis* #295
+/// established and every cell and downstream grep keys on it; the component the refusal names is
+/// what says whether a total or a partial promise was the one broken.
 ///
 /// The failure that produced is not merely mislabelled, it is unreadable: a final partial drain
 /// compares a stream against itself, so `expected` and `got` are the same item, and the
@@ -2241,6 +2326,11 @@ fn refuse_decided(idx: usize, op: &str, at: &str, decided: &Decided, expected: &
 /// genuinely non-conforming lexer whose payloads *are* reflexive never reaches this line and
 /// still fails the ordinary way, with the ordinary tag.
 ///
+/// Since round 5 it is reached later still: only once [`Ranking`] has run every remaining step of
+/// the same search — the rest of the item, the rest of the stream, the item count, the other arm
+/// — and found nothing the kit could convict on. A refusal is now the answer of last resort in
+/// the strict sense, and that is the second half of the same rule.
+///
 /// # This is not a relaxation of the contract
 ///
 /// The obligation predates the report: [`Harness::run_partial`]'s documentation has said since
@@ -2252,6 +2342,7 @@ fn refuse_non_reflexive(
   op: &str,
   at: &str,
   side: &str,
+  noun: &str,
   component: Option<&'static str>,
   rendered: &str,
 ) {
@@ -2260,8 +2351,8 @@ fn refuse_non_reflexive(
   };
   panic!(
     "tokora conformance [input #{idx} non-reflexive-payload] {op} {at}: INCONCLUSIVE — \
-     {component} of the {side} item {rendered} is not equal to ITSELF, so the comparison that \
-     just failed was decided by the payload type and not by the lexer, which this kit has \
+     {component} of the {side} {noun} {rendered} is not equal to ITSELF, so the comparison that \
+     just failed was decided by the value type and not by the lexer, which this kit has \
      therefore not convicted of anything. {NON_REFLEXIVE_BODY}"
   )
 }
@@ -2346,7 +2437,9 @@ where
   ///
   /// Both are bounded to a *total* equality (the span is `Ord`, the slice is `Eq`), which is why
   /// they are asked before either payload: a divergence one of them can settle is never
-  /// attributed to a `PartialEq` that promises no reflexivity.
+  /// attributed to a `PartialEq` that promises no reflexivity. "Can settle" is
+  /// [`Ranking`]'s test and not the bound — a span whose own `Ord` will not equal itself settles
+  /// nothing, and the payload behind it is then what speaks.
   fn compare_shared(&self, other: &Self) -> Comparison {
     Comparison::ranked(&[
       &|| compare_by(Decided::SPAN, &self.span, &other.span),
@@ -2433,10 +2526,11 @@ where
       Some(from_source) => {
         if let Comparison::Differs(decided) = compare_by(Decided::SLICE, &from_source, &slice) {
           let at = format!("position {pos}");
-          refuse_decided(
+          refuse_component(
             idx,
             "span/slice-coherence",
             &at,
+            "reading",
             &decided,
             &format!("{from_source:?}"),
             &format!("{slice:?}"),
@@ -2459,10 +2553,11 @@ where
       let again = lexer.read_frontier();
       if let Comparison::Differs(decided) = compare_by(Decided::FRONTIER, &frontier, &again) {
         let at = format!("position {pos}");
-        refuse_decided(
+        refuse_component(
           idx,
           "read-frontier",
           &at,
+          "reading",
           &decided,
           &format!("{frontier:?}"),
           &format!("{again:?}"),
@@ -2475,10 +2570,11 @@ where
     let after = lexer.span();
     if let Comparison::Differs(decided) = compare_by(Decided::SPAN, &span, &after) {
       let at = format!("position {pos}");
-      refuse_decided(
+      refuse_component(
         idx,
         "read-frontier",
         &at,
+        "reading",
         &decided,
         &format!("{span:?}"),
         &format!("{after:?}"),
@@ -2615,10 +2711,11 @@ where
   for probe in 0..3 {
     let again = lexer.span();
     if let Comparison::Differs(decided) = compare_by(Decided::SPAN, &span, &again) {
-      refuse_decided(
+      refuse_component(
         idx,
         "span-survives-exhaustion",
         "after exhaustion",
+        "reading",
         &decided,
         &format!("{span:?}"),
         &format!("{again:?}"),
@@ -2737,10 +2834,11 @@ where
     // An empty stream is gap-free tiling of an empty source; a non-empty source with
     // no tokens leaves the whole thing untiled.
     if let Comparison::Differs(decided) = compare_by(Decided::OFFSET, &zero, &src_len) {
-      refuse_decided(
+      refuse_component(
         idx,
         "lossless",
         "source length",
+        "endpoint",
         &decided,
         &format!("{zero:?}"),
         &format!("{src_len:?}"),
@@ -2754,10 +2852,11 @@ where
 
   let first_start = first.span.start_ref();
   if let Comparison::Differs(decided) = compare_by(Decided::OFFSET, &zero, first_start) {
-    refuse_decided(
+    refuse_component(
       idx,
       "lossless",
       "position 0",
+      "endpoint",
       &decided,
       &format!("{zero:?}"),
       &format!("{first_start:?}"),
@@ -2773,10 +2872,11 @@ where
     let start = item.span.start_ref().clone();
     if let Comparison::Differs(decided) = compare_by(Decided::OFFSET, &prev_end, &start) {
       let at = format!("position {i}");
-      refuse_decided(
+      refuse_component(
         idx,
         "lossless",
         &at,
+        "endpoint",
         &decided,
         &format!("{prev_end:?}"),
         &format!("{start:?}"),
@@ -2790,10 +2890,11 @@ where
   }
 
   if let Comparison::Differs(decided) = compare_by(Decided::OFFSET, &src_len, &prev_end) {
-    refuse_decided(
+    refuse_component(
       idx,
       "lossless",
       "source end",
+      "endpoint",
       &decided,
       &format!("{src_len:?}"),
       &format!("{prev_end:?}"),
@@ -3120,6 +3221,17 @@ const RAISED: Arm = Arm {
 
 /// Asserts two schedules observed the input layer identically — the same committed tokens and the
 /// same raised lexer errors, both by value.
+///
+/// # The two arms are ONE verdict, and the ranking runs across them
+///
+/// They were two `assert` calls in a fixed order, and the second could not be reached until the
+/// first had returned — so an inconclusive divergence on the committed arm withheld a conclusive
+/// one on the raised-error arm, which is round 5's finding one level above the position/count
+/// ordering [`diverge`] repairs. Both arms carry the same tag and describe one schedule's one
+/// observation of the layer; the header splits them into two sequences for a documented reason
+/// about *where* an error sits, not because they are two laws. So [`Ranking`] composes here too,
+/// over whole [`Divergence`]s rather than over components, and the committed arm is still run and
+/// still reported first whenever it settles anything conclusively.
 fn assert_observed_eq<'inp, L>(
   idx: usize,
   sched: &str,
@@ -3130,17 +3242,28 @@ fn assert_observed_eq<'inp, L>(
   L::Token: PartialEq,
   <L::Token as Token<'inp>>::Error: PartialEq,
 {
-  assert_stream_eq::<L>(idx, sched, COMMITTED, &expected.tokens, &got.tokens);
-  assert_stream_eq::<L>(idx, sched, RAISED, &expected.errors, &got.errors);
+  let mut ranking = Ranking::new();
+  for (arm, expected_arm, got_arm) in [
+    (COMMITTED, &expected.tokens, &got.tokens),
+    (RAISED, &expected.errors, &got.errors),
+  ] {
+    let found = diverge(
+      expected_arm,
+      got_arm,
+      expected_arm.len() != got_arm.len(),
+      |a, b| a.compare(b),
+    );
+    if let Some(((arm, e, g), divergence)) = ranking.settle((arm, expected_arm, got_arm), found) {
+      report_stream_divergence::<L>(idx, sched, arm, e, g, &divergence);
+    }
+  }
+  if let Some(((arm, e, g), divergence)) = ranking.refusal() {
+    report_stream_divergence::<L>(idx, sched, arm, e, g, &divergence);
+  }
 }
 
-/// Asserts two item streams are identical, with position context.
-///
-/// The comparison is [`StreamItem::compare`] — the same component-aware, reflexivity-aware path
-/// the partial tier draws its verdicts from, and the reason this tier has no comparison of its
-/// own. It replaced a local `(kind, span)` one, which was both a projection of the item (#269 at
-/// this tier) and a second implementation of a rule that already existed: the two could drift,
-/// and the older one already had, since it could not see the arm at all.
+/// Asserts one item stream matches another, with position context — the single-arm form, for the
+/// raw-lex cross-check that has no second arm to be ranked against.
 fn assert_stream_eq<'inp, L>(
   idx: usize,
   sched: &str,
@@ -3152,11 +3275,39 @@ fn assert_stream_eq<'inp, L>(
   L::Token: PartialEq,
   <L::Token as Token<'inp>>::Error: PartialEq,
 {
-  match diverge(expected, got, expected.len() != got.len(), |a, b| {
+  if let Some(divergence) = diverge(expected, got, expected.len() != got.len(), |a, b| {
     a.compare(b)
   }) {
-    None => {}
-    Some(Divergence::At(i, decided)) => {
+    report_stream_divergence::<L>(idx, sched, arm, expected, got, &divergence);
+  }
+}
+
+/// Reports one arm's [`Divergence`], with position context. Never returns.
+///
+/// The comparison behind it is [`StreamItem::compare`] — the same component-aware,
+/// reflexivity-aware path the partial tier draws its verdicts from, and the reason this tier has
+/// no comparison of its own. It replaced a local `(kind, span)` one, which was both a projection
+/// of the item (#269 at this tier) and a second implementation of a rule that already existed:
+/// the two could drift, and the older one already had, since it could not see the arm at all.
+///
+/// Reporting is separated from comparing because [`assert_observed_eq`] ranks the two arms
+/// against each other before either of them may speak — see its own docs.
+fn report_stream_divergence<'inp, L>(
+  idx: usize,
+  sched: &str,
+  arm: Arm,
+  expected: &[StreamItem<'inp, L>],
+  got: &[StreamItem<'inp, L>],
+  divergence: &Divergence,
+) -> !
+where
+  L: Lexer<'inp>,
+  L::Token: PartialEq,
+  <L::Token as Token<'inp>>::Error: PartialEq,
+{
+  match divergence {
+    Divergence::At(i, decided) => {
+      let i = *i;
       // `Token::Kind` is bounded `Eq`, `Lexer::Span` is bounded `Ord` and the two payloads are
       // bounded only `PartialEq`, so a refusal here is drawn from whichever of those decided it —
       // exactly as it is at every other comparison this kit draws a verdict from. Guarding some
@@ -3168,7 +3319,7 @@ fn assert_stream_eq<'inp, L>(
         idx,
         &op,
         &at,
-        &decided,
+        decided,
         &expected[i].describe(),
         &got[i].describe(),
       );
@@ -3180,7 +3331,7 @@ fn assert_stream_eq<'inp, L>(
         got[i].describe()
       );
     }
-    Some(Divergence::Count) => panic!(
+    Divergence::Count => panic!(
       "tokora conformance [input #{idx} integration/{sched}] {} stream length differs: straight-lex has {}, schedule has {}",
       arm.noun,
       expected.len(),

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -46,8 +46,17 @@
 //! **Integration tier** — driving an `Input` session through the machinery itself over
 //! a fixed set of named, deterministic save/peek/drain/restore schedules
 //! (`peek-heavy`, `save-early-restore-late`, `drain-then-restore-across-cache`,
-//! `nested-savepoints`) and requiring the committed token stream to equal the
-//! straight-lex stream. No randomness — the schedules are enumerated.
+//! `nested-savepoints`) and requiring every schedule to observe the layer the way the straight
+//! drain did: the same **committed tokens** and the same **raised lexer errors**, both by value.
+//! The straight drain's tokens are additionally required to equal the raw-lex tokens. No
+//! randomness — the schedules are enumerated.
+//!
+//! The two arms are compared as two sequences rather than as one interleaved stream, and the
+//! error arm is not cross-checked against the raw lexer. Both are facts about the input layer,
+//! not weaker claims: a `peek` reports a refusal the moment it lexes the region, so where an
+//! error sits *between* two committed tokens varies by schedule on a conforming lexer; and the
+//! layer reports each refused region once, so a lexer that errors repeatedly over one span is
+//! conforming while the layer raises one error. See `check_integration`.
 //!
 //! **Partial-input tier** (`run_partial`, a separate entry point for
 //! `usize`-offset `str` / `[u8]` sources) — driving the input in
@@ -108,8 +117,9 @@
 //! lexer.** Value equality is drawn from caller [`PartialEq`] implementations, and `PartialEq`
 //! promises symmetry and transitivity but **not** reflexivity: a payload holding an `f64` that can
 //! be `NaN` is not equal to itself. Every comparison any tier draws a verdict from — the two in
-//! the trait tier, the two in the partial tier, the committed-stream one in the integration tier,
-//! and the entry and purity comparisons in [`cache`] — therefore answers with the **component
+//! the trait tier, the two in the partial tier, the committed-token and raised-error ones in the
+//! integration tier, and the entry and purity comparisons in [`cache`] — therefore answers with
+//! the **component
 //! that decided it**, and asks, once it has already failed, whether *that* operation is equal to
 //! itself. A side whose is not gets a refusal tagged `non-reflexive-payload` naming the component
 //! and the obligation, instead of a conformance verdict whose expected-vs-got renders identically
@@ -143,7 +153,7 @@ use std::{format, rc::Rc, string::String, vec, vec::Vec};
 use crate::{
   Lexer, ReadFrontier, Slice, Source, Span, Token,
   cache::DefaultCache,
-  emitter::{Emitter, Silent},
+  emitter::Emitter,
   error::{Incomplete, MaybeIncomplete, token::UnexpectedTokenOf},
   input::{Complete, Cursor, Input, InputRef, Partial},
   span::Spanned,
@@ -516,7 +526,7 @@ where
   <L::Token as Token<'inp>>::Kind: PartialEq + core::fmt::Debug,
   // Semantic equality on the compared values. Since 0.10.0 `run` asks for these two as well, so
   // what separates the tiers is the three above and nothing about equality. See
-  // `PartialItem::compare` for why a `Debug` rendering cannot stand in, and `run_partial`'s own
+  // `StreamItem::compare` for why a `Debug` rendering cannot stand in, and `run_partial`'s own
   // docs for who pays.
   L::Token: PartialEq,
   <L::Token as Token<'inp>>::Error: PartialEq,
@@ -1297,8 +1307,9 @@ fn lex_attempt_ceiling(drains: usize, budget: usize) -> AttemptCeiling {
 
 /// The emitter error the partial check surfaces: the input layer builds it from the frontier
 /// [`Incomplete`] (via [`SurfaceIncomplete`](crate::input::SurfaceIncomplete)), and it is the only
-/// thing that reaches the `Err` channel — [`PartialRecorder`] never rejects a diagnostic. The
+/// thing that reaches the `Err` channel — [`ItemRecorder`] never rejects a diagnostic. The
 /// check never inspects the payload, only that `next` returned `Err` at the frontier.
+#[derive(Debug)]
 enum PartialProbe {
   Incomplete,
 }
@@ -1317,15 +1328,22 @@ impl MaybeIncomplete for PartialProbe {
   }
 }
 
-/// One item of the sequence the partial tier compares — the unit chunked equivalence is a
-/// statement *about*.
+/// One item of a committed stream — the unit **both** tiers that drive an `Input` compare, the
+/// partial one and the integration one.
 ///
 /// A committed **token** and a **lexer error** are both items, because the input layer lexes bytes
 /// and then either commits a token or refuses the region and reports it. Truncation can turn one
 /// into the other, and a comparison over tokens alone cannot see that: a refusal leaves no trace
 /// in the token stream at all. So the error is an item here, and the prefix property is asked of
 /// the interleaved sequence.
-enum PartialItem<'inp, L>
+///
+/// The integration tier holds the same values in the same enum, and reached them a release later:
+/// it reduced every committed token to `(kind, span)` and discarded the `L::Token` its drain loop
+/// already had in hand, which is #269's projection surviving at the one tier neither #269 nor
+/// #295 touched. The two tiers differ in *how* they sequence the arms and not in what an item is
+/// or in how two of them are compared — see [`check_integration`] for the sequencing difference
+/// and why it is a property of the input layer rather than of this type.
+enum StreamItem<'inp, L>
 where
   L: Lexer<'inp>,
 {
@@ -1338,11 +1356,11 @@ where
   /// AST changed. The token is `Clone`, so keeping it costs a clone per item in a test kit.
   Token(L::Token, L::Span),
   /// A lexer error the input layer raised over bytes it lexed and refused: its span and the
-  /// **payload itself** — see [`PartialRecorder`] for what that does and does not assert.
+  /// **payload itself** — see [`ItemRecorder`] for what that does and does not assert.
   LexerError(L::Span, <L::Token as Token<'inp>>::Error),
 }
 
-impl<'inp, L> Clone for PartialItem<'inp, L>
+impl<'inp, L> Clone for StreamItem<'inp, L>
 where
   L: Lexer<'inp>,
 {
@@ -1354,7 +1372,7 @@ where
   }
 }
 
-impl<'inp, L> PartialItem<'inp, L>
+impl<'inp, L> StreamItem<'inp, L>
 where
   L: Lexer<'inp>,
 {
@@ -1457,18 +1475,24 @@ where
   }
 }
 
-/// The shared, ordered log both partial-tier drains append to: [`PartialRecorder`] pushes each
+/// The shared, ordered log both partial-tier drains append to: [`ItemRecorder`] pushes each
 /// lexer error the input layer reports, the drain loop pushes each token `next` hands back, and
 /// because the layer reports an error during the very `next` call that goes on to find the
 /// following token, the vector ends up being the interleaved item stream in production order.
-type PartialLog<'inp, L> = Rc<RefCell<Vec<PartialItem<'inp, L>>>>;
+type StreamLog<'inp, L> = Rc<RefCell<Vec<StreamItem<'inp, L>>>>;
 
-/// The emitter the partial tier drives, and the reason it is not [`Silent`].
+/// The emitter **both** `Input`-driving tiers run under, and the reason neither is [`Silent`].
 ///
 /// `Silent` discards every lexer error, which made the whole error arm invisible to chunked
 /// equivalence: a lexer could refuse a region on a truncated buffer and tokenize the same region
 /// once the missing bytes arrived, and the check saw an empty token list on one side and a token
 /// on the other — a legal *prefix*, and green.
+///
+/// The integration tier ran under `Silent` for one release longer, and the same sentence applies
+/// to it with "truncated buffer" replaced by "schedule": a refusal raised by the straight drain
+/// and not by `peek-heavy` — or raised by both with a payload that moved — left the two token
+/// streams identical, so the whole error arm of the committed stream was outside every one of
+/// that tier's five comparisons. See [`check_integration`].
 ///
 /// # What it compares, and what it deliberately does not
 ///
@@ -1497,16 +1521,16 @@ type PartialLog<'inp, L> = Rc<RefCell<Vec<PartialItem<'inp, L>>>>;
 /// properties a comparison key has to have, and `Debug` has neither: it is not injective, so a
 /// payload that really does move can render identically and pass; and it is not stable, so a
 /// payload rendering an address or a counter reds on a conforming lexer. See
-/// [`PartialItem::compare`] for the full argument and for what the bound on
+/// [`StreamItem::compare`] for the full argument and for what the bound on
 /// [`run_partial`](Harness::run_partial) buys.
-struct PartialRecorder<'inp, L>
+struct ItemRecorder<'inp, L>
 where
   L: Lexer<'inp>,
 {
-  log: PartialLog<'inp, L>,
+  log: StreamLog<'inp, L>,
 }
 
-impl<'inp, L> Emitter<'inp, L> for PartialRecorder<'inp, L>
+impl<'inp, L> Emitter<'inp, L> for ItemRecorder<'inp, L>
 where
   L: Lexer<'inp>,
 {
@@ -1520,7 +1544,7 @@ where
     self
       .log
       .borrow_mut()
-      .push(PartialItem::LexerError(span, payload));
+      .push(StreamItem::LexerError(span, payload));
     Ok(())
   }
 
@@ -1533,9 +1557,11 @@ where
   }
 
   /// A recording emitter owes the log the same rollback discipline a collecting one does, so the
-  /// mark is the log's length and a rewind truncates to it. Both drains here are straight forward
-  /// drains and never save or restore, so nothing calls this today; implementing it means a later
-  /// schedule that does backtrack cannot silently accumulate phantom items.
+  /// mark is the log's length and a rewind truncates to it. The partial tier's two drains are
+  /// straight forward drains and never save or restore, so this was written for a schedule that
+  /// did not exist yet; three of the integration tier's five now do exactly that, and the
+  /// discipline is what makes their error streams comparable at all — a restore that rewinds the
+  /// dedup watermark without rewinding the log would leave every re-lexed refusal recorded twice.
   fn checkpoint(&mut self) -> u64 {
     self.log.borrow().len() as u64
   }
@@ -1545,8 +1571,14 @@ where
   }
 }
 
-/// The partial-check context: a [`PartialRecorder`] over [`PartialProbe`] and the default cache.
-type PartialConfCtx<'inp, L> = (PartialRecorder<'inp, L>, DefaultCache<'inp, L>);
+/// The context both `Input`-driving tiers parse under: an [`ItemRecorder`] over [`PartialProbe`]
+/// and the default cache.
+///
+/// One alias for both, because the tiers differ in the input's *completeness mode* and in nothing
+/// the context carries. [`PartialProbe`] is uninhabited on the integration tier — its only
+/// constructor is `From<Incomplete>`, which a [`Complete`](crate::input::Complete) input never
+/// raises — so a `next()` there still cannot fail, exactly as it could not under [`Silent`].
+type RecordingCtx<'inp, L> = (ItemRecorder<'inp, L>, DefaultCache<'inp, L>);
 
 /// Seeds the state every drive in this module starts from: the caller's lexer state under the
 /// tier's shared [`LexTally`].
@@ -1573,14 +1605,14 @@ fn partial_stream<'inp, L>(
   is_final: bool,
   budget: usize,
   idx: usize,
-) -> (Vec<PartialItem<'inp, Bud<'inp, L>>>, bool)
+) -> (Vec<StreamItem<'inp, Bud<'inp, L>>>, bool)
 where
   L: Lexer<'inp>,
   L::State: Clone,
 {
-  let log: PartialLog<'inp, Bud<'inp, L>> = Rc::new(RefCell::new(Vec::new()));
+  let log: StreamLog<'inp, Bud<'inp, L>> = Rc::new(RefCell::new(Vec::new()));
   let context = crate::input::InputContext::new(
-    PartialRecorder {
+    ItemRecorder {
       log: Rc::clone(&log),
     },
     DefaultCache::<'inp, Bud<'inp, L>>::default(),
@@ -1589,7 +1621,7 @@ where
   let mut input = Input::<
     'inp,
     Bud<'inp, L>,
-    PartialConfCtx<'inp, Bud<'inp, L>>,
+    RecordingCtx<'inp, Bud<'inp, L>>,
     (),
     Partial,
   >::with_state_and_context(src, state, context);
@@ -1607,7 +1639,7 @@ where
     match ir.next() {
       Ok(Some(spanned)) => {
         let (span, tok) = spanned.into_components();
-        log.borrow_mut().push(PartialItem::Token(tok, span));
+        log.borrow_mut().push(StreamItem::Token(tok, span));
       }
       Ok(None) => break false,
       Err(_) => break true,
@@ -1624,14 +1656,14 @@ fn complete_stream<'inp, L>(
   tally: &Rc<LexTally>,
   budget: usize,
   idx: usize,
-) -> Vec<PartialItem<'inp, Bud<'inp, L>>>
+) -> Vec<StreamItem<'inp, Bud<'inp, L>>>
 where
   L: Lexer<'inp>,
   L::State: Clone,
 {
-  let log: PartialLog<'inp, Bud<'inp, L>> = Rc::new(RefCell::new(Vec::new()));
+  let log: StreamLog<'inp, Bud<'inp, L>> = Rc::new(RefCell::new(Vec::new()));
   let context = crate::input::InputContext::new(
-    PartialRecorder {
+    ItemRecorder {
       log: Rc::clone(&log),
     },
     DefaultCache::<'inp, Bud<'inp, L>>::default(),
@@ -1640,7 +1672,7 @@ where
   let mut input = Input::<
     'inp,
     Bud<'inp, L>,
-    PartialConfCtx<'inp, Bud<'inp, L>>,
+    RecordingCtx<'inp, Bud<'inp, L>>,
     (),
     Complete,
   >::with_state_and_context(src, state, context);
@@ -1657,7 +1689,7 @@ where
     {
       Some(spanned) => {
         let (span, tok) = spanned.into_components();
-        log.borrow_mut().push(PartialItem::Token(tok, span));
+        log.borrow_mut().push(StreamItem::Token(tok, span));
       }
       None => break,
     }
@@ -1744,8 +1776,8 @@ where
 fn assert_partial_stream_eq<'inp, L>(
   idx: usize,
   k: usize,
-  expected: &[PartialItem<'inp, L>],
-  got: &[PartialItem<'inp, L>],
+  expected: &[StreamItem<'inp, L>],
+  got: &[StreamItem<'inp, L>],
 ) where
   L: Lexer<'inp>,
   <L::Token as Token<'inp>>::Kind: PartialEq + core::fmt::Debug,
@@ -1792,8 +1824,8 @@ fn assert_partial_stream_eq<'inp, L>(
 fn assert_partial_prefix_of<'inp, L>(
   idx: usize,
   k: usize,
-  expected: &[PartialItem<'inp, L>],
-  got: &[PartialItem<'inp, L>],
+  expected: &[StreamItem<'inp, L>],
+  got: &[StreamItem<'inp, L>],
 ) where
   L: Lexer<'inp>,
   <L::Token as Token<'inp>>::Kind: PartialEq + core::fmt::Debug,
@@ -2079,22 +2111,17 @@ impl<'inp, L> Item<'inp, L>
 where
   L: Lexer<'inp>,
 {
-  /// The token kind (for a token) or `None` (for an error).
-  fn kind(&self) -> Option<<L::Token as Token<'inp>>::Kind> {
-    self.item.as_ref().ok().map(Token::kind)
-  }
-
   /// Whether two items agree on discriminant, **value**, span and slice — and, when they do not,
   /// **which of those decided it**.
   ///
-  /// The components are consulted in [`PartialItem::compare`]'s order and for its reason, with
+  /// The components are consulted in [`StreamItem::compare`]'s order and for its reason, with
   /// the slice — bounded [`Eq`], another total promise — between the span and the payload.
   ///
   /// # Semantically, never by rendering
   ///
   /// This compared `format!("{err:?}")` on the error arm, and the token's
   /// [`kind`](Token::kind) alone on the token arm, until 0.10.0 — and both halves reported an
-  /// identity the kit had not checked (#269). The argument is [`PartialItem::compare`]'s,
+  /// identity the kit had not checked (#269). The argument is [`StreamItem::compare`]'s,
   /// verbatim, and it had already been made there for the partial tier:
   ///
   /// - `Debug` is not **injective**, so two distinct error payloads may render identically — a
@@ -2119,7 +2146,7 @@ where
   {
     match (&self.item, &other.item) {
       (Ok(a), Ok(b)) => {
-        // The kind is compared as well as the token, for [`PartialItem::compare`]'s reason: the
+        // The kind is compared as well as the token, for [`StreamItem::compare`]'s reason: the
         // two are independent caller code, and a `PartialEq` coarser than the classification the
         // parser sees is exactly what this comparison stands between.
         let (ka, kb) = (a.kind(), b.kind());
@@ -2523,40 +2550,96 @@ where
   }
 }
 
-/// The parse context the integration tier drives the input machinery under: a
-/// [`Silent`] emitter (so a lexer error never aborts a run) over the default cache.
-type ConfCtx<'inp, L> = (
-  Silent<<<L as Lexer<'inp>>::Token as Token<'inp>>::Error>,
-  DefaultCache<'inp, L>,
-);
-
-/// Builds a fresh `Input` session over `src` and hands its [`InputRef`] to `f`.
-fn drive<'inp, L, R>(
-  src: &'inp L::Source,
-  tally: &Rc<LexTally>,
-  f: impl FnOnce(&mut InputRef<'inp, '_, Bud<'inp, L>, ConfCtx<'inp, Bud<'inp, L>>, ()>) -> R,
-) -> R
+/// One integration schedule's observation of the input layer: the **committed token** stream it
+/// drained and the **lexer errors** the layer raised underneath it, both as [`StreamItem`]s and
+/// both compared by value.
+///
+/// Two vectors rather than one interleaved log, and that is a fact about the input layer rather
+/// than a weaker claim. The layer emits a refusal the moment it *lexes* the region — a
+/// `peek` that fills the cache past the drain position reports the errors it finds there
+/// immediately, so a peek-and-stop caller never loses them (see the input layer's
+/// `emit_lexer_error_deduped`). The interleaving is therefore schedule-dependent **by design**:
+/// on `"a?b"` the straight drain records `token, error, token` and `peek-heavy` records
+/// `error, token, token`, and both are conforming. What is *not* schedule-dependent is either
+/// sequence taken on its own — the dedup watermark makes the recorded refusals strictly
+/// increasing in span end under every schedule, and a restore rewinds the watermark and the log
+/// together. Comparing the interleaving would red a conforming lexer, which is the failure
+/// direction this module refuses to trade for reach.
+struct Observed<'inp, L>
 where
   L: Lexer<'inp>,
 {
+  /// The committed tokens `next()` handed back, in drain order.
+  tokens: Vec<StreamItem<'inp, L>>,
+  /// The lexer errors the layer raised, in the order it raised them.
+  errors: Vec<StreamItem<'inp, L>>,
+}
+
+/// Builds a fresh `Input` session over `src`, hands its [`InputRef`] to `f`, and returns `f`'s
+/// value beside the lexer errors the layer raised while it ran.
+///
+/// The errors come back from the emitter rather than from `f` because `f` cannot see them: the
+/// layer commits or refuses on its own, and a refusal is reported to the emitter and leaves no
+/// trace in what `next()` hands back. That is the whole reason [`Silent`](crate::emitter::Silent)
+/// was the wrong choice here — a discarded arm is not an arm a schedule comparison can check.
+fn drive<'inp, L, R>(
+  src: &'inp L::Source,
+  tally: &Rc<LexTally>,
+  f: impl FnOnce(&mut InputRef<'inp, '_, Bud<'inp, L>, RecordingCtx<'inp, Bud<'inp, L>>, ()>) -> R,
+) -> (R, Vec<StreamItem<'inp, Bud<'inp, L>>>)
+where
+  L: Lexer<'inp>,
+{
+  let log: StreamLog<'inp, Bud<'inp, L>> = Rc::new(RefCell::new(Vec::new()));
   let context = crate::input::InputContext::new(
-    Silent::<<L::Token as Token<'inp>>::Error>::new(),
+    ItemRecorder {
+      log: Rc::clone(&log),
+    },
     DefaultCache::<'inp, Bud<'inp, L>>::default(),
   );
   let state = seeded::<L>(src, tally);
   let mut input =
-    Input::<'inp, Bud<'inp, L>, ConfCtx<'inp, Bud<'inp, L>>, ()>::with_state_and_context(
+    Input::<'inp, Bud<'inp, L>, RecordingCtx<'inp, Bud<'inp, L>>, ()>::with_state_and_context(
       src, state, context,
     );
-  let mut input_ref = input.as_ref();
-  f(&mut input_ref)
+  let out = {
+    let mut input_ref = input.as_ref();
+    f(&mut input_ref)
+  };
+  let errors = core::mem::take(&mut *log.borrow_mut());
+  (out, errors)
 }
 
-/// Drives `next()` to exhaustion, collecting the committed (kind, span) token stream.
+/// One integration schedule, run: [`drive`] with a drain that collects the committed tokens, both
+/// arms returned together.
+fn observe<'inp, L>(
+  src: &'inp L::Source,
+  tally: &Rc<LexTally>,
+  f: impl FnOnce(
+    &mut InputRef<'inp, '_, Bud<'inp, L>, RecordingCtx<'inp, Bud<'inp, L>>, ()>,
+  ) -> Vec<StreamItem<'inp, Bud<'inp, L>>>,
+) -> Observed<'inp, Bud<'inp, L>>
+where
+  L: Lexer<'inp>,
+{
+  let (tokens, errors) = drive::<L, _>(src, tally, f);
+  Observed { tokens, errors }
+}
+
+/// Drives `next()` to exhaustion, collecting the committed token stream — **the tokens
+/// themselves**, never a projection of them.
+///
+/// This collected `(kind, span)` until 0.11.0, on streams whose `L::Token` values `next()` had
+/// just handed over: the kind is a projection, so a payload could move between two schedules of
+/// the same input while the kind, the span and the item count all held still, and the tier that
+/// exists to compare the committed stream reported them equal. That is #269's defect at the one
+/// tier #269 did not reach — see [`StreamItem::compare`] for the argument, which is unchanged.
+/// Retention is free here: `next()` yields the token owned, [`Token`] is bounded `Clone`, and the
+/// pair being replaced was itself built by cloning the span.
 fn drain_all<'inp, L>(
-  input_ref: &mut InputRef<'inp, '_, L, ConfCtx<'inp, L>, ()>,
+  input_ref: &mut InputRef<'inp, '_, L, RecordingCtx<'inp, L>, ()>,
   budget: usize,
-) -> Vec<(<L::Token as Token<'inp>>::Kind, L::Span)>
+) -> Vec<StreamItem<'inp, L>>
 where
   L: Lexer<'inp>,
 {
@@ -2565,13 +2648,10 @@ where
     if out.len() > budget {
       panic!("tokora conformance integration: next() exceeded the budget of {budget} tokens");
     }
-    match input_ref
-      .next()
-      .expect("the conformance kit's Silent emitter never returns Err")
-    {
+    match input_ref.next().expect(NEVER_ERRS) {
       Some(spanned) => {
         let (span, tok) = spanned.into_components();
-        out.push((tok.kind(), span));
+        out.push(StreamItem::Token(tok, span));
       }
       None => break,
     }
@@ -2579,8 +2659,30 @@ where
   out
 }
 
+/// The `expect` every integration drain carries. [`ItemRecorder`] answers `Ok` on every door, and
+/// its [`PartialProbe`] error has no constructor a [`Complete`](crate::input::Complete) input can
+/// reach — see [`RecordingCtx`].
+const NEVER_ERRS: &str = "the conformance kit's recording emitter never returns Err";
+
 /// Integration tier: the committed stream from each named schedule must equal the
-/// straight-lex stream, and the straight stream must equal the raw-lex tokens.
+/// straight-lex stream, and the straight stream must equal the raw-lex items.
+///
+/// **Both arms, both compared by value.** A committed token contributes the token itself and a
+/// raised refusal contributes its payload, which is the module header's rule for every tier —
+/// and until 0.11.0 this tier kept neither. It reduced each token to `(kind, span)` and ran under
+/// [`Silent`], so the token arm was compared through a projection and the error arm was not
+/// compared at all. See [`drain_all`] for the first half and [`ItemRecorder`] for the second.
+///
+/// The two arms are compared as two sequences rather than as one interleaved stream. That is
+/// [`Observed`]'s statement and it is a property of the input layer: a `peek` reports the
+/// refusals it finds while filling the cache immediately, so where an error sits *between* two
+/// tokens is schedule-dependent on a conforming lexer, while each sequence on its own is not.
+///
+/// The arms also differ in **what they can be compared against**. The token stream is checked
+/// both against the raw lexer and across the schedules; the error stream is checked across the
+/// schedules only, because the layer deduplicates a refusal per region and the raw lexer does
+/// not, so the two sequences are legitimately different lengths. The cross-check that would have
+/// asserted otherwise was written, run, and removed by a positive cell.
 fn check_integration<'inp, L>(
   idx: usize,
   src: &'inp L::Source,
@@ -2588,6 +2690,11 @@ fn check_integration<'inp, L>(
   budget: usize,
 ) where
   L: Lexer<'inp>,
+  // The same two `run` already asks for, reached through `StreamItem::compare` — this tier adds
+  // no obligation of its own. Retaining the values costs no bound at all: [`Token`] is bounded
+  // `Clone` and [`Token::Error`] is bounded `Clone`, both by the trait.
+  L::Token: PartialEq,
+  <L::Token as Token<'inp>>::Error: PartialEq,
 {
   use generic_arraydeque::typenum::U3;
 
@@ -2601,8 +2708,8 @@ fn check_integration<'inp, L>(
   // Sized for five schedules; the per-drain multiple carries the re-lexing their restores and peek
   // refills cost.
   //
-  // Wrapping is invisible to the comparison: `Bud<'inp, L>` carries L's `Token` and `Span`, so the
-  // streams collected here are the same type as `raw_tokens` below.
+  // Wrapping is invisible to the comparison: `Bud<'inp, L>` carries L's `Token`, `Span` and error
+  // type, so the streams collected here are the same type as `raw` below.
   let units = src.slice(..).map(|s| s.len()).unwrap_or(0);
   let tally = LexTally::new(
     idx,
@@ -2613,81 +2720,85 @@ fn check_integration<'inp, L>(
   );
 
   // The straight-lex reference: `next()` to exhaustion, no backtracking.
-  let straight = drive::<L, _>(src, &tally, |ir| drain_all::<Bud<'inp, L>>(ir, budget));
+  let straight = observe::<L>(src, &tally, |ir| drain_all::<Bud<'inp, L>>(ir, budget));
 
-  // Cross-check: the input layer's `next()` stream must equal the raw-lex tokens
-  // (errors are skipped by `next()`, so filter the reference to its Ok items).
-  let raw_tokens: Vec<(<L::Token as Token<'inp>>::Kind, L::Span)> = reference
+  // Cross-check: the input layer's committed TOKEN stream must equal the raw-lex tokens.
+  //
+  // The token arm only, and the error arm is left out on purpose rather than forgotten. Raw
+  // `lex()` errors and the refusals the layer raises are not the same sequence and are not
+  // supposed to be: the layer reports each refused *region* exactly once, keyed on the error
+  // span's end against a high-water mark (`emit_lexer_error_deduped`), so a lexer that errors
+  // eighty times over one span is conforming and the layer raises one. Asking for equality here
+  // would red it — the in-tree `RepeatErrLexer` is exactly that lexer, and it is a positive cell.
+  // What the dedup does NOT vary with is the schedule, which is where the error arm is compared
+  // below.
+  let raw_tokens: Vec<StreamItem<'inp, Bud<'inp, L>>> = reference
     .iter()
-    .filter_map(|it| it.kind().map(|k| (k, it.span.clone())))
+    .filter_map(|it| {
+      it.item
+        .as_ref()
+        .ok()
+        .map(|tok| StreamItem::Token(tok.clone(), it.span.clone()))
+    })
     .collect();
-  assert_stream_eq::<L>(idx, "raw-lex-vs-next", &raw_tokens, &straight);
+  assert_stream_eq::<Bud<'inp, L>>(
+    idx,
+    "raw-lex-vs-next",
+    COMMITTED,
+    &raw_tokens,
+    &straight.tokens,
+  );
 
   // peek-heavy: fill the cache before every consume; the drain path re-serves cached
   // tokens and re-lexes past the window.
-  let peek_heavy = drive::<L, _>(src, &tally, |ir| {
+  let peek_heavy = observe::<L>(src, &tally, |ir| {
     let mut out = Vec::new();
     loop {
       if out.len() > budget {
         panic!("tokora conformance [input #{idx} integration/peek-heavy] exceeded budget");
       }
-      let _ = ir
-        .peek::<U3>()
-        .expect("the conformance kit's Silent emitter never returns Err");
-      match ir
-        .next()
-        .expect("the conformance kit's Silent emitter never returns Err")
-      {
+      let _ = ir.peek::<U3>().expect(NEVER_ERRS);
+      match ir.next().expect(NEVER_ERRS) {
         Some(spanned) => {
           let (span, tok) = spanned.into_components();
-          out.push((tok.kind(), span));
+          out.push(StreamItem::Token(tok, span));
         }
         None => break,
       }
     }
     out
   });
-  assert_stream_eq::<L>(idx, "peek-heavy", &straight, &peek_heavy);
+  assert_observed_eq::<Bud<'inp, L>>(idx, "peek-heavy", &straight, &peek_heavy);
 
   // save-early-restore-late: save at 0, consume a prefix, abandon it, then drain the
   // whole stream — which must re-lex the rewound prefix identically.
-  let save_early = drive::<L, _>(src, &tally, |ir| {
+  let save_early = observe::<L>(src, &tally, |ir| {
     let ckp = ir.save();
     for _ in 0..3 {
-      if ir
-        .next()
-        .expect("the conformance kit's Silent emitter never returns Err")
-        .is_none()
-      {
+      if ir.next().expect(NEVER_ERRS).is_none() {
         break;
       }
     }
     ir.restore(ckp);
     drain_all::<Bud<'inp, L>>(ir, budget)
   });
-  assert_stream_eq::<L>(idx, "save-early-restore-late", &straight, &save_early);
+  assert_observed_eq::<Bud<'inp, L>>(idx, "save-early-restore-late", &straight, &save_early);
 
   // drain-then-restore-across-cache: fill the cache, drain it and lex past it, then
   // restore to a save that predates the cache — the post-save cache is dropped and the
   // region re-lexes on demand.
-  let across_cache = drive::<L, _>(src, &tally, |ir| {
+  let across_cache = observe::<L>(src, &tally, |ir| {
     let ckp = ir.save();
-    let _ = ir
-      .peek::<U3>()
-      .expect("the conformance kit's Silent emitter never returns Err");
+    let _ = ir.peek::<U3>().expect(NEVER_ERRS);
     for _ in 0..4 {
-      if ir
-        .next()
-        .expect("the conformance kit's Silent emitter never returns Err")
-        .is_none()
-      {
+      if ir.next().expect(NEVER_ERRS).is_none() {
         break;
       }
     }
     ir.restore(ckp);
     drain_all::<Bud<'inp, L>>(ir, budget)
   });
-  assert_stream_eq::<L>(
+  assert_observed_eq::<Bud<'inp, L>>(
     idx,
     "drain-then-restore-across-cache",
     &straight,
@@ -2696,88 +2807,112 @@ fn check_integration<'inp, L>(
 
   // nested-savepoints: outer save, consume, inner save, consume, restore inner (LIFO),
   // consume, restore outer, drain. Exercises nested last-in-first-out restores.
-  let nested = drive::<L, _>(src, &tally, |ir| {
+  let nested = observe::<L>(src, &tally, |ir| {
     let outer = ir.save();
-    let _ = ir
-      .next()
-      .expect("the conformance kit's Silent emitter never returns Err");
+    let _ = ir.next().expect(NEVER_ERRS);
     let inner = ir.save();
-    let _ = ir
-      .next()
-      .expect("the conformance kit's Silent emitter never returns Err");
+    let _ = ir.next().expect(NEVER_ERRS);
     ir.restore(inner);
-    let _ = ir
-      .next()
-      .expect("the conformance kit's Silent emitter never returns Err");
+    let _ = ir.next().expect(NEVER_ERRS);
     ir.restore(outer);
     drain_all::<Bud<'inp, L>>(ir, budget)
   });
-  assert_stream_eq::<L>(idx, "nested-savepoints", &straight, &nested);
+  assert_observed_eq::<Bud<'inp, L>>(idx, "nested-savepoints", &straight, &nested);
 }
 
-/// Which component of a committed `(kind, span)` pair decided a comparison of two of them, in
-/// [`Item::compare`]'s order and answering in its terms.
+/// Which arm of a committed stream a divergence was found on, in the two places the report names
+/// it: the noun the verdict uses, and the position label the refusal is asked at.
 ///
-/// Both components are bounded stronger than [`PartialEq`] — [`Token::Kind`] is `Eq` and
-/// [`Lexer::Span`] is `Ord` — so a refusal drawn from either means an implementation claiming a
-/// total equality it does not have. That is a *worse* caller defect than the partial one a token
-/// or error payload carries, and reporting it as a divergence of the committed stream is exactly
-/// as wrong. See [`refuse_non_reflexive`].
-///
-/// The pair has no discriminant, so [`Decided::Discriminant`] cannot arise here: the two
-/// components are the whole observable, and one of them decides every failure.
-fn stream_pair_compare<'inp, L>(
-  expected: &(<L::Token as Token<'inp>>::Kind, L::Span),
-  got: &(<L::Token as Token<'inp>>::Kind, L::Span),
-) -> Comparison
-where
+/// The arm is carried rather than inferred because both arms hold the same [`StreamItem`] type —
+/// each sequence is homogeneous, so the value cannot say which sequence it came from, and a
+/// verdict that called a raised refusal a "committed token" would be describing the wrong half of
+/// the layer's behavior.
+#[derive(Clone, Copy)]
+struct Arm {
+  /// The stream's noun, as in "committed token stream diverges".
+  noun: &'static str,
+  /// What a position on this arm is called, so a `non-reflexive-payload` refusal names the arm
+  /// the failed comparison was drawn from.
+  at: &'static str,
+}
+
+/// The tokens `next()` handed back.
+const COMMITTED: Arm = Arm {
+  noun: "committed token",
+  at: "position",
+};
+
+/// The lexer errors the input layer raised underneath the drain.
+const RAISED: Arm = Arm {
+  noun: "raised lexer-error",
+  at: "error position",
+};
+
+/// Asserts two schedules observed the input layer identically — the same committed tokens and the
+/// same raised lexer errors, both by value.
+fn assert_observed_eq<'inp, L>(
+  idx: usize,
+  sched: &str,
+  expected: &Observed<'inp, L>,
+  got: &Observed<'inp, L>,
+) where
   L: Lexer<'inp>,
+  L::Token: PartialEq,
+  <L::Token as Token<'inp>>::Error: PartialEq,
 {
-  if expected.0 != got.0 {
-    return Comparison::Differs(decided_by(Decided::KIND, &expected.0, &got.0));
-  }
-  if expected.1 != got.1 {
-    return Comparison::Differs(decided_by(Decided::SPAN, &expected.1, &got.1));
-  }
-  Comparison::Equal
+  assert_stream_eq::<L>(idx, sched, COMMITTED, &expected.tokens, &got.tokens);
+  assert_stream_eq::<L>(idx, sched, RAISED, &expected.errors, &got.errors);
 }
 
-/// Asserts two committed (kind, span) token streams are identical, with position context.
+/// Asserts two item streams are identical, with position context.
+///
+/// The comparison is [`StreamItem::compare`] — the same component-aware, reflexivity-aware path
+/// the partial tier draws its verdicts from, and the reason this tier has no comparison of its
+/// own. It replaced a local `(kind, span)` one, which was both a projection of the item (#269 at
+/// this tier) and a second implementation of a rule that already existed: the two could drift,
+/// and the older one already had, since it could not see the arm at all.
 fn assert_stream_eq<'inp, L>(
   idx: usize,
   sched: &str,
-  expected: &[(<L::Token as Token<'inp>>::Kind, L::Span)],
-  got: &[(<L::Token as Token<'inp>>::Kind, L::Span)],
+  arm: Arm,
+  expected: &[StreamItem<'inp, L>],
+  got: &[StreamItem<'inp, L>],
 ) where
   L: Lexer<'inp>,
+  L::Token: PartialEq,
+  <L::Token as Token<'inp>>::Error: PartialEq,
 {
   let n = expected.len().min(got.len());
   for i in 0..n {
-    if let Comparison::Differs(decided) = stream_pair_compare::<L>(&expected[i], &got[i]) {
-      // The third member of the same population. `Token::Kind` is bounded `Eq` and `Lexer::Span`
-      // is bounded `Ord`, so non-reflexivity here is a broken TOTAL-equality promise rather than
-      // the partial one the token and error payloads carry — a stronger caller defect, and the
-      // same wrong verdict to report as a stream divergence. Guarding four comparisons and not
-      // the fifth is the defect relocated, and this one costs a call on a path already panicking.
+    if let Comparison::Differs(decided) = expected[i].compare(&got[i]) {
+      // The third member of the same population. `Token::Kind` is bounded `Eq`, `Lexer::Span` is
+      // bounded `Ord` and the two payloads are bounded only `PartialEq`, so a refusal here is
+      // drawn from whichever of those decided it — exactly as it is on the other four
+      // comparisons. Guarding four and not the fifth is the defect relocated, and this one costs
+      // a call on a path already panicking.
       let op = format!("integration/{sched}");
-      let at = format!("position {i}");
+      let at = format!("{} {i}", arm.at);
       refuse_decided(
         idx,
         &op,
         &at,
         &decided,
-        &format!("{:?}", expected[i]),
-        &format!("{:?}", got[i]),
+        &expected[i].describe(),
+        &got[i].describe(),
       );
       panic!(
-        "tokora conformance [input #{idx} integration/{sched}] position {i}: committed token stream diverges: expected {:?}, got {:?}",
-        expected[i], got[i]
+        "tokora conformance [input #{idx} integration/{sched}] {} {i}: {} stream diverges: expected {}, got {}",
+        arm.at,
+        arm.noun,
+        expected[i].describe(),
+        got[i].describe()
       );
     }
   }
   if expected.len() != got.len() {
     panic!(
-      "tokora conformance [input #{idx} integration/{sched}] committed token stream length differs: straight-lex has {}, schedule has {}",
+      "tokora conformance [input #{idx} integration/{sched}] {} stream length differs: straight-lex has {}, schedule has {}",
+      arm.noun,
       expected.len(),
       got.len()
     );

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -125,8 +125,8 @@
 //! from the one the comparison had asked, and it hid the truncation nonconformance the partial
 //! tier exists to report behind a refusal saying the kit had convicted the lexer of nothing. The
 //! kit never reports an identity it did not check, and it never withholds a verdict it did
-//! establish; those are one rule, and [`Comparison`] is where it is enforced rather than
-//! remembered.
+//! establish; those are one rule, and the comparison's own answer is where it is enforced
+//! rather than remembered.
 
 pub mod cache;
 pub mod emitter;

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -1432,27 +1432,15 @@ where
     <L::Token as Token<'inp>>::Error: PartialEq,
   {
     match (self, other) {
-      (Self::Token(a, sa), Self::Token(b, sb)) => {
-        let (ka, kb) = (a.kind(), b.kind());
-        if ka != kb {
-          return Comparison::Differs(decided_by(Decided::KIND, &ka, &kb));
-        }
-        if sa != sb {
-          return Comparison::Differs(decided_by(Decided::SPAN, sa, sb));
-        }
-        if a != b {
-          return Comparison::Differs(decided_by(Decided::TOKEN_PAYLOAD, a, b));
-        }
-        Comparison::Equal
-      }
+      (Self::Token(a, sa), Self::Token(b, sb)) => Comparison::ranked(&[
+        &|| compare_by(Decided::KIND, &a.kind(), &b.kind()),
+        &|| compare_by(Decided::SPAN, sa, sb),
+        &|| compare_by(Decided::TOKEN_PAYLOAD, a, b),
+      ]),
       (Self::LexerError(sa, a), Self::LexerError(sb, b)) => {
-        if sa != sb {
-          return Comparison::Differs(decided_by(Decided::SPAN, sa, sb));
-        }
-        if a != b {
-          return Comparison::Differs(decided_by(Decided::ERROR_PAYLOAD, a, b));
-        }
-        Comparison::Equal
+        Comparison::ranked(&[&|| compare_by(Decided::SPAN, sa, sb), &|| {
+          compare_by(Decided::ERROR_PAYLOAD, a, b)
+        }])
       }
       // A committed token against a lexer error. This tier exists to catch exactly that, and no
       // caller equality was consulted to find it — see [`Decided::Discriminant`].
@@ -1784,9 +1772,11 @@ fn assert_partial_stream_eq<'inp, L>(
   L::Token: PartialEq,
   <L::Token as Token<'inp>>::Error: PartialEq,
 {
-  let n = expected.len().min(got.len());
-  for i in 0..n {
-    if let Comparison::Differs(decided) = expected[i].compare(&got[i]) {
+  match diverge(expected, got, expected.len() != got.len(), |a, b| {
+    a.compare(b)
+  }) {
+    None => {}
+    Some(Divergence::At(i, decided)) => {
       // The final leg compares the complete stream against a final drain of the SAME source, so
       // this is the site #295 arrived through. See `refuse_non_reflexive`: reached only after the
       // comparison has already failed, so it re-labels a failure and never creates one — and it
@@ -1807,13 +1797,11 @@ fn assert_partial_stream_eq<'inp, L>(
         got[i].describe()
       );
     }
-  }
-  if expected.len() != got.len() {
-    panic!(
+    Some(Divergence::Count) => panic!(
       "tokora conformance [input #{idx} partial-equivalence] split k={k}: prefix item count diverges from the complete prefix: expected {}, got {}",
       expected.len(),
       got.len()
-    );
+    ),
   }
 }
 
@@ -1832,9 +1820,13 @@ fn assert_partial_prefix_of<'inp, L>(
   L::Token: PartialEq,
   <L::Token as Token<'inp>>::Error: PartialEq,
 {
-  let n = expected.len().min(got.len());
-  for i in 0..n {
-    if let Comparison::Differs(decided) = expected[i].compare(&got[i]) {
+  // `got` longer than `expected` is this leg's cardinality difference and nothing else:
+  // withholding MORE is sound here, so a short `got` is not a divergence to rank at all.
+  match diverge(expected, got, got.len() > expected.len(), |a, b| {
+    a.compare(b)
+  }) {
+    None => {}
+    Some(Divergence::At(i, decided)) => {
       // The sibling guard to `assert_partial_stream_eq`'s. A guard at one comparison and not the
       // other is the same defect relocated: this leg compares two different drains, so a payload
       // that will not equal itself fails here too, and reads as a truncation defect.
@@ -1857,13 +1849,11 @@ fn assert_partial_prefix_of<'inp, L>(
         got[i].describe()
       );
     }
-  }
-  if got.len() > expected.len() {
-    panic!(
+    Some(Divergence::Count) => panic!(
       "tokora conformance [input #{idx} partial-equivalence] split k={k}: a non-final prefix drain yielded {} items but the complete parse has only {} ending strictly before the cut. The extra one was decided from bytes that had not arrived; report a read frontier that reaches the buffer end (Lexer::read_frontier) so it is withheld.",
       got.len(),
       expected.len()
-    );
+    ),
   }
 }
 
@@ -1908,6 +1898,173 @@ enum Comparison {
   Equal,
   /// The two sides differ, and [`Decided`] names the operation the verdict rests on.
   Differs(Decided),
+}
+
+impl Comparison {
+  /// [`Ranking`] over a fixed list of comparisons, in the caller's declared order: the first
+  /// **conclusive** difference, or — when none of them is conclusive — the first inconclusive
+  /// one, or [`Equal`](Self::Equal).
+  ///
+  /// A thin adapter and deliberately so: the rule lives in [`Ranking`] and this only spells it
+  /// for the sites that need no tag on the step that answered. Each step is a closure because
+  /// **the search short-circuits**: the moment one of them is conclusive the rest are never run,
+  /// so a comparison that agrees, and one that fails the ordinary way, pay exactly what they paid
+  /// before.
+  fn ranked(steps: &[&dyn Fn() -> Self]) -> Self {
+    let mut ranking = Ranking::new();
+    for step in steps {
+      if let Some(((), decided)) = ranking.settle((), step()) {
+        return Self::Differs(decided);
+      }
+    }
+    ranking
+      .refusal()
+      .map_or(Self::Equal, |((), decided)| Self::Differs(decided))
+  }
+}
+
+/// One component's equality, asked as a [`Comparison`] so that the answer carries the operation
+/// that produced it.
+///
+/// **Every equality this kit draws a verdict from is built here.** That is what makes the guarded
+/// population a matter of construction rather than of a count in a comment: a comparison that
+/// does not come through this cannot produce a [`Decided`], and so cannot reach either the
+/// verdict or the refusal. Reflexivity is probed only on the failure path — see [`decided_by`].
+fn compare_by<T>(name: &'static str, expected: &T, got: &T) -> Comparison
+where
+  T: PartialEq + ?Sized,
+{
+  if expected == got {
+    Comparison::Equal
+  } else {
+    Comparison::Differs(decided_by(name, expected, got))
+  }
+}
+
+/// The ranked search for the difference a verdict is drawn from: **a conclusive difference
+/// outranks an inconclusive one, wherever both are available.**
+///
+/// # The other half of the rule
+///
+/// [`refuse_non_reflexive`] is the half that says the kit never reports a diagnosis it did not
+/// establish. This is the half that says it never withholds one it did. Without it the first
+/// difference a comparison happens to reach decides everything, and an inconclusive one reached
+/// first buries every conclusive one behind it:
+///
+/// - `[Tok(NaN)]` against `[Tok(NaN), Tok(0.0)]` refused at position 0 over the payload and never
+///   reached the length check — while the **extra item** proves replay divergence with no caller
+///   equality consulted at all.
+/// - A cache that returns the right span and the right token beside a corrupted, perfectly
+///   reflexive `L::State` refused over the token, because `NaN != NaN` came first in
+///   `triple_compare`'s order — while the unexamined state difference convicts the cache on its
+///   own.
+///
+/// So the first inconclusive difference is *retained as a fallback* and the search goes on. It is
+/// reported only if nothing conclusive is found anywhere: in the remaining components of the same
+/// item, at a later position of the same stream, or in the item **count**.
+///
+/// # What counts as conclusive
+///
+/// [`Decided::is_conclusive`] is the test, and it is a question about the two values the
+/// comparison actually ran on rather than about the bound the component carries:
+///
+/// - a difference at the **discriminant** — no caller equality ran at all;
+/// - a difference in item **count** — likewise, which is why it carries no [`Decided`] and is
+///   conclusive by construction (see [`Divergence::Count`]);
+/// - a component whose comparison **is** sound on both sides: each value equals itself. That
+///   covers every component bounded to a total equality whose promise holds, and it covers the
+///   ordinary `PartialEq` case — two self-equal payloads that disagree with each other. The
+///   ordinary case is the whole population of honest failures and is **not** demoted by any of
+///   this.
+///
+/// Inconclusive is the complement and nothing else: a comparison one of whose two values will not
+/// equal itself.
+///
+/// # Ordering still chooses among conclusive answers
+///
+/// Each site declares the order its components are consulted in, and that order still picks which
+/// *conclusive* difference speaks — `triple_compare`'s "span first, always" is unchanged for
+/// every entry whose span comparison is sound. Ranking only ever moves an answer past a step the
+/// kit could not have drawn a verdict from.
+struct Ranking<T> {
+  /// The first inconclusive difference seen, and what the caller calls the step that produced
+  /// it. Never overwritten: "first" is in the site's own declared order.
+  inconclusive: Option<(T, Decided)>,
+}
+
+impl<T> Ranking<T> {
+  /// A search with nothing found yet.
+  const fn new() -> Self {
+    Self { inconclusive: None }
+  }
+
+  /// Feeds the next comparison, tagged with whatever the caller needs back to render its own
+  /// message — which component of an entry, which position in a stream, or `()` where the
+  /// [`Decided`] already says everything.
+  ///
+  /// `Some` ends the search: this step is conclusive and outranks anything held. `None` means
+  /// keep going, either because the step agreed or because it is now the fallback.
+  fn settle(&mut self, tag: T, comparison: Comparison) -> Option<(T, Decided)> {
+    let Comparison::Differs(decided) = comparison else {
+      return None;
+    };
+    if decided.is_conclusive() {
+      return Some((tag, decided));
+    }
+    if self.inconclusive.is_none() {
+      self.inconclusive = Some((tag, decided));
+    }
+    None
+  }
+
+  /// The answer once every step has run without one of them being conclusive: the retained
+  /// fallback, which is what the refusal is drawn from, or `None` when the two sides agreed.
+  fn refusal(self) -> Option<(T, Decided)> {
+    self.inconclusive
+  }
+}
+
+/// The difference between two item streams a verdict is drawn from — [`Ranking`]'s answer with
+/// the one step a [`Comparison`] cannot express folded in.
+enum Divergence {
+  /// A position differs, and [`Decided`] names the operation that decided it.
+  At(usize, Decided),
+  /// Every shared position agreed, or every difference among them was inconclusive: the two
+  /// streams differ in item **count**.
+  ///
+  /// **Conclusive by construction.** A count is the kit's own `len()`, so no caller equality
+  /// stands behind it and there is nothing here that could fail to equal itself — which is
+  /// exactly why it outranks a retained fallback instead of queueing behind one.
+  Count,
+}
+
+/// [`Ranking`] over two item streams: the first **conclusive** difference among the shared
+/// positions, else a cardinality difference if there is one, else the first inconclusive
+/// position, else `None`.
+///
+/// The four stream comparisons in this module and [`cache`]'s purity comparison all read their
+/// answer from here, so the ordering between a position and a count cannot come to hold at one of
+/// them and not at another — the shape rounds 2 through 4 each hit by repairing a site.
+///
+/// `counts_differ` is the caller's, because the two legs do not agree on what a count difference
+/// *is*: inequality for a stream compared against a stream, and `got` longer than `expected` for
+/// the prefix leg, where withholding more is sound (see [`assert_partial_prefix_of`]).
+fn diverge<T, F>(expected: &[T], got: &[T], counts_differ: bool, compare: F) -> Option<Divergence>
+where
+  F: Fn(&T, &T) -> Comparison,
+{
+  let mut ranking = Ranking::new();
+  for i in 0..expected.len().min(got.len()) {
+    if let Some((i, decided)) = ranking.settle(i, compare(&expected[i], &got[i])) {
+      return Some(Divergence::At(i, decided));
+    }
+  }
+  if counts_differ {
+    return Some(Divergence::Count);
+  }
+  ranking
+    .refusal()
+    .map(|(i, decided)| Divergence::At(i, decided))
 }
 
 /// The operation a failed comparison was decided by, carrying the reflexivity question asked of
@@ -1955,6 +2112,29 @@ impl Decided {
   /// ``"the `L::State`"`` — the caller's [`PartialEq`] on [`Lexer::State`], which only the cache
   /// tier compares.
   const STATE: &'static str = "the `L::State`";
+  /// `"the span offset"` — [`Lexer::Offset`] is bounded `Ord`, another total promise. The
+  /// endpoint comparisons the tiling and combined-span laws are drawn from name this rather than
+  /// [`SPAN`](Self::SPAN), because a start or an end is what those laws compare and a reader
+  /// looking for the value in the message needs the same noun.
+  const OFFSET: &'static str = "the span offset";
+  /// `"the read frontier"` — [`ReadFrontier`] derives its equality from [`Lexer::Offset`]'s, so
+  /// this is the total promise again, one type further out.
+  const FRONTIER: &'static str = "the read frontier";
+  /// `"the span vector"` — a whole run of spans compared as **one** value, which is what the
+  /// cache kit's order laws do. A slice's equality is elementwise, so one lying [`Lexer::Span`]
+  /// anywhere in the run makes the run unequal to itself and the refusal names the run.
+  const SPANS: &'static str = "the span vector";
+
+  /// Whether the difference this describes is **conclusive**: the kit can convict on it, because
+  /// no equality it cannot trust decided it.
+  ///
+  /// This is [`Ranking`]'s test, written here so it is one statement rather than an inference
+  /// from two `Option`s at each site. `true` exactly when the refusal has nothing to say — at the
+  /// discriminant, where no caller comparison ran, and at a component both of whose values equal
+  /// themselves, which is the ordinary case and the one that must never be demoted.
+  const fn is_conclusive(&self) -> bool {
+    self.expected().is_none() && self.got().is_none()
+  }
 
   /// The component to refuse over on the **expected** side, and `None` when the operation that
   /// failed is sound there — or when no caller comparison ran at all.
@@ -2145,31 +2325,17 @@ where
     <L::Token as Token<'inp>>::Error: PartialEq,
   {
     match (&self.item, &other.item) {
-      (Ok(a), Ok(b)) => {
-        // The kind is compared as well as the token, for [`StreamItem::compare`]'s reason: the
-        // two are independent caller code, and a `PartialEq` coarser than the classification the
-        // parser sees is exactly what this comparison stands between.
-        let (ka, kb) = (a.kind(), b.kind());
-        if ka != kb {
-          return Comparison::Differs(decided_by(Decided::KIND, &ka, &kb));
-        }
-        if let Comparison::Differs(decided) = self.compare_shared(other) {
-          return Comparison::Differs(decided);
-        }
-        if a != b {
-          return Comparison::Differs(decided_by(Decided::TOKEN_PAYLOAD, a, b));
-        }
-        Comparison::Equal
-      }
-      (Err(a), Err(b)) => {
-        if let Comparison::Differs(decided) = self.compare_shared(other) {
-          return Comparison::Differs(decided);
-        }
-        if a != b {
-          return Comparison::Differs(decided_by(Decided::ERROR_PAYLOAD, a, b));
-        }
-        Comparison::Equal
-      }
+      // The kind is compared as well as the token, for [`StreamItem::compare`]'s reason: the two
+      // are independent caller code, and a `PartialEq` coarser than the classification the parser
+      // sees is exactly what this comparison stands between.
+      (Ok(a), Ok(b)) => Comparison::ranked(&[
+        &|| compare_by(Decided::KIND, &a.kind(), &b.kind()),
+        &|| self.compare_shared(other),
+        &|| compare_by(Decided::TOKEN_PAYLOAD, a, b),
+      ]),
+      (Err(a), Err(b)) => Comparison::ranked(&[&|| self.compare_shared(other), &|| {
+        compare_by(Decided::ERROR_PAYLOAD, a, b)
+      }]),
       // A token on one side and a lexer error on the other — see [`Decided::Discriminant`].
       _ => Comparison::Differs(Decided::Discriminant),
     }
@@ -2182,13 +2348,10 @@ where
   /// they are asked before either payload: a divergence one of them can settle is never
   /// attributed to a `PartialEq` that promises no reflexivity.
   fn compare_shared(&self, other: &Self) -> Comparison {
-    if self.span != other.span {
-      return Comparison::Differs(decided_by(Decided::SPAN, &self.span, &other.span));
-    }
-    if self.slice != other.slice {
-      return Comparison::Differs(decided_by(Decided::SLICE, &self.slice, &other.slice));
-    }
-    Comparison::Equal
+    Comparison::ranked(&[
+      &|| compare_by(Decided::SPAN, &self.span, &other.span),
+      &|| compare_by(Decided::SLICE, &self.slice, &other.slice),
+    ])
   }
 
   /// A human-readable one-line rendering for panic context.
@@ -2261,9 +2424,23 @@ where
       );
     }
     // 5. slice() equals the source content at span().
+    //
+    // Through `compare_by` for the reason every other verdict-drawing equality here is: the
+    // `Slice` bound is `Eq`, but `Eq` is a marker and nothing checks its promise, so a caller
+    // whose slice comparison answers `false` to everything — itself included — got a red naming
+    // their lexer for a fact about their own `PartialEq`. Same population, same refusal.
     match src.slice(start.clone()..end.clone()) {
       Some(from_source) => {
-        if from_source != slice {
+        if let Comparison::Differs(decided) = compare_by(Decided::SLICE, &from_source, &slice) {
+          let at = format!("position {pos}");
+          refuse_decided(
+            idx,
+            "span/slice-coherence",
+            &at,
+            &decided,
+            &format!("{from_source:?}"),
+            &format!("{slice:?}"),
+          );
           panic!(
             "tokora conformance [input #{idx} span/slice-coherence] position {pos}: slice() disagrees with the source at span {span:?}: source {from_source:?}, slice() {slice:?}"
           );
@@ -2280,16 +2457,34 @@ where
     let frontier = lexer.read_frontier();
     for probe in 0..3 {
       let again = lexer.read_frontier();
-      if again != frontier {
+      if let Comparison::Differs(decided) = compare_by(Decided::FRONTIER, &frontier, &again) {
+        let at = format!("position {pos}");
+        refuse_decided(
+          idx,
+          "read-frontier",
+          &at,
+          &decided,
+          &format!("{frontier:?}"),
+          &format!("{again:?}"),
+        );
         panic!(
           "tokora conformance [input #{idx} read-frontier] position {pos}: read_frontier() changed between calls: first read {frontier:?}, probe #{probe} read {again:?}. It must be a pure read of recorded fact — the input layer's contract lets it be called at most once per item, but nothing may depend on that."
         );
       }
     }
-    if lexer.span() != span {
+    let after = lexer.span();
+    if let Comparison::Differs(decided) = compare_by(Decided::SPAN, &span, &after) {
+      let at = format!("position {pos}");
+      refuse_decided(
+        idx,
+        "read-frontier",
+        &at,
+        &decided,
+        &format!("{span:?}"),
+        &format!("{after:?}"),
+      );
       panic!(
-        "tokora conformance [input #{idx} read-frontier] position {pos}: read_frontier() moved the lexer: span() was {span:?} before the call and {:?} after. It must not advance the lexer or probe new input.",
-        lexer.span()
+        "tokora conformance [input #{idx} read-frontier] position {pos}: read_frontier() moved the lexer: span() was {span:?} before the call and {after:?} after. It must not advance the lexer or probe new input."
       );
     }
 
@@ -2312,12 +2507,19 @@ where
   L::Token: PartialEq,
   <L::Token as Token<'inp>>::Error: PartialEq,
 {
-  let n = expected.len().min(got.len());
-  for i in 0..n {
-    if let Comparison::Differs(decided) = expected[i].compare(&got[i]) {
+  // The item comparisons and the length check are ONE ranked search, and the order they used to
+  // run in was the defect: a `[Tok(NaN)]` against a `[Tok(NaN), Tok(0.0)]` refused at position 0
+  // and never reached the length check, while the extra item proves replay divergence with no
+  // caller equality consulted at all. See `diverge` and `Ranking`.
+  match diverge(expected, got, expected.len() != got.len(), |a, b| {
+    a.compare(b)
+  }) {
+    None => {}
+    Some(Divergence::At(i, decided)) => {
       // Before naming a culprit, ask whether the comparison that decided this is even comparable
-      // to itself. See `refuse_non_reflexive`: reached only once the comparison has failed, so it
-      // can re-label this failure and can never manufacture one.
+      // to itself. See `refuse_non_reflexive`: reached only once the comparison has failed, and
+      // only once the search has established that nothing conclusive outranks it, so it can
+      // re-label this failure and can never manufacture one.
       let at = format!("position {i}");
       refuse_decided(
         idx,
@@ -2333,13 +2535,11 @@ where
         got[i].describe()
       );
     }
-  }
-  if expected.len() != got.len() {
-    panic!(
+    Some(Divergence::Count) => panic!(
       "tokora conformance [input #{idx} {op}] length mismatch: expected {} items, got {}",
       expected.len(),
       got.len()
-    );
+    ),
   }
 }
 
@@ -2414,7 +2614,15 @@ where
   }
   for probe in 0..3 {
     let again = lexer.span();
-    if again != span {
+    if let Comparison::Differs(decided) = compare_by(Decided::SPAN, &span, &again) {
+      refuse_decided(
+        idx,
+        "span-survives-exhaustion",
+        "after exhaustion",
+        &decided,
+        &format!("{span:?}"),
+        &format!("{again:?}"),
+      );
       panic!(
         "tokora conformance [input #{idx} span-survives-exhaustion] span() changed after exhaustion: first read {span:?}, probe #{probe} read {again:?}. Repeated reads must agree — the input layer reads it more than once."
       );
@@ -2446,9 +2654,16 @@ fn check_resume<'inp, L>(
     let mut resumed = L::with_state(src, state);
     resumed.bump(&offset);
 
-    let mut produced = 0usize;
+    // Collected and then ranked, rather than compared item-by-item as it is produced. The
+    // streaming shape settled the verdict at the first position that differed, which is the same
+    // ordering defect `assert_run_eq` carried: an inconclusive difference at position 0 buried a
+    // decisive item-count difference the suffix comparison had already established. The cost is
+    // paid only on a failure path — a run that would have stopped early now lexes on to
+    // exhaustion, under the SAME budget the passing path is already bounded by, and holds the
+    // suffix it produced for the length of one `k`.
+    let mut observed: Vec<Item<'inp, L>> = Vec::new();
     loop {
-      if produced > budget {
+      if observed.len() > budget {
         panic!(
           "tokora conformance [input #{idx} state-resume] resume-from k={k}: produced more than the budget of {budget} items without exhausting"
         );
@@ -2457,49 +2672,50 @@ fn check_resume<'inp, L>(
       let span = resumed.span();
       let slice = resumed.slice();
       let end = span.end_ref().clone();
-      let observed = Item::<L> {
+      observed.push(Item::<L> {
         item: res,
         span,
         slice,
         end,
         state: resumed.state().clone(),
-      };
-
-      match reference.get(k + produced) {
-        Some(expected) => {
-          if let Comparison::Differs(decided) = expected.compare(&observed) {
-            // The same guard `assert_run_eq` carries, for the same reason and under the same
-            // "only after a failed comparison, and only about the comparison that failed" rule.
-            // See `refuse_non_reflexive`.
-            let at = format!("resume-from k={k}, position {produced}");
-            refuse_decided(
-              idx,
-              "state-resume",
-              &at,
-              &decided,
-              &expected.describe(),
-              &observed.describe(),
-            );
-            panic!(
-              "tokora conformance [input #{idx} state-resume] resume-from k={k}, position {produced}: resumed item diverges from the original suffix: expected {}, got {}",
-              expected.describe(),
-              observed.describe()
-            );
-          }
-        }
-        None => panic!(
-          "tokora conformance [input #{idx} state-resume] resume-from k={k}, position {produced}: resume produced MORE items than the original suffix ({} remaining)",
-          reference.len() - k
-        ),
-      }
-      produced += 1;
+      });
     }
 
-    if k + produced != reference.len() {
-      panic!(
+    let suffix = &reference[k..];
+    let produced = observed.len();
+    match diverge(suffix, &observed, produced != suffix.len(), |a, b| {
+      a.compare(b)
+    }) {
+      None => {}
+      Some(Divergence::At(i, decided)) => {
+        // The same guard `assert_run_eq` carries, for the same reason and under the same "only
+        // after a failed comparison, and only about the comparison that failed" rule. See
+        // `refuse_non_reflexive`.
+        let at = format!("resume-from k={k}, position {i}");
+        refuse_decided(
+          idx,
+          "state-resume",
+          &at,
+          &decided,
+          &suffix[i].describe(),
+          &observed[i].describe(),
+        );
+        panic!(
+          "tokora conformance [input #{idx} state-resume] resume-from k={k}, position {i}: resumed item diverges from the original suffix: expected {}, got {}",
+          suffix[i].describe(),
+          observed[i].describe()
+        );
+      }
+      // One cardinality difference, reported from the side it fell on so both wordings survive.
+      Some(Divergence::Count) if produced > suffix.len() => panic!(
+        "tokora conformance [input #{idx} state-resume] resume-from k={k}, position {}: resume produced MORE items than the original suffix ({} remaining)",
+        suffix.len(),
+        suffix.len()
+      ),
+      Some(Divergence::Count) => panic!(
         "tokora conformance [input #{idx} state-resume] resume-from k={k}: resume produced FEWER items than the original suffix: expected {}, got {produced}",
-        reference.len() - k
-      );
+        suffix.len()
+      ),
     }
   }
 }
@@ -2513,10 +2729,22 @@ where
   let src_len = src.len();
   let zero = L::Offset::default();
 
+  // Every comparison below is an `L::Offset` equality, and `Lexer::Offset` is bounded `Ord` — a
+  // TOTAL promise, and one nothing checks. So they are drawn through `compare_by` exactly as the
+  // item comparisons are: an offset that will not equal itself is a fact about the caller's `Ord`
+  // impl, and reporting it as a tiling defect names the wrong culprit.
   let Some(first) = reference.first() else {
     // An empty stream is gap-free tiling of an empty source; a non-empty source with
     // no tokens leaves the whole thing untiled.
-    if src_len != zero {
+    if let Comparison::Differs(decided) = compare_by(Decided::OFFSET, &zero, &src_len) {
+      refuse_decided(
+        idx,
+        "lossless",
+        "source length",
+        &decided,
+        &format!("{zero:?}"),
+        &format!("{src_len:?}"),
+      );
       panic!(
         "tokora conformance [input #{idx} lossless] the lexer produced no items but the source is non-empty (length {src_len:?}); lossless tiling requires covering the whole source"
       );
@@ -2524,7 +2752,16 @@ where
     return;
   };
 
-  if *first.span.start_ref() != zero {
+  let first_start = first.span.start_ref();
+  if let Comparison::Differs(decided) = compare_by(Decided::OFFSET, &zero, first_start) {
+    refuse_decided(
+      idx,
+      "lossless",
+      "position 0",
+      &decided,
+      &format!("{zero:?}"),
+      &format!("{first_start:?}"),
+    );
     panic!(
       "tokora conformance [input #{idx} lossless] position 0: first span {:?} does not start at 0",
       first.span
@@ -2534,7 +2771,16 @@ where
   let mut prev_end = first.span.end_ref().clone();
   for (i, item) in reference.iter().enumerate().skip(1) {
     let start = item.span.start_ref().clone();
-    if start != prev_end {
+    if let Comparison::Differs(decided) = compare_by(Decided::OFFSET, &prev_end, &start) {
+      let at = format!("position {i}");
+      refuse_decided(
+        idx,
+        "lossless",
+        &at,
+        &decided,
+        &format!("{prev_end:?}"),
+        &format!("{start:?}"),
+      );
       panic!(
         "tokora conformance [input #{idx} lossless] position {i}: gap or overlap — previous span ended at {prev_end:?} but this span {:?} starts at {start:?}",
         item.span
@@ -2543,7 +2789,15 @@ where
     prev_end = item.span.end_ref().clone();
   }
 
-  if prev_end != src_len {
+  if let Comparison::Differs(decided) = compare_by(Decided::OFFSET, &src_len, &prev_end) {
+    refuse_decided(
+      idx,
+      "lossless",
+      "source end",
+      &decided,
+      &format!("{src_len:?}"),
+      &format!("{prev_end:?}"),
+    );
     panic!(
       "tokora conformance [input #{idx} lossless] the last span ends at {prev_end:?} but the source ends at {src_len:?}; lossless tiling must reach the source end"
     );
@@ -2898,15 +3152,16 @@ fn assert_stream_eq<'inp, L>(
   L::Token: PartialEq,
   <L::Token as Token<'inp>>::Error: PartialEq,
 {
-  let n = expected.len().min(got.len());
-  for i in 0..n {
-    if let Comparison::Differs(decided) = expected[i].compare(&got[i]) {
-      // Two more members of the same population, and with them the population is closed: the two
-      // in the trait tier, the two in the partial tier, these two, and the two in `cache`.
+  match diverge(expected, got, expected.len() != got.len(), |a, b| {
+    a.compare(b)
+  }) {
+    None => {}
+    Some(Divergence::At(i, decided)) => {
       // `Token::Kind` is bounded `Eq`, `Lexer::Span` is bounded `Ord` and the two payloads are
       // bounded only `PartialEq`, so a refusal here is drawn from whichever of those decided it —
-      // exactly as it is at the other six. Guarding some and not the rest is the defect
-      // relocated, and this one costs a call on a path already panicking.
+      // exactly as it is at every other comparison this kit draws a verdict from. Guarding some
+      // and not the rest is the defect relocated, and this one costs a call on a path already
+      // panicking.
       let op = format!("integration/{sched}");
       let at = format!("{} {i}", arm.at);
       refuse_decided(
@@ -2925,14 +3180,12 @@ fn assert_stream_eq<'inp, L>(
         got[i].describe()
       );
     }
-  }
-  if expected.len() != got.len() {
-    panic!(
+    Some(Divergence::Count) => panic!(
       "tokora conformance [input #{idx} integration/{sched}] {} stream length differs: straight-lex has {}, schedule has {}",
       arm.noun,
       expected.len(),
       got.len()
-    );
+    ),
   }
 }
 

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -13,7 +13,11 @@
 //! **Trait tier** — driving the [`Lexer`] surface directly:
 //!
 //! 1. **Replay identity** — two fresh `L::new(src)` runs produce the identical
-//!    token/error + span + slice sequence, to exhaustion.
+//!    token/error + span + slice sequence, to exhaustion. **Identical by value**: the whole
+//!    [`Token`], the whole [`Token::Error`], never a rendering of either and never the token's
+//!    [`kind`](Token::kind) standing in for the token. That is what
+//!    [`run`](crate::conformance::Harness::run)'s two `PartialEq` bounds buy, and what a green
+//!    from it did not mean before 0.10.0 — see `run`'s own docs for who pays.
 //! 2. **State-resume faithfulness** — for *every* position `k`, capturing the lexer
 //!    [`State`] there and resuming with
 //!    `L::with_state(src, saved)` + [`bump`](crate::Lexer::bump) to `k`'s offset
@@ -72,14 +76,16 @@
 //! refusal leaves no token behind, so a lexer that errors on a truncated prefix and tokenizes the
 //! full input showed up as "nothing yielded yet", which is a legal prefix.
 //!
-//! Both arms are compared on **value**: a token contributes its kind, its span and the **token
-//! itself**; an error contributes that it *was* an error, its span and the **payload itself**. Not
-//! a rendering — `run_partial` asks for `PartialEq` on both and compares the values, because a
-//! `Debug` string is neither injective (two payloads can render alike, so a real drift passes) nor
-//! stable (a rendering carrying an address or a counter fails on a conforming lexer). Comparing
-//! only the token's *kind* had the same shape on the other arm: a payload decided by a byte that
-//! has not arrived kept its kind and its span, so both runs passed while the value a parser
-//! callback receives changed.
+//! Both arms are compared on **value**, and this is the rule for *every* tier rather than for
+//! this one: a token contributes its kind, its span and the **token itself**; an error contributes
+//! that it *was* an error, its span and the **payload itself**. Not a rendering — both
+//! `run` and `run_partial` ask for `PartialEq` on the token and the error and compare the values,
+//! because a `Debug` string is neither injective (two payloads can render alike, so a real drift
+//! passes) nor stable (a rendering carrying an address or a counter fails on a conforming lexer).
+//! Comparing only the token's *kind* had the same shape on the other arm: a payload decided by a
+//! byte that has not arrived kept its kind and its span, so both runs passed while the value a
+//! parser callback receives changed. The trait tier held the weaker key for one release longer
+//! than the partial tier did, and that gap was #269.
 //!
 //! Nothing from the *diagnostic* channel is compared: no rendered message, no
 //! [`Severity`](crate::emitter::Severity), no label stack.
@@ -97,6 +103,18 @@
 //! A failing check is a bug in the *lexer* (or a mismatch with the documented
 //! contract), surfaced loudly. The kit never mutates the lexer's behavior; it only
 //! observes and asserts.
+//!
+//! **And it never reports a failure that is a fact about a payload type rather than about the
+//! lexer.** Value equality is drawn from caller [`PartialEq`] implementations, and `PartialEq`
+//! promises symmetry and transitivity but **not** reflexivity: a payload holding an `f64` that can
+//! be `NaN` is not equal to itself. Every comparison any tier draws a verdict from — the two in
+//! the trait tier, the two in the partial tier, the committed-stream one in the integration tier,
+//! and the entry and purity comparisons in [`cache`] — therefore asks, once it has already
+//! failed, whether either side is equal to itself. A side that is not gets a refusal tagged
+//! `non-reflexive-payload` naming the component and the obligation, instead of a conformance
+//! verdict whose expected-vs-got renders identically on both sides (#295). The obligation itself
+//! is unchanged and is the caller's: such a type hand-writes the impl that says what equality
+//! means for it.
 
 pub mod cache;
 pub mod emitter;
@@ -355,7 +373,85 @@ where
     self
   }
 
+  /// The anti-hang budget for `src`: `budget_multiple * source_units + BUDGET_FLOOR`.
+  ///
+  /// Checked, not saturating. Saturation here would hand back [`usize::MAX`], and the guards built
+  /// out of this number do not all survive that value: [`instance_ceiling`] adds one to it and
+  /// **overflows** — wrapping to a ceiling of `0` in release, which refuses every lexer on its
+  /// first attempt — and the item guards `out.len() > budget` become comparisons no `Vec` length
+  /// can satisfy. (The aggregate tally is unaffected: it derives its own `u128` ceiling from this
+  /// number rather than using it, so it would still fire.) One broken guard is enough, and a
+  /// budget that has stopped describing the source it came from is not a budget in any case.
+  /// [`MAX_BUDGET_MULTIPLE`] already bounds the multiple; this bounds the product, which on a
+  /// 32-bit target the multiple alone does not.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `budget_multiple * source_units + 64` does not fit in a `usize` with room above
+  /// it for the exhaustion probe. Reaching it needs a source of more than `usize::MAX / 65536`
+  /// units — 256 TiB on a 64-bit target — so what this replaces is not a run that used to work: it
+  /// is a budget silently swapped for one the caller never asked for.
+  fn budget(&self, src: &'inp L::Source) -> usize {
+    let units = src.slice(..).map(|s| s.len()).unwrap_or(0);
+    representable_budget(self.budget_multiple, units).unwrap_or_else(|| {
+      panic!(
+        "tokora conformance: the anti-hang budget for a source of {units} units at a multiple of \
+         {} does not fit in a usize. This is a limit of the kit's arithmetic and not a verdict on \
+         the lexer, which has not been run. Lower the multiple with Harness::budget_multiple: an \
+         unrepresentable budget has to be replaced by some other number, and every replacement is \
+         wrong — usize::MAX overflows the per-instance ceiling derived from it and puts the item \
+         guards past any Vec length, and anything smaller certifies a budget you did not ask for.",
+        self.budget_multiple
+      )
+    })
+  }
+}
+
+impl<'inp, L> Harness<'inp, L>
+where
+  L: Lexer<'inp>,
+  // Semantic equality on the two values every trait-tier comparison is drawn from. These are the
+  // only bounds this entry point asks for beyond `Lexer` itself; see `run`'s own docs for who
+  // pays and what the alternatives cost, and `Item::sig_eq` for why a `Debug` rendering and a
+  // `kind` projection are each the wrong key.
+  L::Token: PartialEq,
+  <L::Token as Token<'inp>>::Error: PartialEq,
+{
   /// Runs every check against every input, panicking on the first violation.
+  ///
+  /// # Who pays for `PartialEq`, and what a green means without it
+  ///
+  /// This asks for `L::Token: PartialEq` and `<L::Token as Token>::Error: PartialEq`. Before
+  /// 0.10.0 it asked for nothing beyond [`Lexer`], and **that is what the defect was** (#269):
+  /// check 1 is documented as identity of the item, and with no equality to call the kit
+  /// substituted the two things it could reach — the error's `Debug` rendering and the token's
+  /// [`kind`](Token::kind). Neither is an equality relation. A rendering is not injective, so two
+  /// unequal error values that print alike replayed green; it is not stable either, so a payload
+  /// rendering a counter or an address reddened a *conforming* lexer; and a kind is a projection,
+  /// so a token payload could move between two fresh runs with the kind, the span and the slice
+  /// all holding still. A certificate that says "identical" and checks something weaker is worth
+  /// less than no certificate, because the caller stops looking.
+  ///
+  /// The alternative to the bound is a caller-supplied comparator or key, and
+  /// [`run_partial`](Self::run_partial) already settled that trade for the other tier: a
+  /// hand-written projection is silently escaped by the next field added, which is the failure
+  /// mode the rendering had. The bound is the narrower obligation and the stronger guarantee.
+  ///
+  /// **What it excludes.** A vocabulary whose token or error type cannot be `PartialEq` — a
+  /// payload holding an `Arc<dyn Error>`, a closure, a handle — loses this entry point outright,
+  /// and with it the whole kit, since every tier hangs off `run` or
+  /// [`run_partial`](Self::run_partial) and the latter already required both bounds. Recovering
+  /// it costs a `#[derive(PartialEq)]`, or a hand-written impl where derivation is wrong, or a
+  /// newtype whose equality is the one the vocabulary means. Nothing about the *lexer* has to
+  /// change. There is no in-tree vocabulary among the excluded: this crate ships no concrete
+  /// [`Token`] implementation at all, and the bundled logos adapter is transparent —
+  /// `LogosLexer<T>` takes its `Token` and `Error` from the caller and constrains neither.
+  ///
+  /// One caveat that comes with value equality rather than with this kit, and it is the same one
+  /// [`run_partial`](Self::run_partial) carries: a payload holding an `f64` that can be `NaN` is
+  /// not equal to itself, and such a type must hand-write an impl that says what it means. Until
+  /// it does, this kit will not pretend to have checked it — it refuses, tagged
+  /// `non-reflexive-payload`, rather than reporting the lexer as non-conforming.
   ///
   /// # Panics
   ///
@@ -393,39 +489,6 @@ where
       check_integration::<L>(idx, src, &reference, budget);
     }
   }
-
-  /// The anti-hang budget for `src`: `budget_multiple * source_units + BUDGET_FLOOR`.
-  ///
-  /// Checked, not saturating. Saturation here would hand back [`usize::MAX`], and the guards built
-  /// out of this number do not all survive that value: [`instance_ceiling`] adds one to it and
-  /// **overflows** — wrapping to a ceiling of `0` in release, which refuses every lexer on its
-  /// first attempt — and the item guards `out.len() > budget` become comparisons no `Vec` length
-  /// can satisfy. (The aggregate tally is unaffected: it derives its own `u128` ceiling from this
-  /// number rather than using it, so it would still fire.) One broken guard is enough, and a
-  /// budget that has stopped describing the source it came from is not a budget in any case.
-  /// [`MAX_BUDGET_MULTIPLE`] already bounds the multiple; this bounds the product, which on a
-  /// 32-bit target the multiple alone does not.
-  ///
-  /// # Panics
-  ///
-  /// Panics when `budget_multiple * source_units + 64` does not fit in a `usize` with room above
-  /// it for the exhaustion probe. Reaching it needs a source of more than `usize::MAX / 65536`
-  /// units — 256 TiB on a 64-bit target — so what this replaces is not a run that used to work: it
-  /// is a budget silently swapped for one the caller never asked for.
-  fn budget(&self, src: &'inp L::Source) -> usize {
-    let units = src.slice(..).map(|s| s.len()).unwrap_or(0);
-    representable_budget(self.budget_multiple, units).unwrap_or_else(|| {
-      panic!(
-        "tokora conformance: the anti-hang budget for a source of {units} units at a multiple of \
-         {} does not fit in a usize. This is a limit of the kit's arithmetic and not a verdict on \
-         the lexer, which has not been run. Lower the multiple with Harness::budget_multiple: an \
-         unrepresentable budget has to be replaced by some other number, and every replacement is \
-         wrong — usize::MAX overflows the per-instance ceiling derived from it and puts the item \
-         guards past any Vec length, and anything smaller certifies a budget you did not ask for.",
-        self.budget_multiple
-      )
-    })
-  }
 }
 
 impl<'inp, L> Harness<'inp, L>
@@ -437,9 +500,10 @@ where
   // lexer honest truncations without a growable source.
   L::Source: core::ops::Index<core::ops::RangeTo<usize>, Output = L::Source>,
   <L::Token as Token<'inp>>::Kind: PartialEq + core::fmt::Debug,
-  // Semantic equality on the compared values, and the only two bounds this tier asks for beyond
-  // what `run` needs. See `PartialItem::sig_eq` for why a `Debug` rendering cannot stand in, and
-  // `run_partial`'s own docs for who pays.
+  // Semantic equality on the compared values. Since 0.10.0 `run` asks for these two as well, so
+  // what separates the tiers is the three above and nothing about equality. See
+  // `PartialItem::sig_eq` for why a `Debug` rendering cannot stand in, and `run_partial`'s own
+  // docs for who pays.
   L::Token: PartialEq,
   <L::Token as Token<'inp>>::Error: PartialEq,
 {
@@ -463,9 +527,10 @@ where
   ///
   /// # Who pays for `PartialEq`, and what it buys
   ///
-  /// This entry point requires `L::Token: PartialEq` and `<L::Token as Token>::Error: PartialEq`,
-  /// which [`run`](Self::run) does not. That is a deliberate choice between the two ways to compare
-  /// a value the kit does not own:
+  /// This entry point requires `L::Token: PartialEq` and `<L::Token as Token>::Error: PartialEq`.
+  /// It asked for them one release before [`run`](Self::run) did, which is why the argument is
+  /// written out here; it is a deliberate choice between the two ways to compare a value the kit
+  /// does not own:
   ///
   /// - a **bound**, as here: the caller derives `PartialEq` — one line for the overwhelming
   ///   majority of vocabularies, which are plain data — and the comparison is then *total*. Every
@@ -477,16 +542,19 @@ where
   ///   this closes. That failure mode is the one the `Debug` rendering already had.
   ///
   /// The bound is the narrower of the two obligations in practice and the stronger guarantee, so it
-  /// is what this asks for. It is also the *restricted* entry point already —
-  /// [`Offset = usize`](crate::Lexer::Offset), a prefix-sliceable source and `L::State: Clone` are
-  /// all required here and not by [`run`](Self::run) — so it is the right place to ask.
+  /// is what this asks for. What still separates this entry point from [`run`](Self::run) is
+  /// [`Offset = usize`](crate::Lexer::Offset), a prefix-sliceable source and `L::State: Clone` —
+  /// all required here and not there. Equality is no longer part of that list: `run` compared an
+  /// error's `Debug` rendering and a token's kind until 0.10.0, and reported an identity it had
+  /// not checked for it (#269), so both entry points now ask for the same two bounds.
   ///
-  /// **A vocabulary with neither** loses this tier and keeps everything else: the trait tier and
-  /// the integration tier both run from [`run`](Self::run), whose bounds are unchanged. Recovering
-  /// this tier costs a `#[derive(PartialEq)]`, or a hand-written impl where derivation is wrong.
+  /// **A vocabulary with neither** loses the kit. Recovering it costs a `#[derive(PartialEq)]`,
+  /// or a hand-written impl where derivation is wrong.
   /// One caveat that comes with value equality rather than with this kit: a payload holding a
   /// `f64` that can be `NaN` is not equal to itself, and such a type must hand-write an impl that
-  /// says what it means.
+  /// says what it means. The kit does not silently accept one — a comparison it decides is
+  /// refused, tagged `non-reflexive-payload`, rather than reported as a conformance failure of
+  /// the lexer (#295).
   ///
   /// This is where a lexer that is not faithful under truncation is caught — one whose item
   /// identity depends on input beyond what it reports having read (lookahead past a token that
@@ -1325,6 +1393,43 @@ where
     }
   }
 
+  /// The first component of this item that fails to compare equal to **itself**, named for a
+  /// reader. `None` when every one of them is reflexive.
+  ///
+  /// This tier is where the defect was found (#295): its final leg compares the complete stream
+  /// against a final drain of the **same source**, so a payload that is not equal to itself fails
+  /// a stream against itself, and both sides of the report render identically. See
+  /// [`refuse_non_reflexive`].
+  fn non_reflexive(&self) -> Option<&'static str>
+  where
+    <L::Token as Token<'inp>>::Kind: PartialEq,
+    L::Token: PartialEq,
+    <L::Token as Token<'inp>>::Error: PartialEq,
+  {
+    match self {
+      Self::Token(tok, span) => {
+        if !self_equal(&tok.kind()) {
+          return Some("the token's `Kind`");
+        }
+        if !self_equal(tok) {
+          return Some("the token payload");
+        }
+        if !self_equal(span) {
+          return Some("the span");
+        }
+      }
+      Self::LexerError(span, payload) => {
+        if !self_equal(payload) {
+          return Some("the lexer error payload");
+        }
+        if !self_equal(span) {
+          return Some("the span");
+        }
+      }
+    }
+    None
+  }
+
   /// A human-readable one-line rendering for panic context.
   ///
   /// `Debug` is the right tool *here* and the wrong one in [`sig_eq`](Self::sig_eq): this text is
@@ -1638,6 +1743,20 @@ fn assert_partial_stream_eq<'inp, L>(
   let n = expected.len().min(got.len());
   for i in 0..n {
     if !expected[i].sig_eq(&got[i]) {
+      // The final leg compares the complete stream against a final drain of the SAME source, so
+      // this is the site #295 arrived through. See `refuse_non_reflexive`: reached only after the
+      // comparison has already failed, so it re-labels a failure and never creates one.
+      let at = format!("split k={k}, position {i}");
+      for (side, item) in [("expected", &expected[i]), ("got", &got[i])] {
+        refuse_non_reflexive(
+          idx,
+          "partial-equivalence",
+          &at,
+          side,
+          item.non_reflexive(),
+          &item.describe(),
+        );
+      }
       panic!(
         "tokora conformance [input #{idx} partial-equivalence] split k={k}, position {i}: prefix item diverges from the complete prefix: expected {}, got {}",
         expected[i].describe(),
@@ -1672,6 +1791,20 @@ fn assert_partial_prefix_of<'inp, L>(
   let n = expected.len().min(got.len());
   for i in 0..n {
     if !expected[i].sig_eq(&got[i]) {
+      // The sibling guard to `assert_partial_stream_eq`'s. A guard at one comparison and not the
+      // other is the same defect relocated: this leg compares two different drains, so a payload
+      // that will not equal itself fails here too, and reads as a truncation defect.
+      let at = format!("split k={k}, position {i}");
+      for (side, item) in [("expected", &expected[i]), ("got", &got[i])] {
+        refuse_non_reflexive(
+          idx,
+          "partial-equivalence",
+          &at,
+          side,
+          item.non_reflexive(),
+          &item.describe(),
+        );
+      }
       panic!(
         "tokora conformance [input #{idx} partial-equivalence] split k={k}, position {i}: prefix item diverges from the complete prefix: expected {}, got {}. An item that is an ERROR on the truncated buffer and a TOKEN on the full one — or an error whose payload moved — was decided from bytes that had not arrived.",
         expected[i].describe(),
@@ -1688,18 +1821,98 @@ fn assert_partial_prefix_of<'inp, L>(
   }
 }
 
+/// The second half of every `non-reflexive-payload` refusal, shared by the trait/partial tiers
+/// here and by the cache kit in [`cache`] so that the two cannot drift apart on what the
+/// diagnosis means or on what it asks the caller to do about it.
+const NON_REFLEXIVE_BODY: &str = "`PartialEq` is partial: it promises symmetry and transitivity, \
+   never reflexivity, and a payload holding an `f64` that can be `NaN` is the case that reaches \
+   this kit. Such a type must hand-write the impl that says what equality means for it — \
+   `Harness::run_partial`'s documentation has carried that obligation since the value comparison \
+   landed. Until it does, this kit cannot tell a value that will not compare from an \
+   implementation that diverges, and the failure it would otherwise report renders expected and \
+   got identically.";
+
+/// Whether `value` compares equal to **itself**.
+///
+/// Written as a call rather than as `value == value` because the two read as opposites: the
+/// operator form is a tautology — `clippy::eq_op` refuses it, and rightly, in the code this kit is
+/// made of — while here the answer really can be `false`. [`PartialEq`] is *partial*, and it
+/// promises symmetry and transitivity and **not** reflexivity; a payload holding an `f64` that can
+/// be `NaN` is the case that reaches this kit.
+fn self_equal<T>(value: &T) -> bool
+where
+  T: PartialEq + ?Sized,
+{
+  let mirror = value;
+  value == mirror
+}
+
+/// Refuses to draw a conformance verdict from a comparison that a value decided by failing to
+/// equal itself, and returns without a word when there is nothing to refuse.
+///
+/// # Why the kit refuses instead of reporting the failure it found
+///
+/// Every tier here decides pass/fail with `PartialEq` on values it does not own — the token, the
+/// lexer's error payload, and in the cache kit the lexer state. Reflexivity is the one law of an
+/// equivalence relation that `PartialEq` does not promise, and when a payload breaks it the
+/// comparison fails for a reason that is a **fact about the payload type** and not about the
+/// lexer, the cache or the input layer under test.
+///
+/// The failure that produced is not merely mislabelled, it is unreadable: a final partial drain
+/// compares a stream against itself, so `expected` and `got` are the same item, and the
+/// `partial-equivalence` panic hands the consumer a red accusing their lexer with two values that
+/// **render identically** (`NaN` and `NaN`). That was #295, and 38 corpus queries in one
+/// downstream reached it.
+///
+/// So before a tier reports divergence it asks each side whether it is equal to itself, and a
+/// side that is not gets this refusal instead — a distinct tag, the component that will not
+/// compare, and the obligation it comes from. The kit says what it cannot check rather than
+/// naming a culprit it has not identified.
+///
+/// # It can only ever re-label a failure, never create one
+///
+/// Every call site reaches this **after** its own comparison has already failed, so a run that
+/// passes cannot be turned red by it and a run this refuses was already going to be reported as a
+/// failure. That is what keeps the repair from trading a false red for a false green: a
+/// genuinely non-conforming lexer whose payloads *are* reflexive never reaches this line and
+/// still fails the ordinary way, with the ordinary tag.
+///
+/// # This is not a relaxation of the contract
+///
+/// The obligation predates the report: [`Harness::run_partial`]'s documentation has said since
+/// 0.10.0 that a payload holding a `NaN`-capable `f64` must hand-write the impl that says what
+/// equality means for it. Nothing here excuses that. What changes is the *diagnosis* — the kit
+/// stops calling an unmet obligation a lexer defect.
+fn refuse_non_reflexive(
+  idx: usize,
+  op: &str,
+  at: &str,
+  side: &str,
+  component: Option<&'static str>,
+  rendered: &str,
+) {
+  let Some(component) = component else {
+    return;
+  };
+  panic!(
+    "tokora conformance [input #{idx} non-reflexive-payload] {op} {at}: INCONCLUSIVE — \
+     {component} of the {side} item {rendered} is not equal to ITSELF, so the comparison that \
+     just failed was decided by the payload type and not by the lexer, which this kit has \
+     therefore not convicted of anything. {NON_REFLEXIVE_BODY}"
+  )
+}
+
 /// One observed lexer item, captured with everything the checks compare or resume from.
 struct Item<'inp, L>
 where
   L: Lexer<'inp>,
 {
-  /// `true` if the item was an [`Err`], `false` for a token.
-  is_error: bool,
-  /// The token kind (for a token) or `None` (for an error).
-  kind: Option<<L::Token as Token<'inp>>::Kind>,
-  /// The error's `Debug` rendering (for an error) or empty (for a token). `Token::Error`
-  /// is only `Debug`, not `PartialEq`, so its `Debug` string is the comparison key.
-  err_dbg: String,
+  /// The item **itself**, by value: the token the lexer yielded or the error it raised.
+  ///
+  /// [`Lexer::lex`] hands this back owned, so keeping it costs *less* than the pair it replaced —
+  /// a `format!("{err:?}")` `String` allocated per error item, plus the kind projected out of the
+  /// token. See [`sig_eq`](Self::sig_eq) for why the value and never a rendering of it.
+  item: Result<L::Token, <L::Token as Token<'inp>>::Error>,
   /// The item's span.
   span: L::Span,
   /// The item's slice.
@@ -1714,21 +1927,99 @@ impl<'inp, L> Item<'inp, L>
 where
   L: Lexer<'inp>,
 {
-  /// Whether two items agree on discriminant, kind/error, span, and slice.
-  fn sig_eq(&self, other: &Self) -> bool {
-    self.is_error == other.is_error
-      && self.kind == other.kind
-      && self.err_dbg == other.err_dbg
-      && self.span == other.span
+  /// The token kind (for a token) or `None` (for an error).
+  fn kind(&self) -> Option<<L::Token as Token<'inp>>::Kind> {
+    self.item.as_ref().ok().map(Token::kind)
+  }
+
+  /// Whether two items agree on discriminant, **value**, span and slice.
+  ///
+  /// # Semantically, never by rendering
+  ///
+  /// This compared `format!("{err:?}")` on the error arm, and the token's
+  /// [`kind`](Token::kind) alone on the token arm, until 0.10.0 — and both halves reported an
+  /// identity the kit had not checked (#269). The argument is [`PartialItem::sig_eq`]'s,
+  /// verbatim, and it had already been made there for the partial tier:
+  ///
+  /// - `Debug` is not **injective**, so two distinct error payloads may render identically — a
+  ///   hand-written `Debug` printing one label for a family of variants is legal and not rare —
+  ///   and then a lexer whose error *value* changes between two fresh runs passes replay
+  ///   identity.
+  /// - `Debug` is not **stable**, so a rendering carrying an address, a counter or any other
+  ///   incidental differs between the two separately constructed lexers and reds a **conforming**
+  ///   one. Both directions have in-tree cells; a rendering is the wrong key in each of them, and
+  ///   no amount of care with the rendering fixes both, because they run in opposite directions.
+  /// - the token arm compared only the kind, so a payload that moved between two fresh runs kept
+  ///   its kind, its span and its slice — everything this looked at — while the value a parser
+  ///   callback receives changed.
+  ///
+  /// The module header states check 1 as identity of the *item*, and identity of a rendering or
+  /// of a projection is a weaker claim wearing that word. Value equality is the claim, which is
+  /// what [`run`](Harness::run) now asks `PartialEq` for.
+  fn sig_eq(&self, other: &Self) -> bool
+  where
+    L::Token: PartialEq,
+    <L::Token as Token<'inp>>::Error: PartialEq,
+  {
+    self.span == other.span
       && self.slice == other.slice
+      && match (&self.item, &other.item) {
+        // The kind is compared as well as the token, for [`PartialItem::sig_eq`]'s reason: the
+        // two are independent caller code, and a `PartialEq` coarser than the classification the
+        // parser sees is exactly what this comparison stands between.
+        (Ok(a), Ok(b)) => a.kind() == b.kind() && a == b,
+        (Err(a), Err(b)) => a == b,
+        _ => false,
+      }
+  }
+
+  /// The first component of this item that fails to compare equal to **itself**, named for a
+  /// reader. `None` when every one of them is reflexive.
+  ///
+  /// See [`refuse_non_reflexive`] for what this is read for and why.
+  fn non_reflexive(&self) -> Option<&'static str>
+  where
+    L::Token: PartialEq,
+    <L::Token as Token<'inp>>::Error: PartialEq,
+  {
+    match &self.item {
+      Ok(tok) => {
+        if !self_equal(&tok.kind()) {
+          return Some("the token's `Kind`");
+        }
+        if !self_equal(tok) {
+          return Some("the token payload");
+        }
+      }
+      Err(err) => {
+        if !self_equal(err) {
+          return Some("the lexer error payload");
+        }
+      }
+    }
+    if !self_equal(&self.span) {
+      return Some("the span");
+    }
+    if !self_equal(&self.slice) {
+      return Some("the slice");
+    }
+    None
   }
 
   /// A human-readable one-line rendering for panic context.
+  ///
+  /// `Debug` is the right tool *here* and the wrong one in [`sig_eq`](Self::sig_eq): this text is
+  /// read by a person diagnosing a failure, and nothing is decided from it.
   fn describe(&self) -> String {
-    format!(
-      "{{ error={}, kind={:?}, err={:?}, span={:?}, slice={:?} }}",
-      self.is_error, self.kind, self.err_dbg, self.span, self.slice
-    )
+    match &self.item {
+      Ok(tok) => format!(
+        "token {:?}@{:?} (payload {tok:?}, slice {:?})",
+        tok.kind(),
+        self.span,
+        self.slice
+      ),
+      Err(err) => format!("lexer error {err:?}@{:?} (slice {:?})", self.span, self.slice),
+    }
   }
 }
 
@@ -1814,14 +2105,8 @@ where
       );
     }
 
-    let (is_error, kind, err_dbg) = match res {
-      Ok(tok) => (false, Some(tok.kind()), String::new()),
-      Err(err) => (true, None, format!("{err:?}")),
-    };
     out.push(Item {
-      is_error,
-      kind,
-      err_dbg,
+      item: res,
       span,
       slice,
       end,
@@ -1836,10 +2121,19 @@ where
 fn assert_run_eq<'inp, L>(idx: usize, op: &str, expected: &[Item<'inp, L>], got: &[Item<'inp, L>])
 where
   L: Lexer<'inp>,
+  L::Token: PartialEq,
+  <L::Token as Token<'inp>>::Error: PartialEq,
 {
   let n = expected.len().min(got.len());
   for i in 0..n {
     if !expected[i].sig_eq(&got[i]) {
+      // Before naming a culprit, ask whether either side is even comparable to itself. See
+      // `refuse_non_reflexive`: this is reached only once the comparison has failed, so it can
+      // re-label this failure and can never manufacture one.
+      let at = format!("position {i}");
+      for (side, item) in [("expected", &expected[i]), ("got", &got[i])] {
+        refuse_non_reflexive(idx, op, &at, side, item.non_reflexive(), &item.describe());
+      }
       panic!(
         "tokora conformance [input #{idx} {op}] position {i}: item mismatch: expected {}, got {}",
         expected[i].describe(),
@@ -1944,6 +2238,8 @@ fn check_resume<'inp, L>(
   budget: usize,
 ) where
   L: Lexer<'inp>,
+  L::Token: PartialEq,
+  <L::Token as Token<'inp>>::Error: PartialEq,
 {
   for k in 0..=reference.len() {
     // The resume point before item k: for k == 0 the initial state at offset 0, else
@@ -1967,15 +2263,9 @@ fn check_resume<'inp, L>(
       let Some(res) = resumed.lex() else { break };
       let span = resumed.span();
       let slice = resumed.slice();
-      let (is_error, kind, err_dbg) = match res {
-        Ok(tok) => (false, Some(tok.kind()), String::new()),
-        Err(err) => (true, None, format!("{err:?}")),
-      };
       let end = span.end_ref().clone();
       let observed = Item::<L> {
-        is_error,
-        kind,
-        err_dbg,
+        item: res,
         span,
         slice,
         end,
@@ -1985,6 +2275,19 @@ fn check_resume<'inp, L>(
       match reference.get(k + produced) {
         Some(expected) => {
           if !expected.sig_eq(&observed) {
+            // The same guard `assert_run_eq` carries, for the same reason and under the same
+            // "only after a failed comparison" rule. See `refuse_non_reflexive`.
+            let at = format!("resume-from k={k}, position {produced}");
+            for (side, item) in [("expected", expected), ("got", &observed)] {
+              refuse_non_reflexive(
+                idx,
+                "state-resume",
+                &at,
+                side,
+                item.non_reflexive(),
+                &item.describe(),
+              );
+            }
             panic!(
               "tokora conformance [input #{idx} state-resume] resume-from k={k}, position {produced}: resumed item diverges from the original suffix: expected {}, got {}",
               expected.describe(),
@@ -2151,7 +2454,7 @@ fn check_integration<'inp, L>(
   // (errors are skipped by `next()`, so filter the reference to its Ok items).
   let raw_tokens: Vec<(<L::Token as Token<'inp>>::Kind, L::Span)> = reference
     .iter()
-    .filter_map(|it| it.kind.map(|k| (k, it.span.clone())))
+    .filter_map(|it| it.kind().map(|k| (k, it.span.clone())))
     .collect();
   assert_stream_eq::<L>(idx, "raw-lex-vs-next", &raw_tokens, &straight);
 
@@ -2247,6 +2550,29 @@ fn check_integration<'inp, L>(
   assert_stream_eq::<L>(idx, "nested-savepoints", &straight, &nested);
 }
 
+/// The first component of a committed `(kind, span)` pair that fails to compare equal to
+/// **itself**, named for a reader. `None` when both are reflexive.
+///
+/// Both components are bounded stronger than [`PartialEq`] — [`Token::Kind`] is `Eq` and
+/// [`Lexer::Span`] is `Ord` — so an answer other than `None` here means an implementation claiming
+/// a total equality it does not have. That is a *worse* caller defect than the partial one
+/// [`Item::non_reflexive`] answers for, and reporting it as a divergence of the committed stream
+/// is exactly as wrong. See [`refuse_non_reflexive`].
+fn stream_pair_non_reflexive<'inp, L>(
+  pair: &(<L::Token as Token<'inp>>::Kind, L::Span),
+) -> Option<&'static str>
+where
+  L: Lexer<'inp>,
+{
+  if !self_equal(&pair.0) {
+    return Some("the token's `Kind`");
+  }
+  if !self_equal(&pair.1) {
+    return Some("the span");
+  }
+  None
+}
+
 /// Asserts two committed (kind, span) token streams are identical, with position context.
 fn assert_stream_eq<'inp, L>(
   idx: usize,
@@ -2259,6 +2585,23 @@ fn assert_stream_eq<'inp, L>(
   let n = expected.len().min(got.len());
   for i in 0..n {
     if expected[i] != got[i] {
+      // The third member of the same population. `Token::Kind` is bounded `Eq` and `Lexer::Span`
+      // is bounded `Ord`, so non-reflexivity here is a broken TOTAL-equality promise rather than
+      // the partial one the token and error payloads carry — a stronger caller defect, and the
+      // same wrong verdict to report as a stream divergence. Guarding four comparisons and not
+      // the fifth is the defect relocated, and this one costs a call on a path already panicking.
+      let op = format!("integration/{sched}");
+      let at = format!("position {i}");
+      for (side, pair) in [("expected", &expected[i]), ("got", &got[i])] {
+        refuse_non_reflexive(
+          idx,
+          &op,
+          &at,
+          side,
+          stream_pair_non_reflexive::<L>(pair),
+          &format!("{pair:?}"),
+        );
+      }
       panic!(
         "tokora conformance [input #{idx} integration/{sched}] position {i}: committed token stream diverges: expected {:?}, got {:?}",
         expected[i], got[i]

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -138,8 +138,16 @@
 //! population of honest failures. All of those are **conclusive**, and a conclusive difference
 //! outranks an inconclusive one wherever both are available: the first inconclusive difference is
 //! retained as a fallback while the search continues into the remaining components of the item,
-//! the later positions of the stream, and the item count, and it is reported only if nothing
-//! conclusive is found anywhere. `Ranking` carries that rule and the argument for it.
+//! the later positions of the stream, the item count, and — where a law is decided by two whole
+//! answers rather than by components — the second arm of the integration tier's observation and
+//! the second half of a prefilled peek's buffer. It is reported only if nothing conclusive is
+//! found anywhere. `Ranking` carries that rule and the argument for it.
+//!
+//! The search is bounded by one **verdict**, and that is the honest edge of it. Two checks under
+//! two different tags are two laws, and the kit keeps its assert-with-context posture across
+//! them: a refusal at replay identity ends the run without asking what state-resume would have
+//! said. Widening that would make the harness accumulate failures instead of stopping at the
+//! first, which is a different tool from the one this module says it is.
 //!
 //! Both halves were learned from the same failure, one direction at a time. Answering `false` and
 //! then scanning the whole item for a non-reflexive value asked a different question from the one
@@ -2251,8 +2259,9 @@ where
 }
 
 /// Both sides' [`refuse_non_reflexive`] for one failed item comparison, asked of the operation
-/// that decided it. Shared by the four item-comparing sites so the rule cannot come to hold at
-/// one of them and not at another.
+/// that decided it. Shared by every site that compares two items — no count is given, because a
+/// count in a comment is a thing that drifts and this branch has already had to correct one: the
+/// population is whichever sites call this, and calling it is the only way to reach the refusal.
 fn refuse_decided(idx: usize, op: &str, at: &str, decided: &Decided, expected: &str, got: &str) {
   refuse_component(idx, op, at, "item", decided, expected, got);
 }

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -109,12 +109,24 @@
 //! promises symmetry and transitivity but **not** reflexivity: a payload holding an `f64` that can
 //! be `NaN` is not equal to itself. Every comparison any tier draws a verdict from — the two in
 //! the trait tier, the two in the partial tier, the committed-stream one in the integration tier,
-//! and the entry and purity comparisons in [`cache`] — therefore asks, once it has already
-//! failed, whether either side is equal to itself. A side that is not gets a refusal tagged
-//! `non-reflexive-payload` naming the component and the obligation, instead of a conformance
-//! verdict whose expected-vs-got renders identically on both sides (#295). The obligation itself
-//! is unchanged and is the caller's: such a type hand-writes the impl that says what equality
-//! means for it.
+//! and the entry and purity comparisons in [`cache`] — therefore answers with the **component
+//! that decided it**, and asks, once it has already failed, whether *that* operation is equal to
+//! itself. A side whose is not gets a refusal tagged `non-reflexive-payload` naming the component
+//! and the obligation, instead of a conformance verdict whose expected-vs-got renders identically
+//! on both sides (#295). The obligation itself is unchanged and is the caller's: such a type
+//! hand-writes the impl that says what equality means for it.
+//!
+//! **The converse is the same rule, and it is what a `bool` could not express.** A comparison
+//! settled by something other than a caller's `PartialEq` is reported directly and terminally: a
+//! difference at the **discriminant** — an item that is a lexer error on one side and a committed
+//! token on the other — or at a component bounded to a *total* equality, or a difference in item
+//! **count**, consults no partial equality at all, so there is nothing there to refuse. Answering
+//! `false` and then scanning the whole item for a non-reflexive value asked a different question
+//! from the one the comparison had asked, and it hid the truncation nonconformance the partial
+//! tier exists to report behind a refusal saying the kit had convicted the lexer of nothing. The
+//! kit never reports an identity it did not check, and it never withholds a verdict it did
+//! establish; those are one rule, and [`Comparison`] is where it is enforced rather than
+//! remembered.
 
 pub mod cache;
 pub mod emitter;
@@ -412,7 +424,7 @@ where
   L: Lexer<'inp>,
   // Semantic equality on the two values every trait-tier comparison is drawn from. These are the
   // only bounds this entry point asks for beyond `Lexer` itself; see `run`'s own docs for who
-  // pays and what the alternatives cost, and `Item::sig_eq` for why a `Debug` rendering and a
+  // pays and what the alternatives cost, and `Item::compare` for why a `Debug` rendering and a
   // `kind` projection are each the wrong key.
   L::Token: PartialEq,
   <L::Token as Token<'inp>>::Error: PartialEq,
@@ -502,7 +514,7 @@ where
   <L::Token as Token<'inp>>::Kind: PartialEq + core::fmt::Debug,
   // Semantic equality on the compared values. Since 0.10.0 `run` asks for these two as well, so
   // what separates the tiers is the three above and nothing about equality. See
-  // `PartialItem::sig_eq` for why a `Debug` rendering cannot stand in, and `run_partial`'s own
+  // `PartialItem::compare` for why a `Debug` rendering cannot stand in, and `run_partial`'s own
   // docs for who pays.
   L::Token: PartialEq,
   <L::Token as Token<'inp>>::Error: PartialEq,
@@ -1352,7 +1364,20 @@ where
   }
 
   /// Whether two items agree on discriminant, span, and **value** — the token itself on one arm,
-  /// the error payload on the other.
+  /// the error payload on the other — and, when they do not, **which of those decided it**.
+  ///
+  /// # The order the components are consulted in, and what rests on it
+  ///
+  /// Discriminant, then the components bounded to a *total* equality ([`kind`](Token::kind) is
+  /// `Eq`, the span is `Ord`), then the payload, whose [`PartialEq`] promises no reflexivity.
+  /// Two sides can differ in several components at once, and this names the first one in that
+  /// order: a divergence a total equality can settle is never attributed to a partial one, and
+  /// the answer is a true statement about a comparison that really failed either way.
+  ///
+  /// Nothing about **correctness** rests on the order, which is the point of stating it. The
+  /// refusal asks its question of whichever component is named, so it fires exactly when the
+  /// operation that produced the verdict is unsound — under this order or any other. What the
+  /// order buys is a *diagnosis*: the strongest evidence available gets to speak.
   ///
   /// # Semantically, never by rendering
   ///
@@ -1380,59 +1405,44 @@ where
   /// ignores a field [`kind`](Token::kind) reads is coarser than the classification the parser
   /// sees, and this comparison is the only thing standing between that and a silent pass. It can
   /// only ever red *more*.
-  fn sig_eq(&self, other: &Self) -> bool
+  fn compare(&self, other: &Self) -> Comparison
   where
     <L::Token as Token<'inp>>::Kind: PartialEq,
     L::Token: PartialEq,
     <L::Token as Token<'inp>>::Error: PartialEq,
   {
     match (self, other) {
-      (Self::Token(a, sa), Self::Token(b, sb)) => a.kind() == b.kind() && a == b && sa == sb,
-      (Self::LexerError(sa, a), Self::LexerError(sb, b)) => sa == sb && a == b,
-      _ => false,
-    }
-  }
-
-  /// The first component of this item that fails to compare equal to **itself**, named for a
-  /// reader. `None` when every one of them is reflexive.
-  ///
-  /// This tier is where the defect was found (#295): its final leg compares the complete stream
-  /// against a final drain of the **same source**, so a payload that is not equal to itself fails
-  /// a stream against itself, and both sides of the report render identically. See
-  /// [`refuse_non_reflexive`].
-  fn non_reflexive(&self) -> Option<&'static str>
-  where
-    <L::Token as Token<'inp>>::Kind: PartialEq,
-    L::Token: PartialEq,
-    <L::Token as Token<'inp>>::Error: PartialEq,
-  {
-    match self {
-      Self::Token(tok, span) => {
-        if !self_equal(&tok.kind()) {
-          return Some("the token's `Kind`");
+      (Self::Token(a, sa), Self::Token(b, sb)) => {
+        let (ka, kb) = (a.kind(), b.kind());
+        if ka != kb {
+          return Comparison::Differs(decided_by(Decided::KIND, &ka, &kb));
         }
-        if !self_equal(tok) {
-          return Some("the token payload");
+        if sa != sb {
+          return Comparison::Differs(decided_by(Decided::SPAN, sa, sb));
         }
-        if !self_equal(span) {
-          return Some("the span");
+        if a != b {
+          return Comparison::Differs(decided_by(Decided::TOKEN_PAYLOAD, a, b));
         }
+        Comparison::Equal
       }
-      Self::LexerError(span, payload) => {
-        if !self_equal(payload) {
-          return Some("the lexer error payload");
+      (Self::LexerError(sa, a), Self::LexerError(sb, b)) => {
+        if sa != sb {
+          return Comparison::Differs(decided_by(Decided::SPAN, sa, sb));
         }
-        if !self_equal(span) {
-          return Some("the span");
+        if a != b {
+          return Comparison::Differs(decided_by(Decided::ERROR_PAYLOAD, a, b));
         }
+        Comparison::Equal
       }
+      // A committed token against a lexer error. This tier exists to catch exactly that, and no
+      // caller equality was consulted to find it — see [`Decided::Discriminant`].
+      _ => Comparison::Differs(Decided::Discriminant),
     }
-    None
   }
 
   /// A human-readable one-line rendering for panic context.
   ///
-  /// `Debug` is the right tool *here* and the wrong one in [`sig_eq`](Self::sig_eq): this text is
+  /// `Debug` is the right tool *here* and the wrong one in [`compare`](Self::compare): this text is
   /// read by a person diagnosing a failure, and nothing is decided from it.
   fn describe(&self) -> String
   where
@@ -1485,7 +1495,7 @@ type PartialLog<'inp, L> = Rc<RefCell<Vec<PartialItem<'inp, L>>>>;
 /// properties a comparison key has to have, and `Debug` has neither: it is not injective, so a
 /// payload that really does move can render identically and pass; and it is not stable, so a
 /// payload rendering an address or a counter reds on a conforming lexer. See
-/// [`PartialItem::sig_eq`] for the full argument and for what the bound on
+/// [`PartialItem::compare`] for the full argument and for what the bound on
 /// [`run_partial`](Harness::run_partial) buys.
 struct PartialRecorder<'inp, L>
 where
@@ -1742,21 +1752,21 @@ fn assert_partial_stream_eq<'inp, L>(
 {
   let n = expected.len().min(got.len());
   for i in 0..n {
-    if !expected[i].sig_eq(&got[i]) {
+    if let Comparison::Differs(decided) = expected[i].compare(&got[i]) {
       // The final leg compares the complete stream against a final drain of the SAME source, so
       // this is the site #295 arrived through. See `refuse_non_reflexive`: reached only after the
-      // comparison has already failed, so it re-labels a failure and never creates one.
+      // comparison has already failed, so it re-labels a failure and never creates one — and it
+      // is asked about the component that failed, so a divergence the discriminant settled falls
+      // straight through to the verdict below.
       let at = format!("split k={k}, position {i}");
-      for (side, item) in [("expected", &expected[i]), ("got", &got[i])] {
-        refuse_non_reflexive(
-          idx,
-          "partial-equivalence",
-          &at,
-          side,
-          item.non_reflexive(),
-          &item.describe(),
-        );
-      }
+      refuse_decided(
+        idx,
+        "partial-equivalence",
+        &at,
+        &decided,
+        &expected[i].describe(),
+        &got[i].describe(),
+      );
       panic!(
         "tokora conformance [input #{idx} partial-equivalence] split k={k}, position {i}: prefix item diverges from the complete prefix: expected {}, got {}",
         expected[i].describe(),
@@ -1790,21 +1800,23 @@ fn assert_partial_prefix_of<'inp, L>(
 {
   let n = expected.len().min(got.len());
   for i in 0..n {
-    if !expected[i].sig_eq(&got[i]) {
+    if let Comparison::Differs(decided) = expected[i].compare(&got[i]) {
       // The sibling guard to `assert_partial_stream_eq`'s. A guard at one comparison and not the
       // other is the same defect relocated: this leg compares two different drains, so a payload
       // that will not equal itself fails here too, and reads as a truncation defect.
+      //
+      // And this is the leg where the whole-item scan cost the most: an error on the truncated
+      // buffer against a token on the full one is what the panic below is *about*, and a scan
+      // that found a `NaN` on either side buried it under a refusal.
       let at = format!("split k={k}, position {i}");
-      for (side, item) in [("expected", &expected[i]), ("got", &got[i])] {
-        refuse_non_reflexive(
-          idx,
-          "partial-equivalence",
-          &at,
-          side,
-          item.non_reflexive(),
-          &item.describe(),
-        );
-      }
+      refuse_decided(
+        idx,
+        "partial-equivalence",
+        &at,
+        &decided,
+        &expected[i].describe(),
+        &got[i].describe(),
+      );
       panic!(
         "tokora conformance [input #{idx} partial-equivalence] split k={k}, position {i}: prefix item diverges from the complete prefix: expected {}, got {}. An item that is an ERROR on the truncated buffer and a TOKEN on the full one — or an error whose payload moved — was decided from bytes that had not arrived.",
         expected[i].describe(),
@@ -1847,6 +1859,132 @@ where
   value == mirror
 }
 
+/// What a verdict-drawing comparison found: the two sides agreed, or they differed and the
+/// answer says **which operation decided it**.
+///
+/// A `bool` said only *whether*. The refusal below then had to guess *why*, and the only tool it
+/// had was a scan of everything the item holds — a second question, asked of values the
+/// comparison may never have looked at. Nothing linked the two, and the gap is not academic: a
+/// committed token on one side and a lexer error on the other differ at the **discriminant**,
+/// with no caller comparison run at all, and a whole-item scan still found a `NaN` in the payload
+/// and refused. That refusal states a diagnosis the kit did not establish, over exactly the
+/// truncation nonconformance the partial tier exists to report.
+enum Comparison {
+  /// Every component the comparison consults agreed.
+  Equal,
+  /// The two sides differ, and [`Decided`] names the operation the verdict rests on.
+  Differs(Decided),
+}
+
+/// The operation a failed comparison was decided by, carrying the reflexivity question asked of
+/// **that** operation — and of nothing else — on each side.
+///
+/// The probe is computed by [`decided_by`] from the same two values the failed comparison was
+/// drawn from, on the same statement. That adjacency is the repair: a refusal can no longer speak
+/// about a component the comparison never consulted, because the only way to build one is from
+/// the comparison that ran.
+enum Decided {
+  /// The kit's own `match` on the two discriminants: a committed token on one side and a lexer
+  /// error on the other.
+  ///
+  /// **No caller comparison ran.** There is no equality behind this to be non-reflexive, so
+  /// there is nothing to refuse and the divergence is reported directly — which is right, since
+  /// an item that is an error on a truncated buffer and a token on the full one is precisely the
+  /// truncation nonconformance the partial tier is for.
+  Discriminant,
+  /// One named component's comparison decided it, and it is sound on whichever side is marked
+  /// reflexive.
+  Component {
+    /// The component, named as the refusal names it.
+    name: &'static str,
+    /// Whether the expected side's `name` compares equal to itself.
+    expected_reflexive: bool,
+    /// Whether the got side's `name` compares equal to itself.
+    got_reflexive: bool,
+  },
+}
+
+impl Decided {
+  /// ``"the token's `Kind`"`` — bounded [`Eq`], so a refusal naming it is a broken **total**
+  /// equality promise rather than the partial one a payload carries.
+  const KIND: &'static str = "the token's `Kind`";
+  /// `"the span"` — [`Lexer::Span`] is bounded `Ord`, so this too is a total promise.
+  const SPAN: &'static str = "the span";
+  /// `"the slice"` — [`Slice`] is bounded `Eq`, so this too is a total promise.
+  const SLICE: &'static str = "the slice";
+  /// `"the token payload"` — the caller's [`PartialEq`] on [`Lexer::Token`], where reflexivity is
+  /// promised by nothing. This is #295's home.
+  const TOKEN_PAYLOAD: &'static str = "the token payload";
+  /// `"the lexer error payload"` — the caller's [`PartialEq`] on [`Token::Error`], the other half
+  /// of that population.
+  const ERROR_PAYLOAD: &'static str = "the lexer error payload";
+  /// ``"the `L::State`"`` — the caller's [`PartialEq`] on [`Lexer::State`], which only the cache
+  /// tier compares.
+  const STATE: &'static str = "the `L::State`";
+
+  /// The component to refuse over on the **expected** side, and `None` when the operation that
+  /// failed is sound there — or when no caller comparison ran at all.
+  const fn expected(&self) -> Option<&'static str> {
+    match self {
+      Self::Discriminant => None,
+      Self::Component {
+        name,
+        expected_reflexive,
+        ..
+      } => {
+        if *expected_reflexive {
+          None
+        } else {
+          Some(*name)
+        }
+      }
+    }
+  }
+
+  /// [`expected`](Self::expected) on the **got** side.
+  const fn got(&self) -> Option<&'static str> {
+    match self {
+      Self::Discriminant => None,
+      Self::Component {
+        name,
+        got_reflexive,
+        ..
+      } => {
+        if *got_reflexive {
+          None
+        } else {
+          Some(*name)
+        }
+      }
+    }
+  }
+}
+
+/// One component's comparison that **failed**, together with the reflexivity question asked of
+/// that same comparison on both sides.
+///
+/// Every [`Decided::Component`] in the kit is built here, from the two values the caller has just
+/// compared, so the probe and the failure cannot be about different operations. Reached only on
+/// the failure path, so a passing comparison pays for none of it.
+fn decided_by<T>(name: &'static str, expected: &T, got: &T) -> Decided
+where
+  T: PartialEq + ?Sized,
+{
+  Decided::Component {
+    name,
+    expected_reflexive: self_equal(expected),
+    got_reflexive: self_equal(got),
+  }
+}
+
+/// Both sides' [`refuse_non_reflexive`] for one failed item comparison, asked of the operation
+/// that decided it. Shared by the four item-comparing sites so the rule cannot come to hold at
+/// one of them and not at another.
+fn refuse_decided(idx: usize, op: &str, at: &str, decided: &Decided, expected: &str, got: &str) {
+  refuse_non_reflexive(idx, op, at, "expected", decided.expected(), expected);
+  refuse_non_reflexive(idx, op, at, "got", decided.got(), got);
+}
+
 /// Refuses to draw a conformance verdict from a comparison that a value decided by failing to
 /// equal itself, and returns without a word when there is nothing to refuse.
 ///
@@ -1864,10 +2002,22 @@ where
 /// **render identically** (`NaN` and `NaN`). That was #295, and 38 corpus queries in one
 /// downstream reached it.
 ///
-/// So before a tier reports divergence it asks each side whether it is equal to itself, and a
-/// side that is not gets this refusal instead — a distinct tag, the component that will not
-/// compare, and the obligation it comes from. The kit says what it cannot check rather than
-/// naming a culprit it has not identified.
+/// So before a tier reports divergence it asks whether the **operation that decided it** is equal
+/// to itself, and a side whose is not gets this refusal instead — a distinct tag, the component
+/// that will not compare, and the obligation it comes from. The kit says what it cannot check
+/// rather than naming a culprit it has not identified.
+///
+/// # It asks about the comparison that ran, and about nothing else
+///
+/// `component` comes from [`Decided`], which every [`Comparison`] in the kit produces from the
+/// two values whose comparison failed. It is never a scan of the item, and the difference is the
+/// whole of what a scan got wrong: a scan runs afterwards and knows nothing about *why*, so a
+/// divergence settled at the **discriminant** — a committed token on one side, a lexer error on
+/// the other, no caller equality consulted at all — still turned up a `NaN` somewhere in the
+/// payload and was refused. That is a diagnosis stated without having been established, and the
+/// thing it hid is the truncation nonconformance the partial tier is built to report. A
+/// difference at the discriminant, or at a component whose comparison is sound, is therefore
+/// terminal here: this returns without a word and the ordinary verdict follows.
 ///
 /// # It can only ever re-label a failure, never create one
 ///
@@ -1911,7 +2061,7 @@ where
   ///
   /// [`Lexer::lex`] hands this back owned, so keeping it costs *less* than the pair it replaced —
   /// a `format!("{err:?}")` `String` allocated per error item, plus the kind projected out of the
-  /// token. See [`sig_eq`](Self::sig_eq) for why the value and never a rendering of it.
+  /// token. See [`compare`](Self::compare) for why the value and never a rendering of it.
   item: Result<L::Token, <L::Token as Token<'inp>>::Error>,
   /// The item's span.
   span: L::Span,
@@ -1932,13 +2082,17 @@ where
     self.item.as_ref().ok().map(Token::kind)
   }
 
-  /// Whether two items agree on discriminant, **value**, span and slice.
+  /// Whether two items agree on discriminant, **value**, span and slice — and, when they do not,
+  /// **which of those decided it**.
+  ///
+  /// The components are consulted in [`PartialItem::compare`]'s order and for its reason, with
+  /// the slice — bounded [`Eq`], another total promise — between the span and the payload.
   ///
   /// # Semantically, never by rendering
   ///
   /// This compared `format!("{err:?}")` on the error arm, and the token's
   /// [`kind`](Token::kind) alone on the token arm, until 0.10.0 — and both halves reported an
-  /// identity the kit had not checked (#269). The argument is [`PartialItem::sig_eq`]'s,
+  /// identity the kit had not checked (#269). The argument is [`PartialItem::compare`]'s,
   /// verbatim, and it had already been made there for the partial tier:
   ///
   /// - `Debug` is not **injective**, so two distinct error payloads may render identically — a
@@ -1956,59 +2110,61 @@ where
   /// The module header states check 1 as identity of the *item*, and identity of a rendering or
   /// of a projection is a weaker claim wearing that word. Value equality is the claim, which is
   /// what [`run`](Harness::run) now asks `PartialEq` for.
-  fn sig_eq(&self, other: &Self) -> bool
+  fn compare(&self, other: &Self) -> Comparison
   where
     L::Token: PartialEq,
     <L::Token as Token<'inp>>::Error: PartialEq,
   {
-    self.span == other.span
-      && self.slice == other.slice
-      && match (&self.item, &other.item) {
-        // The kind is compared as well as the token, for [`PartialItem::sig_eq`]'s reason: the
+    match (&self.item, &other.item) {
+      (Ok(a), Ok(b)) => {
+        // The kind is compared as well as the token, for [`PartialItem::compare`]'s reason: the
         // two are independent caller code, and a `PartialEq` coarser than the classification the
         // parser sees is exactly what this comparison stands between.
-        (Ok(a), Ok(b)) => a.kind() == b.kind() && a == b,
-        (Err(a), Err(b)) => a == b,
-        _ => false,
+        let (ka, kb) = (a.kind(), b.kind());
+        if ka != kb {
+          return Comparison::Differs(decided_by(Decided::KIND, &ka, &kb));
+        }
+        if let Comparison::Differs(decided) = self.compare_shared(other) {
+          return Comparison::Differs(decided);
+        }
+        if a != b {
+          return Comparison::Differs(decided_by(Decided::TOKEN_PAYLOAD, a, b));
+        }
+        Comparison::Equal
       }
+      (Err(a), Err(b)) => {
+        if let Comparison::Differs(decided) = self.compare_shared(other) {
+          return Comparison::Differs(decided);
+        }
+        if a != b {
+          return Comparison::Differs(decided_by(Decided::ERROR_PAYLOAD, a, b));
+        }
+        Comparison::Equal
+      }
+      // A token on one side and a lexer error on the other — see [`Decided::Discriminant`].
+      _ => Comparison::Differs(Decided::Discriminant),
+    }
   }
 
-  /// The first component of this item that fails to compare equal to **itself**, named for a
-  /// reader. `None` when every one of them is reflexive.
+  /// The span and the slice — the two components both arms of
+  /// [`compare`](Self::compare) share, consulted in its order and answering in its terms.
   ///
-  /// See [`refuse_non_reflexive`] for what this is read for and why.
-  fn non_reflexive(&self) -> Option<&'static str>
-  where
-    L::Token: PartialEq,
-    <L::Token as Token<'inp>>::Error: PartialEq,
-  {
-    match &self.item {
-      Ok(tok) => {
-        if !self_equal(&tok.kind()) {
-          return Some("the token's `Kind`");
-        }
-        if !self_equal(tok) {
-          return Some("the token payload");
-        }
-      }
-      Err(err) => {
-        if !self_equal(err) {
-          return Some("the lexer error payload");
-        }
-      }
+  /// Both are bounded to a *total* equality (the span is `Ord`, the slice is `Eq`), which is why
+  /// they are asked before either payload: a divergence one of them can settle is never
+  /// attributed to a `PartialEq` that promises no reflexivity.
+  fn compare_shared(&self, other: &Self) -> Comparison {
+    if self.span != other.span {
+      return Comparison::Differs(decided_by(Decided::SPAN, &self.span, &other.span));
     }
-    if !self_equal(&self.span) {
-      return Some("the span");
+    if self.slice != other.slice {
+      return Comparison::Differs(decided_by(Decided::SLICE, &self.slice, &other.slice));
     }
-    if !self_equal(&self.slice) {
-      return Some("the slice");
-    }
-    None
+    Comparison::Equal
   }
 
   /// A human-readable one-line rendering for panic context.
   ///
-  /// `Debug` is the right tool *here* and the wrong one in [`sig_eq`](Self::sig_eq): this text is
+  /// `Debug` is the right tool *here* and the wrong one in [`compare`](Self::compare): this text is
   /// read by a person diagnosing a failure, and nothing is decided from it.
   fn describe(&self) -> String {
     match &self.item {
@@ -2129,14 +2285,19 @@ where
 {
   let n = expected.len().min(got.len());
   for i in 0..n {
-    if !expected[i].sig_eq(&got[i]) {
-      // Before naming a culprit, ask whether either side is even comparable to itself. See
-      // `refuse_non_reflexive`: this is reached only once the comparison has failed, so it can
-      // re-label this failure and can never manufacture one.
+    if let Comparison::Differs(decided) = expected[i].compare(&got[i]) {
+      // Before naming a culprit, ask whether the comparison that decided this is even comparable
+      // to itself. See `refuse_non_reflexive`: reached only once the comparison has failed, so it
+      // can re-label this failure and can never manufacture one.
       let at = format!("position {i}");
-      for (side, item) in [("expected", &expected[i]), ("got", &got[i])] {
-        refuse_non_reflexive(idx, op, &at, side, item.non_reflexive(), &item.describe());
-      }
+      refuse_decided(
+        idx,
+        op,
+        &at,
+        &decided,
+        &expected[i].describe(),
+        &got[i].describe(),
+      );
       panic!(
         "tokora conformance [input #{idx} {op}] position {i}: item mismatch: expected {}, got {}",
         expected[i].describe(),
@@ -2277,20 +2438,19 @@ fn check_resume<'inp, L>(
 
       match reference.get(k + produced) {
         Some(expected) => {
-          if !expected.sig_eq(&observed) {
+          if let Comparison::Differs(decided) = expected.compare(&observed) {
             // The same guard `assert_run_eq` carries, for the same reason and under the same
-            // "only after a failed comparison" rule. See `refuse_non_reflexive`.
+            // "only after a failed comparison, and only about the comparison that failed" rule.
+            // See `refuse_non_reflexive`.
             let at = format!("resume-from k={k}, position {produced}");
-            for (side, item) in [("expected", expected), ("got", &observed)] {
-              refuse_non_reflexive(
-                idx,
-                "state-resume",
-                &at,
-                side,
-                item.non_reflexive(),
-                &item.describe(),
-              );
-            }
+            refuse_decided(
+              idx,
+              "state-resume",
+              &at,
+              &decided,
+              &expected.describe(),
+              &observed.describe(),
+            );
             panic!(
               "tokora conformance [input #{idx} state-resume] resume-from k={k}, position {produced}: resumed item diverges from the original suffix: expected {}, got {}",
               expected.describe(),
@@ -2553,27 +2713,31 @@ fn check_integration<'inp, L>(
   assert_stream_eq::<L>(idx, "nested-savepoints", &straight, &nested);
 }
 
-/// The first component of a committed `(kind, span)` pair that fails to compare equal to
-/// **itself**, named for a reader. `None` when both are reflexive.
+/// Which component of a committed `(kind, span)` pair decided a comparison of two of them, in
+/// [`Item::compare`]'s order and answering in its terms.
 ///
 /// Both components are bounded stronger than [`PartialEq`] — [`Token::Kind`] is `Eq` and
-/// [`Lexer::Span`] is `Ord` — so an answer other than `None` here means an implementation claiming
-/// a total equality it does not have. That is a *worse* caller defect than the partial one
-/// [`Item::non_reflexive`] answers for, and reporting it as a divergence of the committed stream
-/// is exactly as wrong. See [`refuse_non_reflexive`].
-fn stream_pair_non_reflexive<'inp, L>(
-  pair: &(<L::Token as Token<'inp>>::Kind, L::Span),
-) -> Option<&'static str>
+/// [`Lexer::Span`] is `Ord` — so a refusal drawn from either means an implementation claiming a
+/// total equality it does not have. That is a *worse* caller defect than the partial one a token
+/// or error payload carries, and reporting it as a divergence of the committed stream is exactly
+/// as wrong. See [`refuse_non_reflexive`].
+///
+/// The pair has no discriminant, so [`Decided::Discriminant`] cannot arise here: the two
+/// components are the whole observable, and one of them decides every failure.
+fn stream_pair_compare<'inp, L>(
+  expected: &(<L::Token as Token<'inp>>::Kind, L::Span),
+  got: &(<L::Token as Token<'inp>>::Kind, L::Span),
+) -> Comparison
 where
   L: Lexer<'inp>,
 {
-  if !self_equal(&pair.0) {
-    return Some("the token's `Kind`");
+  if expected.0 != got.0 {
+    return Comparison::Differs(decided_by(Decided::KIND, &expected.0, &got.0));
   }
-  if !self_equal(&pair.1) {
-    return Some("the span");
+  if expected.1 != got.1 {
+    return Comparison::Differs(decided_by(Decided::SPAN, &expected.1, &got.1));
   }
-  None
+  Comparison::Equal
 }
 
 /// Asserts two committed (kind, span) token streams are identical, with position context.
@@ -2587,7 +2751,7 @@ fn assert_stream_eq<'inp, L>(
 {
   let n = expected.len().min(got.len());
   for i in 0..n {
-    if expected[i] != got[i] {
+    if let Comparison::Differs(decided) = stream_pair_compare::<L>(&expected[i], &got[i]) {
       // The third member of the same population. `Token::Kind` is bounded `Eq` and `Lexer::Span`
       // is bounded `Ord`, so non-reflexivity here is a broken TOTAL-equality promise rather than
       // the partial one the token and error payloads carry — a stronger caller defect, and the
@@ -2595,16 +2759,14 @@ fn assert_stream_eq<'inp, L>(
       // the fifth is the defect relocated, and this one costs a call on a path already panicking.
       let op = format!("integration/{sched}");
       let at = format!("position {i}");
-      for (side, pair) in [("expected", &expected[i]), ("got", &got[i])] {
-        refuse_non_reflexive(
-          idx,
-          &op,
-          &at,
-          side,
-          stream_pair_non_reflexive::<L>(pair),
-          &format!("{pair:?}"),
-        );
-      }
+      refuse_decided(
+        idx,
+        &op,
+        &at,
+        &decided,
+        &format!("{:?}", expected[i]),
+        &format!("{:?}", got[i]),
+      );
       panic!(
         "tokora conformance [input #{idx} integration/{sched}] position {i}: committed token stream diverges: expected {:?}, got {:?}",
         expected[i], got[i]

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -484,8 +484,10 @@ where
   /// One caveat that comes with value equality rather than with this kit, and it is the same one
   /// [`run_partial`](Self::run_partial) carries: a payload holding an `f64` that can be `NaN` is
   /// not equal to itself, and such a type must hand-write an impl that says what it means. Until
-  /// it does, this kit will not pretend to have checked it — it refuses, tagged
-  /// `non-reflexive-payload`, rather than reporting the lexer as non-conforming.
+  /// it does, this kit will not pretend to have checked it — where nothing conclusive outranks
+  /// that comparison it refuses, tagged `non-reflexive-payload`, rather than reporting the lexer
+  /// as non-conforming. The same holds for a `Kind`, span, slice or offset whose `Eq` or `Ord`
+  /// breaks the reflexivity those traits promise.
   ///
   /// # Panics
   ///
@@ -586,9 +588,9 @@ where
   /// or a hand-written impl where derivation is wrong.
   /// One caveat that comes with value equality rather than with this kit: a payload holding a
   /// `f64` that can be `NaN` is not equal to itself, and such a type must hand-write an impl that
-  /// says what it means. The kit does not silently accept one — a comparison it decides is
-  /// refused, tagged `non-reflexive-payload`, rather than reported as a conformance failure of
-  /// the lexer (#295).
+  /// says what it means. The kit does not silently accept one — a comparison such a value decides,
+  /// and that nothing conclusive outranks, is refused, tagged `non-reflexive-payload`, rather than
+  /// reported as a conformance failure of the lexer (#295, #324).
   ///
   /// This is where a lexer that is not faithful under truncation is caught — one whose item
   /// identity depends on input beyond what it reports having read (lookahead past a token that

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -225,7 +225,9 @@ const MAX_BUDGET_MULTIPLE: usize = 1 << 16;
 ///   }
 /// }
 ///
-/// #[derive(Clone, Debug)]
+/// // `PartialEq` because `run` compares the token by VALUE (#269) — this is the one line
+/// // the new bound costs a vocabulary that is plain data, which is nearly all of them.
+/// #[derive(Clone, Debug, PartialEq)]
 /// struct CharTok;
 /// impl Token<'_> for CharTok {
 ///   type Kind = CharKind;

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -2018,7 +2018,10 @@ where
         self.span,
         self.slice
       ),
-      Err(err) => format!("lexer error {err:?}@{:?} (slice {:?})", self.span, self.slice),
+      Err(err) => format!(
+        "lexer error {err:?}@{:?} (slice {:?})",
+        self.span, self.slice
+      ),
     }
   }
 }

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -2901,11 +2901,12 @@ fn assert_stream_eq<'inp, L>(
   let n = expected.len().min(got.len());
   for i in 0..n {
     if let Comparison::Differs(decided) = expected[i].compare(&got[i]) {
-      // The third member of the same population. `Token::Kind` is bounded `Eq`, `Lexer::Span` is
-      // bounded `Ord` and the two payloads are bounded only `PartialEq`, so a refusal here is
-      // drawn from whichever of those decided it — exactly as it is on the other four
-      // comparisons. Guarding four and not the fifth is the defect relocated, and this one costs
-      // a call on a path already panicking.
+      // Two more members of the same population, and with them the population is closed: the two
+      // in the trait tier, the two in the partial tier, these two, and the two in `cache`.
+      // `Token::Kind` is bounded `Eq`, `Lexer::Span` is bounded `Ord` and the two payloads are
+      // bounded only `PartialEq`, so a refusal here is drawn from whichever of those decided it —
+      // exactly as it is at the other six. Guarding some and not the rest is the defect
+      // relocated, and this one costs a call on a path already panicking.
       let op = format!("integration/{sched}");
       let at = format!("{} {i}", arm.at);
       refuse_decided(

--- a/tokora/src/conformance/mod.rs
+++ b/tokora/src/conformance/mod.rs
@@ -2570,8 +2570,16 @@ where
   L: Lexer<'inp>,
 {
   /// The committed tokens `next()` handed back, in drain order.
+  ///
+  /// Bounded by the drain loop's own `budget` guard, as it always was.
   tokens: Vec<StreamItem<'inp, L>>,
   /// The lexer errors the layer raised, in the order it raised them.
+  ///
+  /// Bounded by [`LexTally`] and by nothing else, which is the tier's own rule rather than an
+  /// omission: no drain loop counts this vector, and it grows at one site — the layer's refusal,
+  /// which the layer reaches only by *lexing* the region it refuses. Every push therefore charges
+  /// an attempt to the tally first, so the length is at most the tier's attempt ceiling, and the
+  /// tally is the boundary because it is the one counter a checkpoint restore cannot refund.
   errors: Vec<StreamItem<'inp, L>>,
 }
 
@@ -2772,6 +2780,14 @@ fn check_integration<'inp, L>(
 
   // save-early-restore-late: save at 0, consume a prefix, abandon it, then drain the
   // whole stream — which must re-lex the rewound prefix identically.
+  //
+  // EVERY restoring schedule saves at position 0, and the two arms are aligned by that rather
+  // than by a shared rewind. The abandoned prefix's tokens are dropped by never being collected;
+  // its errors are dropped by `ItemRecorder::rewind`, which truncates to the log length the save
+  // captured — zero here, because nothing has been raised yet. A schedule that saved MID-stream
+  // would keep the errors before its save and start its token vector empty, and the two arms
+  // would no longer describe the same suffix; such a schedule owes the drain loop the same
+  // rewind, and this is the note that says so.
   let save_early = observe::<L>(src, &tally, |ir| {
     let ckp = ir.save();
     for _ in 0..3 {

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -3730,12 +3730,16 @@ fn a_prefilled_impurity_the_prefix_decided_is_not_withheld_over_a_nan_the_append
     );
   });
   assert!(
-    msg.contains("pure-peek/prefilled at depth 1] against a full cache: two prefilled peeks on an unchanged cache disagreed in the prefix the buffer already held"),
-    "the impurity the prefix decided must be reported, got: {msg}"
+    msg.contains("pure-peek/prefilled at depth 1] against a full cache: two prefilled peeks on an unchanged cache disagreed in the prefix the buffer already held: [(SimpleSpan { start: 0, end: 1 }, FTok(1.0), ())] then [(SimpleSpan { start: 9, end: 10 }, FTok(1.0), ())]"),
+    "the impurity the prefix decided must be reported, and reported with the prefix's own two runs, got: {msg}"
   );
   assert!(
     !msg.contains("non-reflexive-payload"),
     "the verdict rests on a span, which is reflexive; the NaN is in the pair that decided nothing, got: {msg}"
+  );
+  assert!(
+    !msg.contains("FTok(NaN)"),
+    "the appended pair decided nothing and must not be rendered as though it had, got: {msg}"
   );
 }
 
@@ -3758,9 +3762,9 @@ fn a_nan_in_the_appended_pair_that_actually_decided_is_still_refused() {
   });
   assert!(
     msg.contains(
-      "non-reflexive-payload] pure-peek/prefilled at depth 1 against a full cache, position 0: INCONCLUSIVE — the token payload of the second appended entry"
+      "non-reflexive-payload] pure-peek/prefilled at depth 1 against a full cache, position 0: INCONCLUSIVE — the token payload of the second appended entry (SimpleSpan { start: 4, end: 5 }, FTok(NaN), ())"
     ),
-    "a NaN that decided the appended comparison must still be refused, and named as the appended side, got: {msg}"
+    "a NaN that decided the appended comparison must still be refused, named as the appended side and rendered as the appended ENTRY — the value the verdict rests on, got: {msg}"
   );
 }
 
@@ -3783,9 +3787,9 @@ fn a_nan_in_the_prefix_pair_that_actually_decided_is_still_refused() {
   });
   assert!(
     msg.contains(
-      "non-reflexive-payload] pure-peek/prefilled at depth 1 against a full cache, position 0: INCONCLUSIVE — the token payload of the second prefix entry"
+      "non-reflexive-payload] pure-peek/prefilled at depth 1 against a full cache, position 0: INCONCLUSIVE — the token payload of the second prefix entry (SimpleSpan { start: 0, end: 1 }, FTok(NaN), ())"
     ),
-    "a NaN that decided the prefix comparison must still be refused, got: {msg}"
+    "a NaN that decided the prefix comparison must still be refused, and rendered as the prefix ENTRY, got: {msg}"
   );
 }
 
@@ -3806,8 +3810,8 @@ fn a_prefix_impurity_with_reflexive_payloads_throughout_still_reds_the_ordinary_
     );
   });
   assert!(
-    msg.contains("pure-peek/prefilled at depth 1] against a full cache: two prefilled peeks on an unchanged cache disagreed in the prefix the buffer already held"),
-    "the ordinary impurity failure must keep its tag and its wording, got: {msg}"
+    msg.contains("pure-peek/prefilled at depth 1] against a full cache: two prefilled peeks on an unchanged cache disagreed in the prefix the buffer already held: [(SimpleSpan { start: 0, end: 1 }, FTok(1.0), ())] then [(SimpleSpan { start: 9, end: 10 }, FTok(1.0), ())]"),
+    "the ordinary impurity failure must keep its tag, its wording and the deciding half's two runs, got: {msg}"
   );
   assert!(
     !msg.contains("non-reflexive-payload"),
@@ -3834,12 +3838,13 @@ fn an_appended_decided_impurity_is_reported_as_appended_and_not_as_the_prefix() 
     );
   });
   assert!(
-    msg.contains("disagreed in the run it appended behind that prefix"),
-    "an appended-decided impurity must be reported as appended, got: {msg}"
+    msg.contains("disagreed in the run it appended behind that prefix: [(SimpleSpan { start: 4, end: 5 }, FTok(2.0), ())] then [(SimpleSpan { start: 6, end: 7 }, FTok(2.0), ())]"),
+    "an appended-decided impurity must be reported as appended, with the appended run's own two values, got: {msg}"
   );
   assert!(
-    !msg.contains("the prefix the buffer already held"),
-    "the prefix was reproduced exactly and must not be blamed, got: {msg}"
+    !msg.contains("the prefix the buffer already held")
+      && !msg.contains("SimpleSpan { start: 0, end: 1 }"),
+    "the prefix was reproduced exactly and must be neither blamed nor printed, got: {msg}"
   );
 }
 

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -3900,17 +3900,18 @@ fn two_peeked_runs_that_differ_only_in_length_are_refused_nothing() {
   // than the one before it settles the verdict with no `PartialEq` involved — and a scan of one
   // run still found the `NaN` in it and refused, over a `peek` that genuinely is not pure.
   //
-  // `Length` is a DECISION and not an absence, which is #324: an answer that said `None` here
+  // `Count` is a DECISION and not an absence, which is #324: an answer that said `None` here
   // said the same thing about two runs that agree, so a caller needing both facts had to ask a
-  // second question and compose the two by hand.
-  use super::cache::{PurityDecided, runs_decided};
+  // second question and compose the two by hand. And a count is CONCLUSIVE, so it outranks the
+  // `NaN` at position 0 rather than queueing behind it — see `Ranking`.
+  use super::{Divergence, cache::runs_decided};
   let entry = || (SimpleSpan::new(0, 1), FTok(f64::NAN), ());
   let first = [entry()];
   let second: [(SimpleSpan, FTok, ()); 0] = [];
   assert!(
     matches!(
       runs_decided::<NanPayloadLexer<'_>>(&first, &second),
-      Some(PurityDecided::Length)
+      Some(Divergence::Count)
     ),
     "a length divergence consults no caller equality, so there is nothing to refuse — and it is \
      still what decided the verdict"
@@ -3936,13 +3937,13 @@ fn a_peeked_run_is_probed_at_the_position_the_two_runs_disagree_at() {
   // And where they do disagree at a position, the question is asked THERE. A scan answered from
   // the first non-reflexive entry anywhere in one run, which need not be — and here is not — the
   // position the two runs actually differ at.
-  use super::cache::{PurityDecided, runs_decided};
+  use super::{Divergence, cache::runs_decided};
   let head = || (SimpleSpan::new(0, 1), FTok(1.0), ());
   let middle = |end: usize| (SimpleSpan::new(1, end), FTok(2.0), ());
   let nan = || (SimpleSpan::new(4, 5), FTok(f64::NAN), ());
   let first = [head(), middle(2), nan()];
   let second = [head(), middle(3), nan()];
-  let Some(PurityDecided::At(i, decided)) = runs_decided::<NanPayloadLexer<'_>>(&first, &second)
+  let Some(Divergence::At(i, decided)) = runs_decided::<NanPayloadLexer<'_>>(&first, &second)
   else {
     panic!("position 1 differs in its span, so a position is what decided it")
   };
@@ -4135,5 +4136,262 @@ fn two_prefilled_peeks_that_agree_in_both_halves_are_not_a_failure() {
     "a full cache",
     (&prefix, &prefix),
     (&appended, &appended),
+  );
+}
+
+// ── #324 round 5: a conclusive difference outranks an inconclusive one ──────────────
+//
+// Rounds 1–4 built the rule that the kit never reports a diagnosis it did not establish. These
+// cells are its mirror: it never withholds one it did. Every one of them is differential — at the
+// commit before this round each produced the wrong answer quoted in its own comment.
+
+/// A one-character-per-token lexer over the `NaN`-capable payload whose `L::State` is a
+/// **comparable** counter.
+///
+/// [`FloatLexer`]'s state is `()`, and a `()` state cannot differ — so the third of
+/// `triple_compare`'s three questions had no fixture that could make it fire while the token
+/// question was already failing, which is exactly the arrangement round 5's second finding lives
+/// in. This is that fixture and it is conforming in everything else.
+struct StateLexer<'a> {
+  src: &'a str,
+  start: usize,
+  end: usize,
+  state: Emitted,
+}
+
+impl<'a> Lexer<'a> for StateLexer<'a> {
+  type State = Emitted;
+  type Source = str;
+  type Token = FTok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a str) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: Emitted(0),
+    }
+  }
+  fn with_state(src: &'a str, state: Emitted) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
+  }
+  fn check(&self) -> Result<(), Infallible> {
+    Ok(())
+  }
+  fn state(&self) -> &Emitted {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut Emitted {
+    &mut self.state
+  }
+  fn into_state(self) -> Emitted {
+    self.state
+  }
+  fn source(&self) -> &'a str {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> &'a str {
+    &self.src[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<FTok, Infallible>> {
+    self.start = self.end;
+    if self.start >= self.src.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src, self.start);
+    self.state.0 += 1;
+    Some(Ok(FTok(float_of(self.src.as_bytes()[self.start]))))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+/// One captured item of the `NaN`-capable float lexer, for the stream comparisons that take
+/// `Item`s directly. Every component but the payload is the caller's to choose, so a cell can
+/// hold spans, slices and kinds constant and move exactly one thing.
+fn float_item(
+  value: f64,
+  start: usize,
+  end: usize,
+) -> super::Item<'static, NanPayloadLexer<'static>> {
+  super::Item {
+    item: Ok(FTok(value)),
+    span: SimpleSpan::new(start, end),
+    slice: "x",
+    end,
+    state: (),
+  }
+}
+
+#[test]
+fn an_extra_item_outranks_a_non_reflexive_payload_at_position_zero() {
+  // THE FINDING. `[Tok(NaN)]` against `[Tok(NaN), Tok(0.0)]`: identical kind, span and slice at
+  // position 0, so only the payload can decide there — and it cannot decide anything, because
+  // `NaN != NaN`. The extra item proves replay divergence with NO caller equality consulted at
+  // all, and it sat behind the refusal.
+  //
+  // Before: "[input #0 replay-identity] position 0: INCONCLUSIVE — the token payload …".
+  let msg = panic_message(|| {
+    super::assert_run_eq::<NanPayloadLexer<'_>>(
+      0,
+      "replay-identity",
+      &[float_item(f64::NAN, 0, 1)],
+      &[float_item(f64::NAN, 0, 1), float_item(0.0, 1, 2)],
+    );
+  });
+  assert!(
+    msg.contains("[input #0 replay-identity] length mismatch: expected 1 items, got 2"),
+    "an item COUNT consults no caller equality, so it convicts the lexer on its own, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "the kit established replay divergence and may not withhold it, got: {msg}"
+  );
+}
+
+#[test]
+#[should_panic(
+  expected = "non-reflexive-payload] replay-identity position 0: INCONCLUSIVE — the token payload"
+)]
+fn a_non_reflexive_payload_with_nothing_conclusive_anywhere_is_still_refused() {
+  // CONTROL 1, and it pulls the opposite way from the finding: two streams of the same length,
+  // identical in every component a total equality settles, differing only in a payload that will
+  // not equal itself. Nothing conclusive exists ANYWHERE, so the retained fallback is the answer
+  // and #295's repair survives.
+  super::assert_run_eq::<NanPayloadLexer<'_>>(
+    0,
+    "replay-identity",
+    &[float_item(f64::NAN, 0, 1)],
+    &[float_item(f64::NAN, 0, 1)],
+  );
+}
+
+#[test]
+fn an_ordinary_divergence_over_reflexive_payloads_keeps_its_component_and_its_wording() {
+  // CONTROL 2. The ordinary case is a caller `PartialEq` over two values that are BOTH self-equal
+  // — the whole population of honest failures — and ranking must not demote it to a fallback. It
+  // is conclusive, it is reported at the first position it occurs, and the words are the ones the
+  // kit has always used.
+  let msg = panic_message(|| {
+    super::assert_run_eq::<NanPayloadLexer<'_>>(
+      0,
+      "replay-identity",
+      &[float_item(1.0, 0, 1)],
+      &[float_item(2.0, 0, 1)],
+    );
+  });
+  assert!(
+    msg.contains("[input #0 replay-identity] position 0: item mismatch: expected"),
+    "a reflexive payload divergence keeps the ordinary tag and wording, got: {msg}"
+  );
+  assert!(
+    msg.contains("FTok(1.0)") && msg.contains("FTok(2.0)"),
+    "and it names two distinguishable values, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "both sides equal themselves, so there is nothing to refuse, got: {msg}"
+  );
+}
+
+#[test]
+fn a_conclusive_difference_later_in_the_stream_is_found_and_not_only_one_at_the_same_position() {
+  // CONTROL 3, and it pulls a third way: a repair that only looked at the REST OF THE SAME ITEM
+  // would pass the finding and control 1 and still stop at the first position that differs. The
+  // `NaN` is at position 0; the span divergence — settled by `Lexer::Span`, bounded `Ord` — is at
+  // position 1, and it is what the kit has established.
+  //
+  // Before: "[input #0 replay-identity] position 0: INCONCLUSIVE — the token payload …".
+  let msg = panic_message(|| {
+    super::assert_run_eq::<NanPayloadLexer<'_>>(
+      0,
+      "replay-identity",
+      &[float_item(f64::NAN, 0, 1), float_item(1.0, 1, 2)],
+      &[float_item(f64::NAN, 0, 1), float_item(1.0, 1, 3)],
+    );
+  });
+  assert!(
+    msg.contains("[input #0 replay-identity] position 1: item mismatch: expected"),
+    "the conclusive difference is at position 1 and the search must reach it, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "position 1 is settled by a span, so there is nothing to refuse, got: {msg}"
+  );
+}
+
+#[test]
+fn a_reflexive_state_corruption_outranks_a_non_reflexive_token() {
+  // THE SECOND FINDING, at the shared function it lives in. Same span, a `NaN` token on both
+  // sides, and two DIFFERENT `L::State`s that each equal themselves. `triple_compare` returned at
+  // the token and never examined the state, so the guard called the whole thing inconclusive over
+  // a cache the unexamined state convicts on its own.
+  //
+  // Before: `Some((EntryPart::Token, …))`, both sides non-reflexive, hence a refusal.
+  use super::cache::{EntryPart, triple_compare};
+  let span = SimpleSpan::new(0, 1);
+  let nan = FTok(f64::NAN);
+  let Some((part, decided)) =
+    triple_compare::<StateLexer<'_>>((&span, &nan, &Emitted(7)), (&span, &nan, &Emitted(9)))
+  else {
+    panic!("the state differs, so the triple differs")
+  };
+  assert_eq!(
+    part,
+    EntryPart::State,
+    "the state is what the kit established and what it must report"
+  );
+  assert!(
+    decided.expected().is_none() && decided.got().is_none(),
+    "both states equal themselves, so there is nothing to refuse"
+  );
+}
+
+#[test]
+fn a_span_still_outranks_a_state_when_the_span_comparison_is_sound() {
+  // The control for "span first, always". Ranking may only move an answer PAST a step the kit
+  // could not draw a verdict from; a sound span still speaks before everything behind it.
+  use super::cache::{EntryPart, triple_compare};
+  let token = FTok(1.0);
+  let Some((part, _)) = triple_compare::<StateLexer<'_>>(
+    (&SimpleSpan::new(0, 1), &token, &Emitted(7)),
+    (&SimpleSpan::new(0, 2), &token, &Emitted(9)),
+  ) else {
+    panic!("the span and the state both differ")
+  };
+  assert_eq!(part, EntryPart::Span, "span first, always");
+}
+
+#[test]
+fn a_purity_run_length_outranks_a_non_reflexive_entry_at_a_shared_position() {
+  // The same ordering, one level up, on the comparison the cache's purity laws read. A `NaN` at
+  // position 0 and a second run one entry longer: the length is the kit's own `len()`, so no
+  // caller equality stands behind it.
+  //
+  // Before: `At(0, …)` over the payload, and a refusal.
+  use super::{Divergence, cache::runs_decided};
+  let nan = || (SimpleSpan::new(0, 1), FTok(f64::NAN), ());
+  let first = [nan()];
+  let second = [nan(), (SimpleSpan::new(1, 2), FTok(1.0), ())];
+  assert!(
+    matches!(
+      runs_decided::<NanPayloadLexer<'_>>(&first, &second),
+      Some(Divergence::Count)
+    ),
+    "a count outranks a payload that will not equal itself"
   );
 }

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -2770,10 +2770,20 @@ impl<'a> Lexer<'a> for AltErrLexer<'a> {
 
   fn new(src: &'a str) -> Self {
     let pick = ALT_FLIP.fetch_xor(true, core::sync::atomic::Ordering::Relaxed);
-    Self { src, start: 0, end: 0, state: AltChoice(pick) }
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: AltChoice(pick),
+    }
   }
   fn with_state(src: &'a str, state: AltChoice) -> Self {
-    Self { src, start: 0, end: 0, state }
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
   }
   fn check(&self) -> Result<(), Collide> {
     Ok(())
@@ -2803,7 +2813,11 @@ impl<'a> Lexer<'a> for AltErrLexer<'a> {
     }
     self.end = boundary_after(self.src, self.start);
     if self.start == 0 {
-      return Some(Err(if self.state.0 { Collide::Junk } else { Collide::Cut }));
+      return Some(Err(if self.state.0 {
+        Collide::Junk
+      } else {
+        Collide::Cut
+      }));
     }
     Some(Ok(CTok))
   }
@@ -2861,10 +2875,20 @@ impl<'a> Lexer<'a> for AltTokLexer<'a> {
 
   fn new(src: &'a str) -> Self {
     let pick = ALT_TOK_FLIP.fetch_xor(true, core::sync::atomic::Ordering::Relaxed);
-    Self { src, start: 0, end: 0, state: AltChoice(pick) }
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: AltChoice(pick),
+    }
   }
   fn with_state(src: &'a str, state: AltChoice) -> Self {
-    Self { src, start: 0, end: 0, state }
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
   }
   fn check(&self) -> Result<(), Infallible> {
     Ok(())
@@ -2928,11 +2952,21 @@ impl<'a> Lexer<'a> for ResumeDriftErrLexer<'a> {
   type Offset = usize;
 
   fn new(src: &'a str) -> Self {
-    Self { src, start: 0, end: 0, state: AltChoice(false) }
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: AltChoice(false),
+    }
   }
   fn with_state(src: &'a str, _state: AltChoice) -> Self {
     // The defect: a rebuilt lexer decides the error differently from the one that saved the state.
-    Self { src, start: 0, end: 0, state: AltChoice(true) }
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: AltChoice(true),
+    }
   }
   fn check(&self) -> Result<(), Collide> {
     Ok(())
@@ -2962,7 +2996,11 @@ impl<'a> Lexer<'a> for ResumeDriftErrLexer<'a> {
     }
     self.end = boundary_after(self.src, self.start);
     if self.start == 0 {
-      return Some(Err(if self.state.0 { Collide::Junk } else { Collide::Cut }));
+      return Some(Err(if self.state.0 {
+        Collide::Junk
+      } else {
+        Collide::Cut
+      }));
     }
     Some(Ok(CTok))
   }
@@ -3041,10 +3079,20 @@ impl<'a, const MODE: u8> Lexer<'a> for FloatLexer<'a, MODE> {
   type Offset = usize;
 
   fn new(src: &'a str) -> Self {
-    Self { src, start: 0, end: 0, state: () }
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: (),
+    }
   }
   fn with_state(src: &'a str, state: ()) -> Self {
-    Self { src, start: 0, end: 0, state }
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
   }
   fn check(&self) -> Result<(), Infallible> {
     Ok(())
@@ -3161,7 +3209,10 @@ fn a_reflexive_payload_of_the_same_type_still_fails_the_ordinary_way() {
     "the control must not be re-labelled as a payload problem, got: {msg}"
   );
   // And expected-vs-got must be two distinguishable values, unlike the NaN cell's.
-  assert!(msg.contains("FTok(122.0)") && msg.contains("FTok(98.0)"), "{msg}");
+  assert!(
+    msg.contains("FTok(122.0)") && msg.contains("FTok(98.0)"),
+    "{msg}"
+  );
 }
 
 #[test]
@@ -3177,7 +3228,7 @@ fn a_conforming_lexer_over_the_same_float_payload_passes_both_tiers() {
 /// partial one a token or error payload carries — a stronger caller defect, and exactly as wrong
 /// to report as a stream divergence. It stands in for the whole `Eq`/`Ord` half of the population:
 /// `Lexer::Span` is bounded `Ord` and can lie the same way.
-#[derive(Clone, Copy, Debug, Hash)]
+#[derive(Clone, Copy, Debug)]
 struct LyingKind;
 
 impl PartialEq for LyingKind {
@@ -3187,6 +3238,14 @@ impl PartialEq for LyingKind {
 }
 
 impl Eq for LyingKind {}
+
+/// Hand-written because `Token::Kind` requires `Hash` and deriving it beside a manual `PartialEq`
+/// is what `clippy::derived_hash_with_manual_eq` exists to stop. The lint's law —
+/// `k1 == k2` implies `hash(k1) == hash(k2)` — is satisfied *vacuously* here, since nothing is
+/// equal to anything, so this impl is not a second lie on top of the one the fixture is for.
+impl core::hash::Hash for LyingKind {
+  fn hash<H: core::hash::Hasher>(&self, _: &mut H) {}
+}
 
 impl core::fmt::Display for LyingKind {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3227,10 +3286,20 @@ impl<'a> Lexer<'a> for LyingKindLexer<'a> {
   type Offset = usize;
 
   fn new(src: &'a str) -> Self {
-    Self { src, start: 0, end: 0, state: () }
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: (),
+    }
   }
   fn with_state(src: &'a str, state: ()) -> Self {
-    Self { src, start: 0, end: 0, state }
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
   }
   fn check(&self) -> Result<(), Infallible> {
     Ok(())

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -5046,3 +5046,28 @@ fn a_prefilled_impurity_the_appended_run_decided_is_not_withheld_over_a_nan_in_t
     "a span settled the appended half, so there is nothing to refuse, got: {msg}"
   );
 }
+
+#[test]
+fn one_side_that_will_not_equal_itself_is_enough_to_make_a_difference_inconclusive() {
+  // Pins the AND in `Decided::is_conclusive`. Reflexivity is asked of both sides and either one
+  // failing makes the comparison unusable: `NaN != 2.0` is `false` for two reasons at once and
+  // the kit cannot tell them apart. An OR here would call position 0 conclusive, refuse over it,
+  // and withhold the ordinary divergence at position 1 — which is the finding again, reached
+  // through the one-sided case the other cells do not cover.
+  let msg = panic_message(|| {
+    super::assert_run_eq::<NanPayloadLexer<'_>>(
+      0,
+      "replay-identity",
+      &[float_item(f64::NAN, 0, 1), float_item(1.0, 1, 2)],
+      &[float_item(2.0, 0, 1), float_item(3.0, 1, 2)],
+    );
+  });
+  assert!(
+    msg.contains("[input #0 replay-identity] position 1: item mismatch: expected"),
+    "position 0 is inconclusive on one side, so position 1 is what the kit established, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "a conclusive difference exists, so nothing is refused, got: {msg}"
+  );
+}

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -3350,8 +3350,8 @@ fn a_kind_that_does_not_equal_itself_is_diagnosed_and_not_blamed_on_the_lexer() 
 )]
 fn a_kind_that_does_not_equal_itself_is_diagnosed_at_the_committed_stream_comparison() {
   // The integration tier's comparison, reached directly: `run` rejects such a `Kind` at replay
-  // identity, three checks earlier, so nothing arrives here through the entry point. Guarding four
-  // comparisons and not the fifth would leave the same defect one relocation away.
+  // identity, three checks earlier, so nothing arrives here through the entry point. Guarding some
+  // of the comparisons and not the rest would leave the same defect one relocation away.
   let stream = [super::StreamItem::<LyingKindLexer<'_>>::Token(
     LTok,
     SimpleSpan::new(0, 1),

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -5071,3 +5071,40 @@ fn one_side_that_will_not_equal_itself_is_enough_to_make_a_difference_inconclusi
     "a conclusive difference exists, so nothing is refused, got: {msg}"
   );
 }
+
+#[test]
+fn a_later_component_of_the_same_item_outranks_an_earlier_one_the_kit_cannot_use() {
+  // The ranking inside ONE item, which the stream cells cannot reach: `LyingKind` is consulted
+  // first and decides nothing — it answers `false` to every comparison, its own included — while
+  // the span behind it is `Ord` and settles the divergence outright.
+  //
+  // Before: "[input #0 non-reflexive-payload] integration/peek-heavy position 0: INCONCLUSIVE —
+  // the token's `Kind` …", over a span divergence the kit had established. The existing
+  // `LyingKind` cell asks the other question — a lying kind with NOTHING conclusive behind it —
+  // so the pair differs in the one thing.
+  let expected = [super::StreamItem::<LyingKindLexer<'_>>::Token(
+    LTok,
+    SimpleSpan::new(0, 1),
+  )];
+  let got = [super::StreamItem::<LyingKindLexer<'_>>::Token(
+    LTok,
+    SimpleSpan::new(0, 2),
+  )];
+  let msg = panic_message(|| {
+    super::assert_stream_eq::<LyingKindLexer<'_>>(
+      0,
+      "peek-heavy",
+      super::COMMITTED,
+      &expected,
+      &got,
+    );
+  });
+  assert!(
+    msg.contains("[input #0 integration/peek-heavy] position 0: committed token stream diverges"),
+    "the span is what the kit established and the kind is not, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "a sound span outranks a `Kind` the kit cannot use, got: {msg}"
+  );
+}

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -1941,7 +1941,7 @@ fn a_checkpoint_restore_does_not_refund_the_tally() {
 
   let plain = super::LexTally::new(0, "test", SRC.len(), ceiling, instance);
   super::drive::<TileLexer<'_>, _>(SRC, &plain, |ir| {
-    while ir.next().expect("Silent never returns Err").is_some() {}
+    while ir.next().expect(super::NEVER_ERRS).is_some() {}
   });
   let once = plain.spent();
   // A floor with a reason, not `> 0`: `TileLexer` tiles the source one character per token, so a
@@ -1957,9 +1957,9 @@ fn a_checkpoint_restore_does_not_refund_the_tally() {
   let replayed = super::LexTally::new(0, "test", SRC.len(), ceiling, instance);
   super::drive::<TileLexer<'_>, _>(SRC, &replayed, |ir| {
     let ckp = ir.save();
-    while ir.next().expect("Silent never returns Err").is_some() {}
+    while ir.next().expect(super::NEVER_ERRS).is_some() {}
     ir.restore(ckp);
-    while ir.next().expect("Silent never returns Err").is_some() {}
+    while ir.next().expect(super::NEVER_ERRS).is_some() {}
   });
 
   assert!(
@@ -3181,8 +3181,8 @@ fn a_nan_payload_is_diagnosed_at_the_resume_comparison() {
 fn a_nan_payload_is_diagnosed_at_the_prefix_comparison() {
   // `assert_partial_prefix_of`'s comparison, reached directly for `check_resume`'s reason: the
   // final leg runs before the split loop and fires first.
-  use super::PartialItem;
-  let nan = || PartialItem::<NanPayloadLexer<'_>>::Token(FTok(f64::NAN), SimpleSpan::new(0, 1));
+  use super::StreamItem;
+  let nan = || StreamItem::<NanPayloadLexer<'_>>::Token(FTok(f64::NAN), SimpleSpan::new(0, 1));
   super::assert_partial_prefix_of::<NanPayloadLexer<'_>>(0, 1, &[nan()], &[nan()]);
 }
 
@@ -3352,8 +3352,249 @@ fn a_kind_that_does_not_equal_itself_is_diagnosed_at_the_committed_stream_compar
   // The integration tier's comparison, reached directly: `run` rejects such a `Kind` at replay
   // identity, three checks earlier, so nothing arrives here through the entry point. Guarding four
   // comparisons and not the fifth would leave the same defect one relocation away.
-  let stream = [(LyingKind, SimpleSpan::new(0, 1))];
-  super::assert_stream_eq::<LyingKindLexer<'_>>(0, "peek-heavy", &stream, &stream);
+  let stream = [super::StreamItem::<LyingKindLexer<'_>>::Token(
+    LTok,
+    SimpleSpan::new(0, 1),
+  )];
+  super::assert_stream_eq::<LyingKindLexer<'_>>(
+    0,
+    "peek-heavy",
+    super::COMMITTED,
+    &stream,
+    &stream,
+  );
+}
+
+// ── #269 at the integration tier: the committed stream is the ITEM, not a projection of it ──
+//
+// The trait tier compares the whole item, the partial tier compares the whole item, and the
+// integration tier reduced every committed token to `(kind, span)` — the same projection #269
+// removed one tier over, on streams whose full `L::Token` values were already in hand.
+
+/// How many `Lexer::new` constructions the kit has made in the cell below. `run()` spends a fixed
+/// number of them on the trait tier and then exactly one per integration schedule (`drive` →
+/// `seeded` → `L::new(src).into_state()`; every lexer the input layer itself builds comes through
+/// `with_state`), so the instance index is a stable handle on WHICH of the five integration
+/// streams a token belongs to.
+static FLIP_INSTANCE: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
+
+/// The instance index the payload flips at, calibrated so that every trait-tier construction and
+/// the straight integration drive fall below it and `peek-heavy` is the first above.
+const FLIP_AT: usize = 6;
+
+/// The lexer's choice, carried in `L::State` so a `with_state` resume — which is every lexer the
+/// input layer builds — inherits the payload of the drive it belongs to rather than re-deciding.
+#[derive(Clone, Copy, Debug)]
+struct InstanceChoice(u8);
+
+impl crate::State for InstanceChoice {
+  type Error = Infallible;
+  fn check(&self) -> Result<(), Infallible> {
+    Ok(())
+  }
+}
+
+/// A one-token-per-character lexer whose kind, span, slice, item count and state resume are all
+/// exactly what a conforming lexer produces, and whose token **payload** is decided by which
+/// `L::new` instance the stream came from.
+struct InstanceFlipLexer<'a> {
+  src: &'a str,
+  start: usize,
+  end: usize,
+  state: InstanceChoice,
+}
+
+impl<'a> Lexer<'a> for InstanceFlipLexer<'a> {
+  type State = InstanceChoice;
+  type Source = str;
+  type Token = VTok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a str) -> Self {
+    let n = FLIP_INSTANCE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: InstanceChoice(u8::from(n >= FLIP_AT)),
+    }
+  }
+  fn with_state(src: &'a str, state: InstanceChoice) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
+  }
+  fn check(&self) -> Result<(), Infallible> {
+    Ok(())
+  }
+  fn state(&self) -> &InstanceChoice {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut InstanceChoice {
+    &mut self.state
+  }
+  fn into_state(self) -> InstanceChoice {
+    self.state
+  }
+  fn source(&self) -> &'a str {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> &'a str {
+    &self.src[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<VTok, Infallible>> {
+    self.start = self.end;
+    if self.start >= self.src.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src, self.start);
+    Some(Ok(VTok(self.state.0)))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+#[test]
+#[should_panic(
+  expected = "integration/peek-heavy] position 0: committed token stream diverges: expected token"
+)]
+fn a_token_payload_that_moves_between_two_integration_schedules_is_falsified() {
+  // The observation the tier has to make, made directly first and without spending an instance:
+  // the two streams' tokens agree on the kind and the span — everything this tier compared before
+  // 0.11.0 — and hold different values. `with_state` is the door every lexer the input layer
+  // builds comes through, so this is literally the pair the two drives lex with.
+  let low = InstanceFlipLexer::with_state("x", InstanceChoice(0))
+    .lex()
+    .expect("the source has one token")
+    .expect("this lexer never errors");
+  let high = InstanceFlipLexer::with_state("x", InstanceChoice(1))
+    .lex()
+    .expect("the source has one token")
+    .expect("this lexer never errors");
+  assert_eq!(low.kind(), high.kind(), "the kind is what held still");
+  assert_ne!(low, high, "the value is what moved");
+
+  FLIP_INSTANCE.store(0, core::sync::atomic::Ordering::Relaxed);
+  // Every trait-tier check passes: two fresh runs, the resume at every position and the sticky
+  // and span-after-exhaustion probes all fall below the flip. The straight integration drive is
+  // the sixth construction and `peek-heavy` the seventh, so the two committed streams hold
+  // `VTok(0)` and `VTok(1)` at the same kind, the same span and the same length — and the tier
+  // reported them equal until it stopped comparing `(kind, span)`.
+  Harness::<InstanceFlipLexer<'_>>::new("x").run();
+}
+
+/// [`InstanceFlipLexer`]'s defect on the **error** arm: one refused region per input, whose
+/// payload is decided by which `L::new` instance the drive came from.
+///
+/// The token arm and the error arm are the two halves of an item, and until 0.11.0 the
+/// integration tier held neither: it compared the token through a projection and ran under
+/// [`Silent`](crate::emitter::Silent), which discards a refusal outright. A refusal leaves no
+/// trace in the token stream, so this lexer's five schedules produced five *identical* (empty)
+/// token streams while the value a parser's error channel receives changed.
+struct InstanceFlipErrLexer<'a> {
+  src: &'a str,
+  start: usize,
+  end: usize,
+  state: InstanceChoice,
+}
+
+impl<'a> Lexer<'a> for InstanceFlipErrLexer<'a> {
+  type State = InstanceChoice;
+  type Source = str;
+  type Token = ETok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a str) -> Self {
+    let n = ERR_FLIP_INSTANCE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: InstanceChoice(u8::from(n >= FLIP_AT)),
+    }
+  }
+  fn with_state(src: &'a str, state: InstanceChoice) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
+  }
+  fn check(&self) -> Result<(), BadByte> {
+    Ok(())
+  }
+  fn state(&self) -> &InstanceChoice {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut InstanceChoice {
+    &mut self.state
+  }
+  fn into_state(self) -> InstanceChoice {
+    self.state
+  }
+  fn source(&self) -> &'a str {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> &'a str {
+    &self.src[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<ETok, BadByte>> {
+    self.start = self.end;
+    if self.start >= self.src.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src, self.start);
+    Some(Err(BadByte {
+      reason: if self.state.0 == 0 { "low" } else { "high" },
+    }))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+/// [`FLIP_INSTANCE`]'s twin for the error-arm fixture; separate so the two cells can run
+/// concurrently without either one moving the other's instance index.
+static ERR_FLIP_INSTANCE: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
+
+#[test]
+#[should_panic(
+  expected = "integration/peek-heavy] error position 0: raised lexer-error stream diverges: expected lexer error"
+)]
+fn an_error_payload_that_moves_between_two_integration_schedules_is_falsified() {
+  let low = InstanceFlipErrLexer::with_state("?", InstanceChoice(0))
+    .lex()
+    .expect("the source has one item")
+    .expect_err("this lexer only errors");
+  let high = InstanceFlipErrLexer::with_state("?", InstanceChoice(1))
+    .lex()
+    .expect("the source has one item")
+    .expect_err("this lexer only errors");
+  assert_ne!(low, high, "the error payload is what moved");
+
+  ERR_FLIP_INSTANCE.store(0, core::sync::atomic::Ordering::Relaxed);
+  // Both committed TOKEN streams are empty and every span agrees, so nothing the tier compared
+  // before 0.11.0 — under `Silent`, which never handed it a refusal at all — could see this.
+  Harness::<InstanceFlipErrLexer<'_>>::new("?").run();
 }
 
 #[test]
@@ -3556,9 +3797,8 @@ fn a_non_reflexive_error_payload_is_still_refused_when_it_is_what_decided_the_co
   // whose spans agree, so the error payload is the operation that decided the comparison — and it
   // is the one that will not equal itself. The refusal must still fire, and it must still name
   // the error payload.
-  use super::PartialItem;
-  let nan =
-    || PartialItem::<NanErrFlipLexer<'_>>::LexerError(SimpleSpan::new(0, 1), FErr(f64::NAN));
+  use super::StreamItem;
+  let nan = || StreamItem::<NanErrFlipLexer<'_>>::LexerError(SimpleSpan::new(0, 1), FErr(f64::NAN));
   super::assert_partial_prefix_of::<NanErrFlipLexer<'_>>(0, 1, &[nan()], &[nan()]);
 }
 
@@ -3569,9 +3809,8 @@ fn a_non_reflexive_error_payload_is_still_refused_when_it_is_what_decided_the_co
 fn the_error_arm_is_refused_at_the_final_leg_too() {
   // `assert_partial_stream_eq`'s comparison over the error arm, reached directly: the final leg
   // fires before the split loop, so a lexer whose FINAL drain errors with a `NaN` arrives here.
-  use super::PartialItem;
-  let nan =
-    || PartialItem::<NanErrFlipLexer<'_>>::LexerError(SimpleSpan::new(0, 1), FErr(f64::NAN));
+  use super::StreamItem;
+  let nan = || StreamItem::<NanErrFlipLexer<'_>>::LexerError(SimpleSpan::new(0, 1), FErr(f64::NAN));
   super::assert_partial_stream_eq::<NanErrFlipLexer<'_>>(0, usize::MAX, &[nan()], &[nan()]);
 }
 

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -2727,3 +2727,588 @@ mod recorded_value {
     Harness::<HonestLexer<'_>>::over(["1.5", "1.", "12 34", "1.5 2.5"]).run_partial();
   }
 }
+
+// ── #269: the trait tier compares the ITEM, and a rendering is not the item ─────────────
+//
+// Three cells over the two comparisons `run` draws a verdict from, plus the conforming-lexer
+// control that the rendering key reddened. The partial tier already had this repair and its own
+// three cells (`a_colliding_debug_...`, `an_unstable_debug_...`, `a_token_payload_that_changes_...`
+// above); these are the same defects one tier over, where they survived a release longer.
+
+/// Which `Collide` variant the next fresh construction hands out. Flipped by `new` alone, so two
+/// *fresh* runs alternate while a `with_state` resume reproduces the run it was captured from —
+/// which isolates the replay comparison from the resume one.
+static ALT_FLIP: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+/// A lexer's choice, carried in `L::State` so a resume inherits it rather than re-flipping.
+#[derive(Clone, Copy, Debug)]
+struct AltChoice(bool);
+
+impl crate::State for AltChoice {
+  type Error = Infallible;
+  fn check(&self) -> Result<(), Infallible> {
+    Ok(())
+  }
+}
+
+/// The first item is always an error and *which* error alternates between fresh constructions.
+/// Spans, slices, kinds, item count and the error-vs-token discriminant are all held constant, so
+/// the only thing that moves is the payload — and `Collide`'s `Debug` renders both as `LexError`.
+struct AltErrLexer<'a> {
+  src: &'a str,
+  start: usize,
+  end: usize,
+  state: AltChoice,
+}
+
+impl<'a> Lexer<'a> for AltErrLexer<'a> {
+  type State = AltChoice;
+  type Source = str;
+  type Token = CTok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a str) -> Self {
+    let pick = ALT_FLIP.fetch_xor(true, core::sync::atomic::Ordering::Relaxed);
+    Self { src, start: 0, end: 0, state: AltChoice(pick) }
+  }
+  fn with_state(src: &'a str, state: AltChoice) -> Self {
+    Self { src, start: 0, end: 0, state }
+  }
+  fn check(&self) -> Result<(), Collide> {
+    Ok(())
+  }
+  fn state(&self) -> &AltChoice {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut AltChoice {
+    &mut self.state
+  }
+  fn into_state(self) -> AltChoice {
+    self.state
+  }
+  fn source(&self) -> &'a str {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> &'a str {
+    &self.src[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<CTok, Collide>> {
+    self.start = self.end;
+    if self.start >= self.src.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src, self.start);
+    if self.start == 0 {
+      return Some(Err(if self.state.0 { Collide::Junk } else { Collide::Cut }));
+    }
+    Some(Ok(CTok))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+#[test]
+#[should_panic(expected = "replay-identity] position 0: item mismatch: expected lexer error")]
+fn an_error_value_that_changes_between_fresh_runs_is_falsified() {
+  ALT_FLIP.store(false, core::sync::atomic::Ordering::Relaxed);
+  // The observation the check has to make, made directly first: the two public error VALUES
+  // differ and their `Debug` renderings do not. `run()` compared the rendering and passed (#269).
+  let ea = AltErrLexer::new("ab").lex().unwrap().unwrap_err();
+  let eb = AltErrLexer::new("ab").lex().unwrap().unwrap_err();
+  assert_ne!(ea, eb);
+  assert_eq!(format!("{ea:?}"), format!("{eb:?}"));
+
+  ALT_FLIP.store(false, core::sync::atomic::Ordering::Relaxed);
+  Harness::<AltErrLexer<'_>>::new("ab").run();
+}
+
+#[test]
+fn a_conforming_lexer_with_an_unstable_debug_passes_run() {
+  // The other direction, and the reason correcting the docs to describe rendering-equality would
+  // not have been a fix either: `TickingErrLexer` is conforming in every respect the contract
+  // names, and its payload's `Debug` never renders the same way twice. Comparing the rendering
+  // reddened it — `expected err="junk#0", got err="junk#1"` — on a lexer with no defect at all.
+  Harness::<TickingErrLexer<'_>>::over(["a?b", "??", "?", ""]).run();
+}
+
+/// Which token payload the next fresh construction hands out; the token twin of [`ALT_FLIP`].
+static ALT_TOK_FLIP: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+/// [`AltErrLexer`]'s defect on the token arm: same kind, same span, same slice, same item count,
+/// and a **payload** that alternates between fresh runs. Nothing the trait tier used to compare
+/// moves, so this passed `run()` for the third reason the kind projection is not the token.
+struct AltTokLexer<'a> {
+  src: &'a str,
+  start: usize,
+  end: usize,
+  state: AltChoice,
+}
+
+impl<'a> Lexer<'a> for AltTokLexer<'a> {
+  type State = AltChoice;
+  type Source = str;
+  type Token = VTok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a str) -> Self {
+    let pick = ALT_TOK_FLIP.fetch_xor(true, core::sync::atomic::Ordering::Relaxed);
+    Self { src, start: 0, end: 0, state: AltChoice(pick) }
+  }
+  fn with_state(src: &'a str, state: AltChoice) -> Self {
+    Self { src, start: 0, end: 0, state }
+  }
+  fn check(&self) -> Result<(), Infallible> {
+    Ok(())
+  }
+  fn state(&self) -> &AltChoice {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut AltChoice {
+    &mut self.state
+  }
+  fn into_state(self) -> AltChoice {
+    self.state
+  }
+  fn source(&self) -> &'a str {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> &'a str {
+    &self.src[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<VTok, Infallible>> {
+    self.start = self.end;
+    if self.start >= self.src.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src, self.start);
+    Some(Ok(VTok(u8::from(self.state.0))))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+#[test]
+#[should_panic(expected = "replay-identity] position 0: item mismatch: expected token VKind")]
+fn a_token_payload_that_changes_between_fresh_runs_is_falsified() {
+  ALT_TOK_FLIP.store(false, core::sync::atomic::Ordering::Relaxed);
+  Harness::<AltTokLexer<'_>>::new("ab").run();
+}
+
+/// Conforming under two fresh `new`s and **not** under a resume: `with_state` flips the choice,
+/// so the suffix a restore reproduces carries the other `Collide` variant at the same span and
+/// slice. Isolates `check_resume`'s comparison from `assert_run_eq`'s — replay identity passes.
+struct ResumeDriftErrLexer<'a> {
+  src: &'a str,
+  start: usize,
+  end: usize,
+  state: AltChoice,
+}
+
+impl<'a> Lexer<'a> for ResumeDriftErrLexer<'a> {
+  type State = AltChoice;
+  type Source = str;
+  type Token = CTok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a str) -> Self {
+    Self { src, start: 0, end: 0, state: AltChoice(false) }
+  }
+  fn with_state(src: &'a str, _state: AltChoice) -> Self {
+    // The defect: a rebuilt lexer decides the error differently from the one that saved the state.
+    Self { src, start: 0, end: 0, state: AltChoice(true) }
+  }
+  fn check(&self) -> Result<(), Collide> {
+    Ok(())
+  }
+  fn state(&self) -> &AltChoice {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut AltChoice {
+    &mut self.state
+  }
+  fn into_state(self) -> AltChoice {
+    self.state
+  }
+  fn source(&self) -> &'a str {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> &'a str {
+    &self.src[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<CTok, Collide>> {
+    self.start = self.end;
+    if self.start >= self.src.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src, self.start);
+    if self.start == 0 {
+      return Some(Err(if self.state.0 { Collide::Junk } else { Collide::Cut }));
+    }
+    Some(Ok(CTok))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+#[test]
+#[should_panic(expected = "state-resume] resume-from k=0, position 0: resumed item diverges")]
+fn a_resumed_error_value_that_moved_is_falsified() {
+  // Check 1 passes here — both fresh runs say `Cut` — so this reds `check_resume`'s comparison
+  // and only that one. Prefix replay is the assumption the whole input layer rests on.
+  Harness::<ResumeDriftErrLexer<'_>>::over(["ab"]).run();
+}
+
+// ── #295: a payload that will not equal itself is not a lexer defect ────────────────────
+//
+// One cell per comparison the sweep guarded, the two controls that say the guard has not traded
+// a false red for a false green, and the direct-call cells for the two comparisons an earlier
+// check reaches first. Every guard sits on a path that has ALREADY failed its comparison, so a
+// reflexive payload can never reach one — which is what makes the controls structural rather
+// than lucky.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct FKind;
+
+impl core::fmt::Display for FKind {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_str("f")
+  }
+}
+
+/// A payload holding an `f64`. Its derived `PartialEq` is **non-reflexive** exactly when the float
+/// is `NaN` — the case 38 pql corpus queries reached — and reflexive at every other value, which
+/// is what lets the control differ from the plant in one thing only.
+#[derive(Clone, Debug, PartialEq)]
+struct FTok(f64);
+
+impl Token<'_> for FTok {
+  type Kind = FKind;
+  type Error = Infallible;
+
+  const SCAN_LOOKAHEAD: crate::ScanLookahead = crate::ScanLookahead::Unbounded;
+
+  fn kind(&self) -> FKind {
+    FKind
+  }
+  fn is_trivia(&self) -> bool {
+    false
+  }
+}
+
+/// `NaN` for `n`, the byte's own value otherwise.
+fn float_of(b: u8) -> f64 {
+  if b == b'n' { f64::NAN } else { f64::from(b) }
+}
+
+/// [`ValueLexer`] over a float payload, at the same two modes: `OWN_BYTE` is conforming and
+/// `LAST_BYTE` reads the payload off the end of the buffer.
+struct FloatLexer<'a, const MODE: u8> {
+  src: &'a str,
+  start: usize,
+  end: usize,
+  state: (),
+}
+
+impl<'a, const MODE: u8> Lexer<'a> for FloatLexer<'a, MODE> {
+  type State = ();
+  type Source = str;
+  type Token = FTok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a str) -> Self {
+    Self { src, start: 0, end: 0, state: () }
+  }
+  fn with_state(src: &'a str, state: ()) -> Self {
+    Self { src, start: 0, end: 0, state }
+  }
+  fn check(&self) -> Result<(), Infallible> {
+    Ok(())
+  }
+  fn state(&self) -> &() {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut () {
+    &mut self.state
+  }
+  fn into_state(self) {}
+  fn source(&self) -> &'a str {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> &'a str {
+    &self.src[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<FTok, Infallible>> {
+    self.start = self.end;
+    if self.start >= self.src.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src, self.start);
+    let bytes = self.src.as_bytes();
+    let byte = match MODE {
+      OWN_BYTE => bytes[self.start],
+      _ => *bytes.last().expect("the source is non-empty here"),
+    };
+    Some(Ok(FTok(float_of(byte))))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+type NanPayloadLexer<'a> = FloatLexer<'a, OWN_BYTE>;
+type DriftingFloatLexer<'a> = FloatLexer<'a, LAST_BYTE>;
+
+#[test]
+#[should_panic(
+  expected = "non-reflexive-payload] partial-equivalence split k=18446744073709551615, position 0: INCONCLUSIVE — the token payload"
+)]
+fn a_nan_payload_is_diagnosed_and_not_blamed_on_the_lexer() {
+  // The filed case. The final leg compares the complete stream against a final drain of the SAME
+  // source, so before this it reported `partial-equivalence` — a red accusing the lexer, with
+  // `expected token FKind@0..1 (payload FTok(NaN)), got token FKind@0..1 (payload FTok(NaN))`:
+  // two things that render identically.
+  Harness::<NanPayloadLexer<'_>>::over(["n"]).run_partial();
+}
+
+#[test]
+#[should_panic(
+  expected = "non-reflexive-payload] replay-identity position 0: INCONCLUSIVE — the token payload"
+)]
+fn a_nan_payload_is_diagnosed_in_the_trait_tier_too() {
+  // The trait tier compared a `kind` and a `Debug` string, so a `NaN` payload was invisible to it
+  // and this was green. #269's repair is what puts the value in front of a comparison here — the
+  // guard has to arrive with it, or the repair introduces the defect one tier over.
+  Harness::<NanPayloadLexer<'_>>::over(["n"]).run();
+}
+
+#[test]
+#[should_panic(
+  expected = "non-reflexive-payload] state-resume resume-from k=0, position 0: INCONCLUSIVE — the token payload"
+)]
+fn a_nan_payload_is_diagnosed_at_the_resume_comparison() {
+  // `check_resume`'s comparison, reached directly because `run` runs replay identity first and a
+  // non-reflexive payload reds every comparison it reaches — so no lexer can arrive here through
+  // the entry point. A guard that is unreachable through one order of checks is still a guard:
+  // reachability is an argument about check ORDER, not a bound.
+  let budget = 8 * "n".len() + 64;
+  let reference = super::lex_run::<NanPayloadLexer<'_>>(0, "n", budget);
+  super::check_resume::<NanPayloadLexer<'_>>(0, "n", &reference, budget);
+}
+
+#[test]
+#[should_panic(
+  expected = "non-reflexive-payload] partial-equivalence split k=1, position 0: INCONCLUSIVE — the token payload"
+)]
+fn a_nan_payload_is_diagnosed_at_the_prefix_comparison() {
+  // `assert_partial_prefix_of`'s comparison, reached directly for `check_resume`'s reason: the
+  // final leg runs before the split loop and fires first.
+  use super::PartialItem;
+  let nan = || PartialItem::<NanPayloadLexer<'_>>::Token(FTok(f64::NAN), SimpleSpan::new(0, 1));
+  super::assert_partial_prefix_of::<NanPayloadLexer<'_>>(0, 1, &[nan()], &[nan()]);
+}
+
+#[test]
+fn a_reflexive_payload_of_the_same_type_still_fails_the_ordinary_way() {
+  // THE CONTROL, and the whole point of it: same payload type, same lexer shape, same source
+  // length, genuinely non-conforming — its payload is read off the end of the buffer — and never
+  // `NaN`. It must still red `partial-equivalence`, or the repair has traded a false red for a
+  // false green. It is structural rather than lucky: every guard sits on a path a failed
+  // comparison has already taken, and a reflexive value never fails against itself.
+  let panicked = std::panic::catch_unwind(|| {
+    Harness::<DriftingFloatLexer<'_>>::over(["abz"]).run_partial();
+  })
+  .unwrap_err();
+  let msg = panicked
+    .downcast_ref::<String>()
+    .expect("the kit panics with a formatted message");
+  assert!(
+    msg.contains("partial-equivalence] split k=2, position 0: prefix item diverges"),
+    "the control must keep the ORDINARY tag, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "the control must not be re-labelled as a payload problem, got: {msg}"
+  );
+  // And expected-vs-got must be two distinguishable values, unlike the NaN cell's.
+  assert!(msg.contains("FTok(122.0)") && msg.contains("FTok(98.0)"), "{msg}");
+}
+
+#[test]
+fn a_conforming_lexer_over_the_same_float_payload_passes_both_tiers() {
+  // The positive control: the payload TYPE is not what any of this rejects.
+  Harness::<NanPayloadLexer<'_>>::over(["ab", "a", ""]).run();
+  Harness::<NanPayloadLexer<'_>>::over(["ab", "a", ""]).run_partial();
+}
+
+/// A `Kind` that claims `Eq` and answers `false` to every comparison, itself included.
+///
+/// `Token::Kind` is bounded `Eq`, so this is a **broken total-equality promise** rather than the
+/// partial one a token or error payload carries — a stronger caller defect, and exactly as wrong
+/// to report as a stream divergence. It stands in for the whole `Eq`/`Ord` half of the population:
+/// `Lexer::Span` is bounded `Ord` and can lie the same way.
+#[derive(Clone, Copy, Debug, Hash)]
+struct LyingKind;
+
+impl PartialEq for LyingKind {
+  fn eq(&self, _: &Self) -> bool {
+    false
+  }
+}
+
+impl Eq for LyingKind {}
+
+impl core::fmt::Display for LyingKind {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_str("lying")
+  }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct LTok;
+
+impl Token<'_> for LTok {
+  type Kind = LyingKind;
+  type Error = Infallible;
+
+  const SCAN_LOOKAHEAD: crate::ScanLookahead = crate::ScanLookahead::Unbounded;
+
+  fn kind(&self) -> LyingKind {
+    LyingKind
+  }
+  fn is_trivia(&self) -> bool {
+    false
+  }
+}
+
+/// A per-character lexer, conforming in everything the contract names, over [`LyingKind`].
+struct LyingKindLexer<'a> {
+  src: &'a str,
+  start: usize,
+  end: usize,
+  state: (),
+}
+
+impl<'a> Lexer<'a> for LyingKindLexer<'a> {
+  type State = ();
+  type Source = str;
+  type Token = LTok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a str) -> Self {
+    Self { src, start: 0, end: 0, state: () }
+  }
+  fn with_state(src: &'a str, state: ()) -> Self {
+    Self { src, start: 0, end: 0, state }
+  }
+  fn check(&self) -> Result<(), Infallible> {
+    Ok(())
+  }
+  fn state(&self) -> &() {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut () {
+    &mut self.state
+  }
+  fn into_state(self) {}
+  fn source(&self) -> &'a str {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> &'a str {
+    &self.src[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<LTok, Infallible>> {
+    self.start = self.end;
+    if self.start >= self.src.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src, self.start);
+    Some(Ok(LTok))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+#[test]
+#[should_panic(
+  expected = "non-reflexive-payload] replay-identity position 0: INCONCLUSIVE — the token's `Kind`"
+)]
+fn a_kind_that_does_not_equal_itself_is_diagnosed_and_not_blamed_on_the_lexer() {
+  Harness::<LyingKindLexer<'_>>::over(["ab"]).run();
+}
+
+#[test]
+#[should_panic(
+  expected = "non-reflexive-payload] integration/peek-heavy position 0: INCONCLUSIVE — the token's `Kind`"
+)]
+fn a_kind_that_does_not_equal_itself_is_diagnosed_at_the_committed_stream_comparison() {
+  // The integration tier's comparison, reached directly: `run` rejects such a `Kind` at replay
+  // identity, three checks earlier, so nothing arrives here through the entry point. Guarding four
+  // comparisons and not the fifth would leave the same defect one relocation away.
+  let stream = [(LyingKind, SimpleSpan::new(0, 1))];
+  super::assert_stream_eq::<LyingKindLexer<'_>>(0, "peek-heavy", &stream, &stream);
+}
+
+#[test]
+#[should_panic(expected = "cache conformance [cache non-reflexive-payload]")]
+fn the_cache_kit_diagnoses_a_non_reflexive_token_instead_of_blaming_the_cache() {
+  // The cache tier draws its verdicts from the same population — its observable is the whole
+  // `(span, token, state)` triple and it asks `PartialEq` of two of the three — so it needs the
+  // same guard, or the sweep stops one tier short. Eight `NaN`-payload tokens, a conforming
+  // cache: before this the kit reported `entry-token`, "the entry at 0..1 is a DIFFERENT token
+  // from the one stored there — expected FTok(NaN), got FTok(NaN)".
+  crate::conformance::cache::CacheHarness::<
+    NanPayloadLexer<'_>,
+    crate::cache::DefaultCache<'_, NanPayloadLexer<'_>>,
+  >::new("nnnnnnnn")
+  .run();
+}
+
+#[test]
+fn the_cache_kit_still_runs_over_a_reflexive_payload_of_the_same_type() {
+  // The cache tier's control, and it is the same shape as the partial tier's: the payload TYPE is
+  // not what the guard rejects, only a value that will not equal itself.
+  crate::conformance::cache::CacheHarness::<
+    NanPayloadLexer<'_>,
+    crate::cache::DefaultCache<'_, NanPayloadLexer<'_>>,
+  >::new("abcdefgh")
+  .run();
+}

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -4395,3 +4395,654 @@ fn a_purity_run_length_outranks_a_non_reflexive_entry_at_a_shared_position() {
     "a count outranks a payload that will not equal itself"
   );
 }
+
+// ── #324 round 5 residue: `Eq` is a marker, and nothing checks its promise ──────────
+//
+// Round 4 classified a second population of verdict-drawing comparisons as settled by TOTAL
+// equalities and therefore outside the guarded population — span/slice coherence, read-frontier
+// purity, the span after exhaustion, gap-free tiling, and the cache's span-valued laws. The
+// classification is what these cells attack. `Eq` and `Ord` promise reflexivity and nothing
+// verifies the promise, so the same lying impl that gets a `non-reflexive-payload` refusal at an
+// item comparison got a red naming the caller's lexer three hundred lines away. One answer, not
+// two.
+
+/// A source slice whose `PartialEq` answers `false` to everything, itself included, while
+/// claiming [`Eq`].
+///
+/// This is the brief's own falsifier and it is a legal, compiling implementation of the
+/// [`Slice`](crate::Slice) bound: nothing in the trait system, and nothing in this kit before
+/// now, asks whether the promise `Eq` makes is kept.
+#[derive(Clone, Copy, Debug)]
+struct LyingSlice<'a>(&'a str);
+
+impl PartialEq for LyingSlice<'_> {
+  fn eq(&self, _: &Self) -> bool {
+    false
+  }
+}
+
+impl Eq for LyingSlice<'_> {}
+
+impl<'source> crate::Slice<'source> for LyingSlice<'source> {
+  type Char = char;
+  type Iter<'a>
+    = core::str::Chars<'a>
+  where
+    Self: 'a;
+  type PositionedIter<'a>
+    = core::str::CharIndices<'a>
+  where
+    Self: 'a;
+
+  fn iter<'a>(&'a self) -> Self::Iter<'a>
+  where
+    Self: 'a,
+  {
+    self.0.chars()
+  }
+  fn positioned_iter<'a>(&'a self) -> Self::PositionedIter<'a>
+  where
+    Self: 'a,
+  {
+    self.0.char_indices()
+  }
+  fn len(&self) -> usize {
+    self.0.len()
+  }
+}
+
+/// A `str`-backed source whose slices are [`LyingSlice`]s. Everything else about it is `str`'s
+/// own behaviour.
+#[derive(Debug)]
+struct LyingSliceSource(&'static str);
+
+impl crate::Source<usize> for LyingSliceSource {
+  type Slice<'source>
+    = LyingSlice<'source>
+  where
+    Self: 'source;
+
+  fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+  fn len(&self) -> usize {
+    self.0.len()
+  }
+  fn as_slice(&self) -> Self::Slice<'_> {
+    LyingSlice(self.0)
+  }
+  fn slice<R>(&self, range: R) -> Option<Self::Slice<'_>>
+  where
+    R: core::ops::RangeBounds<usize>,
+  {
+    self
+      .0
+      .get((
+        range.start_bound().map(|s| *s),
+        range.end_bound().map(|s| *s),
+      ))
+      .map(LyingSlice)
+  }
+  fn is_boundary(&self, index: usize) -> bool {
+    self.0.is_char_boundary(index)
+  }
+}
+
+/// A per-character lexer over [`LyingSliceSource`], conforming in everything the contract names.
+/// The only thing wrong anywhere near it is the caller's own slice equality.
+struct LyingSliceLexer<'a> {
+  src: &'a LyingSliceSource,
+  start: usize,
+  end: usize,
+  state: (),
+}
+
+impl<'a> Lexer<'a> for LyingSliceLexer<'a> {
+  type State = ();
+  type Source = LyingSliceSource;
+  type Token = PTok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a LyingSliceSource) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: (),
+    }
+  }
+  fn with_state(src: &'a LyingSliceSource, state: ()) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
+  }
+  fn check(&self) -> Result<(), Infallible> {
+    Ok(())
+  }
+  fn state(&self) -> &() {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut () {
+    &mut self.state
+  }
+  fn into_state(self) {}
+  fn source(&self) -> &'a LyingSliceSource {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> LyingSlice<'a> {
+    LyingSlice(&self.src.0[self.start..self.end])
+  }
+  fn lex(&mut self) -> Option<Result<PTok, Infallible>> {
+    self.start = self.end;
+    if self.start >= self.src.0.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src.0, self.start);
+    Some(Ok(PTok))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+#[test]
+fn a_slice_that_will_not_equal_itself_is_refused_and_not_blamed_on_the_lexer() {
+  // THE FALSIFIER round 4's exemption had to survive, and it does not. Before this the kit said
+  // "[input #0 span/slice-coherence] position 0: slice() disagrees with the source at span 0..1:
+  // source LyingSlice("a"), slice() LyingSlice("a")" — a red naming the caller's LEXER, with two
+  // values that render identically, which is #295 verbatim at a site round 4 called exempt.
+  let src = LyingSliceSource("ab");
+  let msg = panic_message(|| {
+    let _ = super::lex_run::<LyingSliceLexer<'_>>(0, &src, 8 * 2 + 64);
+  });
+  assert!(
+    msg
+      .contains("non-reflexive-payload] span/slice-coherence position 0: INCONCLUSIVE — the slice"),
+    "a broken TOTAL equality gets the same answer as a broken partial one, got: {msg}"
+  );
+}
+
+#[test]
+fn an_honest_slice_that_genuinely_disagrees_still_reds_span_slice_coherence() {
+  // The control, and the one that keeps the guard from trading a false red for a false green: a
+  // lexer whose `slice()` really does disagree with its own span, over a slice type that equals
+  // itself. `BadSliceLexer` is the kit's existing fixture for exactly that, and its cell
+  // (`incoherent_slice_is_caught`) still reds the ordinary way — asserted here as well so the two
+  // sit next to each other.
+  let msg = panic_message(|| {
+    Harness::<BadSliceLexer<'_>>::new("abc").run();
+  });
+  assert!(
+    msg.contains("span/slice-coherence") && !msg.contains("non-reflexive-payload"),
+    "a slice that equals itself and disagrees is a lexer defect and must be reported as one, got: {msg}"
+  );
+}
+
+/// An offset whose `PartialEq` answers `false` to everything, itself included, while claiming
+/// [`Eq`] through [`Ord`] — and whose **ordering** is honest.
+///
+/// The two halves are separate impls, which is the whole point: `cmp` and `eq` are independent
+/// caller code, so an `Ord` can be a total order for every purpose that compares two *different*
+/// values and still break the one law `Eq` adds on top of it. Every `<`-shaped check the kit runs
+/// therefore behaves exactly as it does over `usize`, and only the equalities move — which is what
+/// makes this a differential fixture rather than a lexer that fails everything.
+///
+/// [`Lexer::Span`](crate::Lexer::Span) is `SimpleSpan<LyingOffset>` here, whose derived
+/// `PartialEq` is elementwise, so the span lies too. One fixture, both components.
+#[derive(Clone, Copy, Debug, Default)]
+struct LyingOffset(usize);
+
+/// Hand-written for [`LyingKind`]'s reason: `Lexer::Offset` requires `Hash`, and deriving it
+/// beside a manual `PartialEq` is what `clippy::derived_hash_with_manual_eq` exists to stop. The
+/// lint's law — `a == b` implies `hash(a) == hash(b)` — holds *vacuously*, since nothing is equal
+/// to anything, so this is not a second lie on top of the one the fixture is for.
+impl core::hash::Hash for LyingOffset {
+  fn hash<H: core::hash::Hasher>(&self, _: &mut H) {}
+}
+
+impl PartialEq for LyingOffset {
+  fn eq(&self, _: &Self) -> bool {
+    false
+  }
+}
+
+impl Eq for LyingOffset {}
+
+impl PartialOrd for LyingOffset {
+  fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+impl Ord for LyingOffset {
+  fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+    self.0.cmp(&other.0)
+  }
+}
+
+impl core::ops::AddAssign<&LyingOffset> for LyingOffset {
+  fn add_assign(&mut self, rhs: &Self) {
+    self.0 += rhs.0;
+  }
+}
+
+/// A `str`-backed source addressed by [`LyingOffset`]. Everything else about it is `str`'s own
+/// behaviour.
+#[derive(Debug)]
+struct LyingOffsetSource(&'static str);
+
+impl crate::Source<LyingOffset> for LyingOffsetSource {
+  type Slice<'source>
+    = &'source str
+  where
+    Self: 'source;
+
+  fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+  fn len(&self) -> LyingOffset {
+    LyingOffset(self.0.len())
+  }
+  fn as_slice(&self) -> &str {
+    self.0
+  }
+  fn slice<R>(&self, range: R) -> Option<&str>
+  where
+    R: core::ops::RangeBounds<LyingOffset>,
+  {
+    use core::ops::Bound;
+    let start = match range.start_bound() {
+      Bound::Included(o) => o.0,
+      Bound::Excluded(o) => o.0 + 1,
+      Bound::Unbounded => 0,
+    };
+    let end = match range.end_bound() {
+      Bound::Included(o) => o.0 + 1,
+      Bound::Excluded(o) => o.0,
+      Bound::Unbounded => self.0.len(),
+    };
+    self.0.get(start..end)
+  }
+  fn is_boundary(&self, index: LyingOffset) -> bool {
+    self.0.is_char_boundary(index.0)
+  }
+}
+
+/// A per-character lexer over [`LyingOffsetSource`], conforming in everything the contract names.
+///
+/// It reports its frontier as [`ReadTo`](crate::ReadFrontier::ReadTo) rather than
+/// [`SpanEnd`](crate::ReadFrontier::SpanEnd) because `ReadFrontier`'s equality is derived from the
+/// offset's: a unit variant compares equal whatever the offset does, so `SpanEnd` would hide the
+/// very thing this fixture exists to show.
+struct LyingOffsetLexer<'a> {
+  src: &'a LyingOffsetSource,
+  start: usize,
+  end: usize,
+  state: (),
+}
+
+impl<'a> Lexer<'a> for LyingOffsetLexer<'a> {
+  type State = ();
+  type Source = LyingOffsetSource;
+  type Token = PTok;
+  type Span = SimpleSpan<LyingOffset>;
+  type Offset = LyingOffset;
+
+  fn new(src: &'a LyingOffsetSource) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: (),
+    }
+  }
+  fn with_state(src: &'a LyingOffsetSource, state: ()) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
+  }
+  fn check(&self) -> Result<(), Infallible> {
+    Ok(())
+  }
+  fn state(&self) -> &() {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut () {
+    &mut self.state
+  }
+  fn into_state(self) {}
+  fn source(&self) -> &'a LyingOffsetSource {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan<LyingOffset> {
+    SimpleSpan::new(LyingOffset(self.start), LyingOffset(self.end))
+  }
+  fn slice(&self) -> &'a str {
+    &self.src.0[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<PTok, Infallible>> {
+    self.start = self.end;
+    if self.start >= self.src.0.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src.0, self.start);
+    Some(Ok(PTok))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<LyingOffset> {
+    crate::ReadFrontier::ReadTo(LyingOffset(self.end))
+  }
+  fn bump(&mut self, n: &LyingOffset) {
+    self.end += n.0;
+  }
+}
+
+/// The items a conforming [`LyingOffsetLexer`] run over `src` produces, captured WITHOUT the
+/// guarded checks that would refuse first.
+///
+/// `lex_run` refuses at read-frontier purity for this fixture, which is the first equality it
+/// reaches — so the checks that run later have to be reached directly, exactly as
+/// `a_nan_payload_is_diagnosed_at_the_resume_comparison` reaches `check_resume`. Reachability is
+/// an argument about check ORDER; a guard behind another guard is still a guard.
+fn lying_offset_items(src: &LyingOffsetSource) -> Vec<super::Item<'_, LyingOffsetLexer<'_>>> {
+  let mut lexer = <LyingOffsetLexer<'_> as Lexer<'_>>::new(src);
+  let mut out = Vec::new();
+  while let Some(item) = lexer.lex() {
+    let span = lexer.span();
+    let end = *span.end_ref();
+    out.push(super::Item {
+      item,
+      span,
+      slice: lexer.slice(),
+      end,
+      state: (),
+    });
+  }
+  out
+}
+
+#[test]
+fn a_read_frontier_that_will_not_equal_itself_is_refused_and_not_blamed_on_the_lexer() {
+  // Before: "[input #0 read-frontier] position 0: read_frontier() changed between calls: first
+  // read ReadTo(LyingOffset(1)), probe #0 read ReadTo(LyingOffset(1))" — a purity accusation over
+  // two readings that are the same reading, rendered identically.
+  let src = LyingOffsetSource("ab");
+  let msg = panic_message(|| {
+    let _ = super::lex_run::<LyingOffsetLexer<'_>>(0, &src, 8 * 2 + 64);
+  });
+  assert!(
+    msg.contains(
+      "non-reflexive-payload] read-frontier position 0: INCONCLUSIVE — the read frontier"
+    ),
+    "the frontier's equality is the offset's, and a broken one is not a purity defect, got: {msg}"
+  );
+}
+
+#[test]
+fn a_span_that_will_not_equal_itself_is_refused_after_exhaustion_too() {
+  // Before: "[input #0 span-survives-exhaustion] span() changed after exhaustion: first read
+  // 2..2, probe #0 read 2..2". The clause this enforces is read by a refill driver, so the red it
+  // used to produce sent a caller looking for a lexer bug that is not there.
+  let src = LyingOffsetSource("ab");
+  let msg = panic_message(|| {
+    super::check_span_after_exhaustion::<LyingOffsetLexer<'_>>(0, &src, 8 * 2 + 64);
+  });
+  assert!(
+    msg.contains(
+      "non-reflexive-payload] span-survives-exhaustion after exhaustion: INCONCLUSIVE — the span"
+    ),
+    "the span after exhaustion is compared for stability, and the comparison is the caller's, got: {msg}"
+  );
+}
+
+#[test]
+fn an_offset_that_will_not_equal_itself_is_refused_by_the_tiling_law() {
+  // Before: "[input #0 lossless] position 0: first span 0..1 does not start at 0" — a tiling
+  // accusation over an offset that IS zero. Gap-free tiling is four `Offset` equalities and every
+  // one of them was unguarded; this is the one a run reaches first.
+  let src = LyingOffsetSource("ab");
+  let items = lying_offset_items(&src);
+  let msg = panic_message(|| {
+    super::check_lossless::<LyingOffsetLexer<'_>>(0, &src, &items);
+  });
+  assert!(
+    msg.contains("non-reflexive-payload] lossless position 0: INCONCLUSIVE — the span offset"),
+    "a tiling verdict is drawn from `L::Offset` equality and inherits the same refusal, got: {msg}"
+  );
+}
+
+#[test]
+fn an_honest_lexer_over_the_same_lying_offset_type_is_not_what_any_of_this_rejects() {
+  // The positive control for the whole residue repair: the ORDERING half of `LyingOffset` is
+  // honest, so every `<`-shaped check passes, and the refusals above are reached only because an
+  // equality was asked. Nothing here may pass silently that a `usize`-offset lexer would fail, so
+  // the same source through the same checks must still reach a refusal rather than a green.
+  let src = LyingOffsetSource("ab");
+  let items = lying_offset_items(&src);
+  assert_eq!(items.len(), 2, "the fixture lexes one token per character");
+  assert!(
+    items[0].span.start_ref().cmp(items[0].span.end_ref()) == core::cmp::Ordering::Less,
+    "the ordering half is honest, which is what keeps the fixture differential"
+  );
+}
+
+#[test]
+fn the_cache_kits_span_valued_laws_are_shadowed_by_its_entry_comparison_today() {
+  // **This cell is NOT differential for the residue, and says so on purpose.** The cache kit's
+  // eleven span-valued comparisons are guarded now, and with a wholly-lying `L::Span` not one of
+  // them is reachable: `run()` reaches an ENTRY comparison first, at `accepted-push`, and that
+  // one has been guarded since round 2. Removing `guard_entry` and re-running this fixture lands
+  // on `accepted-push`'s own verdict — never on a span-valued law — which is how the shadowing
+  // was established rather than assumed.
+  //
+  // So what this pins is the ORDER, not the repair: it is the cell that changes if a future
+  // reordering makes a span-valued law the first comparison a lying span reaches. The repair at
+  // those eleven sites is defensive for exactly that reason — reachability is an argument about
+  // check order and not a bound, which is the same argument
+  // `a_nan_payload_is_diagnosed_at_the_resume_comparison` rests on — and it costs a call on a
+  // path already panicking.
+  let src = LyingOffsetSource("abcdefghijklmnop");
+  let msg = panic_message(|| {
+    crate::conformance::cache::CacheHarness::<
+      LyingOffsetLexer<'_>,
+      crate::cache::DefaultCache<'_, LyingOffsetLexer<'_>>,
+    >::new(&src)
+    .run();
+  });
+  assert!(
+    msg.contains("non-reflexive-payload] accepted-push")
+      && msg.contains("INCONCLUSIVE — the span of the got entry"),
+    "a lying `L::Span` must reach the ENTRY comparison first and be refused there, got: {msg}"
+  );
+}
+
+/// A `NaN`-capable token payload whose **error** type is constructible.
+///
+/// [`FTok`]'s error is `Infallible`, so no fixture could put a non-reflexive value on the
+/// committed arm and a real divergence on the raised one at the same time — which is exactly the
+/// arrangement the integration tier's two-arm ordering fails in. This is the pair of arms in one
+/// token type.
+#[derive(Clone, Debug, PartialEq)]
+struct MTok(f64);
+
+impl Token<'_> for MTok {
+  type Kind = FKind;
+  type Error = FErr;
+
+  const SCAN_LOOKAHEAD: crate::ScanLookahead = crate::ScanLookahead::Unbounded;
+
+  fn kind(&self) -> FKind {
+    FKind
+  }
+  fn is_trivia(&self) -> bool {
+    false
+  }
+}
+
+/// A per-character lexer over [`MTok`], conforming in everything the contract names. It exists to
+/// name the type parameter the two-arm comparison is generic over; the cells below build the
+/// observations by hand, exactly as the partial tier's own refusal cells do.
+struct MixedArmLexer<'a> {
+  src: &'a str,
+  start: usize,
+  end: usize,
+  state: (),
+}
+
+impl<'a> Lexer<'a> for MixedArmLexer<'a> {
+  type State = ();
+  type Source = str;
+  type Token = MTok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a str) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: (),
+    }
+  }
+  fn with_state(src: &'a str, state: ()) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
+  }
+  fn check(&self) -> Result<(), FErr> {
+    Ok(())
+  }
+  fn state(&self) -> &() {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut () {
+    &mut self.state
+  }
+  fn into_state(self) {}
+  fn source(&self) -> &'a str {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> &'a str {
+    &self.src[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<MTok, FErr>> {
+    self.start = self.end;
+    if self.start >= self.src.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src, self.start);
+    Some(Ok(MTok(float_of(self.src.as_bytes()[self.start]))))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+#[test]
+fn a_raised_error_divergence_is_not_withheld_over_a_nan_the_committed_arm_holds() {
+  // The integration tier's two arms are one verdict, and they were two `assert` calls in a fixed
+  // order — so a committed-token divergence a `NaN` decided withheld a raised-error divergence a
+  // SPAN had settled. That is round 5's finding one level above the position/count ordering.
+  //
+  // Before: "[input #0 non-reflexive-payload] integration/peek-heavy position 0: INCONCLUSIVE —
+  // the token payload …", over an error arm that convicts the layer on its own.
+  use super::{Observed, StreamItem};
+  let nan_token = || StreamItem::<MixedArmLexer<'_>>::Token(MTok(f64::NAN), SimpleSpan::new(0, 1));
+  let error_at =
+    |end: usize| StreamItem::<MixedArmLexer<'_>>::LexerError(SimpleSpan::new(1, end), FErr(1.0));
+  let expected = Observed {
+    tokens: vec![nan_token()],
+    errors: vec![error_at(2)],
+  };
+  let got = Observed {
+    tokens: vec![nan_token()],
+    errors: vec![error_at(3)],
+  };
+  let msg = panic_message(|| {
+    super::assert_observed_eq::<MixedArmLexer<'_>>(0, "peek-heavy", &expected, &got);
+  });
+  assert!(
+    msg.contains(
+      "[input #0 integration/peek-heavy] error position 0: raised lexer-error stream diverges"
+    ),
+    "the error arm's span divergence is conclusive and must be what speaks, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "a span settled the error arm, so there is nothing to refuse, got: {msg}"
+  );
+}
+
+#[test]
+#[should_panic(
+  expected = "non-reflexive-payload] integration/peek-heavy position 0: INCONCLUSIVE — the token payload"
+)]
+fn a_committed_arm_nan_with_a_reproduced_error_arm_is_still_refused() {
+  // The control for it: the same committed arm, and an error arm that agrees. Nothing conclusive
+  // exists anywhere, so the retained fallback is the answer and the arm ordering is unchanged.
+  use super::{Observed, StreamItem};
+  let nan_token = || StreamItem::<MixedArmLexer<'_>>::Token(MTok(f64::NAN), SimpleSpan::new(0, 1));
+  let error = || StreamItem::<MixedArmLexer<'_>>::LexerError(SimpleSpan::new(1, 2), FErr(1.0));
+  let expected = Observed {
+    tokens: vec![nan_token()],
+    errors: vec![error()],
+  };
+  let got = Observed {
+    tokens: vec![nan_token()],
+    errors: vec![error()],
+  };
+  super::assert_observed_eq::<MixedArmLexer<'_>>(0, "peek-heavy", &expected, &got);
+}
+
+#[test]
+fn a_prefilled_impurity_the_appended_run_decided_is_not_withheld_over_a_nan_in_the_prefix() {
+  // THE COUNTEREXAMPLE'S MIRROR, and the third level the same finding lives at. The existing cell
+  // above runs the other way — a conclusive prefix and a `NaN` in the appended run — and passed
+  // because `find_map` takes the prefix first. This one is the direction `find_map` got wrong:
+  // the prefix's divergence is a `NaN` that decides nothing, and the appended run's is a span.
+  //
+  // Before: "[cache non-reflexive-payload] pure-peek/prefilled at depth 1 … INCONCLUSIVE — the
+  // token payload of the first prefix entry …".
+  let prefix_first = [(SimpleSpan::new(0, 1), FTok(f64::NAN), ())];
+  let prefix_second = [(SimpleSpan::new(0, 1), FTok(f64::NAN), ())];
+  let appended_first = [(SimpleSpan::new(4, 5), FTok(2.0), ())];
+  let appended_second = [(SimpleSpan::new(6, 7), FTok(2.0), ())];
+  let msg = panic_message(|| {
+    purity_harness().assert_prefilled_peek_pure(
+      "prefilled",
+      1,
+      "a full cache",
+      (&prefix_first, &prefix_second),
+      (&appended_first, &appended_second),
+    );
+  });
+  assert!(
+    msg.contains("disagreed in the run it appended behind that prefix"),
+    "the appended half is what the kit established, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "a span settled the appended half, so there is nothing to refuse, got: {msg}"
+  );
+}

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -3624,13 +3624,35 @@ fn two_peeked_runs_that_differ_only_in_length_are_refused_nothing() {
   // The purity comparison. A count is not a comparison of caller values, so a run that is longer
   // than the one before it settles the verdict with no `PartialEq` involved — and a scan of one
   // run still found the `NaN` in it and refused, over a `peek` that genuinely is not pure.
-  use super::cache::runs_decided;
+  //
+  // `Length` is a DECISION and not an absence, which is #324: an answer that said `None` here
+  // said the same thing about two runs that agree, so a caller needing both facts had to ask a
+  // second question and compose the two by hand.
+  use super::cache::{PurityDecided, runs_decided};
   let entry = || (SimpleSpan::new(0, 1), FTok(f64::NAN), ());
   let first = [entry()];
   let second: [(SimpleSpan, FTok, ()); 0] = [];
   assert!(
-    runs_decided::<NanPayloadLexer<'_>>(&first, &second).is_none(),
-    "a length divergence consults no caller equality, so there is nothing to refuse"
+    matches!(
+      runs_decided::<NanPayloadLexer<'_>>(&first, &second),
+      Some(PurityDecided::Length)
+    ),
+    "a length divergence consults no caller equality, so there is nothing to refuse — and it is \
+     still what decided the verdict"
+  );
+}
+
+#[test]
+fn two_equal_peeked_runs_are_the_only_thing_the_purity_comparison_answers_nothing_about() {
+  // The other half of that totality, and the reason `None` can carry a meaning at all now: it
+  // means the two runs are EQUAL, which is the one answer the failure path must never be reached
+  // with. Two `NaN`-carrying runs are not equal — they disagree at position 0 — so the pair here
+  // is reflexive on purpose.
+  use super::cache::runs_decided;
+  let run = [(SimpleSpan::new(0, 1), FTok(1.0), ())];
+  assert!(
+    runs_decided::<NanPayloadLexer<'_>>(&run, &run).is_none(),
+    "two equal runs differ in nothing, so there is nothing to decide"
   );
 }
 
@@ -3639,17 +3661,199 @@ fn a_peeked_run_is_probed_at_the_position_the_two_runs_disagree_at() {
   // And where they do disagree at a position, the question is asked THERE. A scan answered from
   // the first non-reflexive entry anywhere in one run, which need not be — and here is not — the
   // position the two runs actually differ at.
-  use super::cache::runs_decided;
+  use super::cache::{PurityDecided, runs_decided};
   let head = || (SimpleSpan::new(0, 1), FTok(1.0), ());
   let middle = |end: usize| (SimpleSpan::new(1, end), FTok(2.0), ());
   let nan = || (SimpleSpan::new(4, 5), FTok(f64::NAN), ());
   let first = [head(), middle(2), nan()];
   let second = [head(), middle(3), nan()];
-  let (i, decided) =
-    runs_decided::<NanPayloadLexer<'_>>(&first, &second).expect("position 1 differs in its span");
+  let Some(PurityDecided::At(i, decided)) = runs_decided::<NanPayloadLexer<'_>>(&first, &second)
+  else {
+    panic!("position 1 differs in its span, so a position is what decided it")
+  };
   assert_eq!(i, 1, "the divergence is at position 1, not at the NaN in 2");
   assert!(
     decided.expected().is_none() && decided.got().is_none(),
     "a span decided position 1, and a span is reflexive"
+  );
+}
+
+// ── #324: the prefilled purity law composes TWO comparisons, and `||` collapsed them ───
+//
+// The law compares the prefix `peek` was handed and the run it appended behind that prefix. `||`
+// over the two answers a `bool` that does not record which half fired, and the failure path then
+// re-ran both guards — so the half that did NOT decide was probed too, and its probe can fire.
+//
+// These cells call `assert_prefilled_peek_pure` directly, for the reason the two entry-comparison
+// cells above do and one more: the fabricated `NaN` the counterexample needs is a value no cache
+// the kit can drive is able to produce. The kit's own corpus lexer carries a source slice, which
+// is always reflexive, and a `NaN` in the CORPUS is refused at check 2's first entry comparison,
+// long before the prefilled sweep runs. Only a cache that manufactures the value in its own
+// `peek` reaches this — which is exactly the sequence below, with the manufacture done by hand.
+
+/// The harness the cells drive the prefilled purity law through. It never touches the cache, so
+/// the type parameter is only there to name one.
+fn purity_harness<'a>() -> crate::conformance::cache::CacheHarness<
+  'a,
+  NanPayloadLexer<'a>,
+  crate::cache::DefaultCache<'a, NanPayloadLexer<'a>>,
+> {
+  crate::conformance::cache::CacheHarness::new("nn")
+}
+
+/// The message a panic carried, or a failure saying the kit did not panic at all.
+fn panic_message(f: impl FnOnce() + std::panic::UnwindSafe) -> String {
+  let panicked = std::panic::catch_unwind(f).expect_err("the purity law must fail here");
+  panicked
+    .downcast_ref::<String>()
+    .expect("the kit panics with a formatted message")
+    .clone()
+}
+
+#[test]
+fn a_prefilled_impurity_the_prefix_decided_is_not_withheld_over_a_nan_the_appended_run_holds() {
+  // THE COUNTEREXAMPLE. The prefix already proves `peek` impure and its divergence is settled by
+  // the SPAN, which is reflexive — so that half's probe says nothing. The appended pair is not
+  // what decided anything: it differs because the second peek fabricated a `NaN`, and asking it
+  // withheld a verdict the kit had established, over a value no verdict rests on.
+  let prefix_first = [(SimpleSpan::new(0, 1), FTok(1.0), ())];
+  let prefix_second = [(SimpleSpan::new(9, 10), FTok(1.0), ())];
+  let appended_first = [(SimpleSpan::new(4, 5), FTok(2.0), ())];
+  let appended_second = [(SimpleSpan::new(4, 5), FTok(f64::NAN), ())];
+  let msg = panic_message(|| {
+    purity_harness().assert_prefilled_peek_pure(
+      "prefilled",
+      1,
+      "a full cache",
+      (&prefix_first, &prefix_second),
+      (&appended_first, &appended_second),
+    );
+  });
+  assert!(
+    msg.contains("pure-peek/prefilled at depth 1] against a full cache: two prefilled peeks on an unchanged cache disagreed in the prefix the buffer already held"),
+    "the impurity the prefix decided must be reported, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "the verdict rests on a span, which is reflexive; the NaN is in the pair that decided nothing, got: {msg}"
+  );
+}
+
+#[test]
+fn a_nan_in_the_appended_pair_that_actually_decided_is_still_refused() {
+  // CONTROL 1, the appended half: the same fabricated `NaN`, with the prefix now reproduced
+  // exactly. Nothing else decided, so the token payload is what the verdict rests on and the
+  // refusal must stand — or the repair has traded a false green for a false red.
+  let prefix = [(SimpleSpan::new(0, 1), FTok(1.0), ())];
+  let appended_first = [(SimpleSpan::new(4, 5), FTok(2.0), ())];
+  let appended_second = [(SimpleSpan::new(4, 5), FTok(f64::NAN), ())];
+  let msg = panic_message(|| {
+    purity_harness().assert_prefilled_peek_pure(
+      "prefilled",
+      1,
+      "a full cache",
+      (&prefix, &prefix),
+      (&appended_first, &appended_second),
+    );
+  });
+  assert!(
+    msg.contains(
+      "non-reflexive-payload] pure-peek/prefilled at depth 1 against a full cache, position 0: INCONCLUSIVE — the token payload of the second appended entry"
+    ),
+    "a NaN that decided the appended comparison must still be refused, and named as the appended side, got: {msg}"
+  );
+}
+
+#[test]
+fn a_nan_in_the_prefix_pair_that_actually_decided_is_still_refused() {
+  // CONTROL 1, the prefix half — the same rule on the other side of the decision, which is what
+  // pins the two halves to their own labels. The spans agree here, so the token payload is what
+  // decided the prefix comparison.
+  let prefix_first = [(SimpleSpan::new(0, 1), FTok(1.0), ())];
+  let prefix_second = [(SimpleSpan::new(0, 1), FTok(f64::NAN), ())];
+  let appended = [(SimpleSpan::new(4, 5), FTok(2.0), ())];
+  let msg = panic_message(|| {
+    purity_harness().assert_prefilled_peek_pure(
+      "prefilled",
+      1,
+      "a full cache",
+      (&prefix_first, &prefix_second),
+      (&appended, &appended),
+    );
+  });
+  assert!(
+    msg.contains(
+      "non-reflexive-payload] pure-peek/prefilled at depth 1 against a full cache, position 0: INCONCLUSIVE — the token payload of the second prefix entry"
+    ),
+    "a NaN that decided the prefix comparison must still be refused, got: {msg}"
+  );
+}
+
+#[test]
+fn a_prefix_impurity_with_reflexive_payloads_throughout_still_reds_the_ordinary_way() {
+  // CONTROL 2: nothing here is non-reflexive, and the cache is genuinely impure on the prefix.
+  // The ordinary `pure-peek` failure is the whole point of the law and must survive the repair.
+  let prefix_first = [(SimpleSpan::new(0, 1), FTok(1.0), ())];
+  let prefix_second = [(SimpleSpan::new(9, 10), FTok(1.0), ())];
+  let appended = [(SimpleSpan::new(4, 5), FTok(2.0), ())];
+  let msg = panic_message(|| {
+    purity_harness().assert_prefilled_peek_pure(
+      "prefilled",
+      1,
+      "a full cache",
+      (&prefix_first, &prefix_second),
+      (&appended, &appended),
+    );
+  });
+  assert!(
+    msg.contains("pure-peek/prefilled at depth 1] against a full cache: two prefilled peeks on an unchanged cache disagreed in the prefix the buffer already held"),
+    "the ordinary impurity failure must keep its tag and its wording, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "there is no non-reflexive value anywhere in this pair, got: {msg}"
+  );
+}
+
+#[test]
+fn an_appended_decided_impurity_is_reported_as_appended_and_not_as_the_prefix() {
+  // CONTROL 3, and it pulls against the other two: a repair that always blamed the prefix would
+  // pass the counterexample and control 2 while replacing one misattribution with another. The
+  // prefix is reproduced exactly here and the appended run is not, so the appended half is what
+  // decided — and the failure has to say so.
+  let prefix = [(SimpleSpan::new(0, 1), FTok(1.0), ())];
+  let appended_first = [(SimpleSpan::new(4, 5), FTok(2.0), ())];
+  let appended_second = [(SimpleSpan::new(6, 7), FTok(2.0), ())];
+  let msg = panic_message(|| {
+    purity_harness().assert_prefilled_peek_pure(
+      "prefilled",
+      1,
+      "a full cache",
+      (&prefix, &prefix),
+      (&appended_first, &appended_second),
+    );
+  });
+  assert!(
+    msg.contains("disagreed in the run it appended behind that prefix"),
+    "an appended-decided impurity must be reported as appended, got: {msg}"
+  );
+  assert!(
+    !msg.contains("the prefix the buffer already held"),
+    "the prefix was reproduced exactly and must not be blamed, got: {msg}"
+  );
+}
+
+#[test]
+fn two_prefilled_peeks_that_agree_in_both_halves_are_not_a_failure() {
+  // The positive control, and the one that keeps the law from being a check that cannot pass:
+  // both halves reproduced, `NaN` nowhere, no panic.
+  let prefix = [(SimpleSpan::new(0, 1), FTok(1.0), ())];
+  let appended = [(SimpleSpan::new(4, 5), FTok(2.0), ())];
+  purity_harness().assert_prefilled_peek_pure(
+    "prefilled",
+    1,
+    "a full cache",
+    (&prefix, &prefix),
+    (&appended, &appended),
   );
 }

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -3381,3 +3381,275 @@ fn the_cache_kit_still_runs_over_a_reflexive_payload_of_the_same_type() {
   >::new("abcdefgh")
   .run();
 }
+
+// ── The reviewer's counterexample: a divergence the DISCRIMINANT decided ────────────
+
+/// A lexer error payload holding an `f64` — [`FTok`]'s twin on the error arm, non-reflexive
+/// exactly at `NaN`.
+#[derive(Clone, Debug, PartialEq)]
+struct FErr(f64);
+
+/// A token whose *error* type is the `NaN`-capable one. Its own payload is trivial: the whole
+/// point of the fixture is that the non-reflexive value sits on the arm that is NOT compared,
+/// because the two sides are not the same arm at all.
+#[derive(Clone, Debug, PartialEq)]
+struct NTok;
+
+impl Token<'_> for NTok {
+  type Kind = FKind;
+  type Error = FErr;
+
+  const SCAN_LOOKAHEAD: crate::ScanLookahead = crate::ScanLookahead::Unbounded;
+
+  fn kind(&self) -> FKind {
+    FKind
+  }
+  fn is_trivia(&self) -> bool {
+    false
+  }
+}
+
+/// [`ErrLexer`]'s `FLIPS_TO_TOKEN` defect over a `NaN`-carrying error payload: the first item is
+/// an **error** unless the buffer's last byte is `z`, so the prefix `"ab"` yields
+/// `LexerError(0..1, FErr(NaN))` where the complete parse of `"abz"` has `NTok@0..1`.
+///
+/// The truncation nonconformance is the same one [`FlippingErrLexer`] carries — those two differ
+/// in the error payload and in nothing else, which is what makes them a differential pair.
+struct NanErrFlipLexer<'a> {
+  src: &'a str,
+  start: usize,
+  end: usize,
+  state: (),
+}
+
+impl<'a> Lexer<'a> for NanErrFlipLexer<'a> {
+  type State = ();
+  type Source = str;
+  type Token = NTok;
+  type Span = SimpleSpan;
+  type Offset = usize;
+
+  fn new(src: &'a str) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state: (),
+    }
+  }
+  fn with_state(src: &'a str, state: ()) -> Self {
+    Self {
+      src,
+      start: 0,
+      end: 0,
+      state,
+    }
+  }
+  fn check(&self) -> Result<(), FErr> {
+    Ok(())
+  }
+  fn state(&self) -> &() {
+    &self.state
+  }
+  fn state_mut(&mut self) -> &mut () {
+    &mut self.state
+  }
+  fn into_state(self) {}
+  fn source(&self) -> &'a str {
+    self.src
+  }
+  fn span(&self) -> SimpleSpan {
+    SimpleSpan::new(self.start, self.end)
+  }
+  fn slice(&self) -> &'a str {
+    &self.src[self.start..self.end]
+  }
+  fn lex(&mut self) -> Option<Result<NTok, FErr>> {
+    self.start = self.end;
+    if self.start >= self.src.len() {
+      return None;
+    }
+    self.end = boundary_after(self.src, self.start);
+    let sealed = self.src.as_bytes().last() == Some(&b'z');
+    if self.start == 0 && !sealed {
+      return Some(Err(FErr(f64::NAN)));
+    }
+    Some(Ok(NTok))
+  }
+  fn read_frontier(&self) -> crate::ReadFrontier<usize> {
+    crate::ReadFrontier::SpanEnd
+  }
+  fn bump(&mut self, n: &usize) {
+    self.end += *n;
+  }
+}
+
+#[test]
+fn a_discriminant_divergence_is_reported_even_when_a_payload_will_not_compare() {
+  // THE COUNTEREXAMPLE. `"abz"` at split k=2: the complete parse has `NTok@0..1` and the prefix
+  // `"ab"` yields `LexerError(0..1, FErr(NaN))`. The two sides are not the same ARM, so the
+  // comparison is settled by the discriminant and no caller equality is consulted at all — and a
+  // whole-item scan, which runs afterwards and knows nothing about why, still found the `NaN` and
+  // refused. That refusal claimed the kit had convicted the lexer of nothing, over exactly the
+  // truncation nonconformance the panic below is about.
+  //
+  // Its reflexive twin is `an_error_that_becomes_a_token_on_append_is_falsified` above:
+  // `FlippingErrLexer` carries the same defect with a payload that equals itself, and it has
+  // always reported the ordinary tag. The two differ in the payload and in nothing else.
+  let panicked = std::panic::catch_unwind(|| {
+    Harness::<NanErrFlipLexer<'_>>::over(["abz"]).run_partial();
+  })
+  .unwrap_err();
+  let msg = panicked
+    .downcast_ref::<String>()
+    .expect("the kit panics with a formatted message");
+  assert!(
+    msg.contains(
+      "partial-equivalence] split k=2, position 0: prefix item diverges from the complete prefix: expected token"
+    ),
+    "the truncation nonconformance must be reported, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "a divergence the DISCRIMINANT decided consults no caller equality and must not be refused, got: {msg}"
+  );
+}
+
+#[test]
+fn a_divergence_the_span_decided_is_reported_beside_a_payload_that_will_not_compare() {
+  // The counterexample's second shape, and the one that says the rule is about the OPERATION
+  // rather than about the discriminant alone: both sides are tokens, the payloads are `NaN` on
+  // both, and what differs is the SPAN — bounded `Ord`, so the comparison that decided the
+  // verdict is sound and there is nothing to refuse. A scan reached the payload first and
+  // refused, hiding a real divergence behind a diagnosis it had not established.
+  use super::Item;
+  let item = |end: usize| Item::<NanPayloadLexer<'_>> {
+    item: Ok(FTok(f64::NAN)),
+    span: SimpleSpan::new(0, end),
+    slice: &"nn"[..end],
+    end,
+    state: (),
+  };
+  let panicked = std::panic::catch_unwind(|| {
+    super::assert_run_eq::<NanPayloadLexer<'_>>(0, "replay-identity", &[item(1)], &[item(2)]);
+  })
+  .unwrap_err();
+  let msg = panicked
+    .downcast_ref::<String>()
+    .expect("the kit panics with a formatted message");
+  assert!(
+    msg.contains("replay-identity] position 0: item mismatch"),
+    "the span divergence must be reported, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "the comparison was decided by the span, which is reflexive, got: {msg}"
+  );
+}
+
+#[test]
+#[should_panic(
+  expected = "non-reflexive-payload] partial-equivalence split k=1, position 0: INCONCLUSIVE — the lexer error payload"
+)]
+fn a_non_reflexive_error_payload_is_still_refused_when_it_is_what_decided_the_comparison() {
+  // The other side of the same coin, and the #295 half of the mandate: two items on the SAME arm
+  // whose spans agree, so the error payload is the operation that decided the comparison — and it
+  // is the one that will not equal itself. The refusal must still fire, and it must still name
+  // the error payload.
+  use super::PartialItem;
+  let nan =
+    || PartialItem::<NanErrFlipLexer<'_>>::LexerError(SimpleSpan::new(0, 1), FErr(f64::NAN));
+  super::assert_partial_prefix_of::<NanErrFlipLexer<'_>>(0, 1, &[nan()], &[nan()]);
+}
+
+#[test]
+#[should_panic(
+  expected = "non-reflexive-payload] partial-equivalence split k=18446744073709551615, position 0: INCONCLUSIVE — the lexer error payload"
+)]
+fn the_error_arm_is_refused_at_the_final_leg_too() {
+  // `assert_partial_stream_eq`'s comparison over the error arm, reached directly: the final leg
+  // fires before the split loop, so a lexer whose FINAL drain errors with a `NaN` arrives here.
+  use super::PartialItem;
+  let nan =
+    || PartialItem::<NanErrFlipLexer<'_>>::LexerError(SimpleSpan::new(0, 1), FErr(f64::NAN));
+  super::assert_partial_stream_eq::<NanErrFlipLexer<'_>>(0, usize::MAX, &[nan()], &[nan()]);
+}
+
+// ── The cache tier's two comparisons, pinned where the harness cannot reach them ────
+//
+// Both cells call the repaired comparison directly, and they have to: on the cache tier a value
+// that will not equal itself is refused at the FIRST entry comparison the sweep makes — check 2's
+// accepted `push_front` into a fresh cache — because on a conforming cache every span agrees and
+// the non-reflexive component is the only thing that can fail. So no cache defect reachable
+// through `CacheHarness::run` is ever compared *beside* such a value, and the difference between
+// asking the component that decided and scanning the whole entry has nothing to show there.
+// Reachability is an argument about check order; the rule the cells pin is not.
+
+#[test]
+fn a_cache_entry_divergence_the_span_decided_is_not_refused_over_a_nan_token() {
+  // A permuted cache — the right token at the wrong span — beside a payload that will not compare.
+  // The span is bounded `Ord`, so the comparison that produced the verdict is sound and the entry
+  // message must stand. A whole-entry scan reached the token first and refused, hiding a real
+  // cache defect behind a diagnosis nothing had established.
+  use super::cache::{EntryPart, triple_compare};
+  let want = (SimpleSpan::new(0, 1), FTok(f64::NAN), ());
+  let got = (SimpleSpan::new(1, 2), FTok(f64::NAN), ());
+  let (part, decided) =
+    triple_compare::<NanPayloadLexer<'_>>((&want.0, &want.1, &want.2), (&got.0, &got.1, &got.2))
+      .expect("the two entries differ");
+  assert_eq!(part, EntryPart::Span, "the span is what differs");
+  assert!(
+    decided.expected().is_none() && decided.got().is_none(),
+    "the span decided it and a span is reflexive, so there is nothing to refuse"
+  );
+}
+
+#[test]
+fn a_cache_entry_divergence_the_token_decided_is_still_refused() {
+  // The #295 half at the same site: the spans agree, so the token payload is the operation that
+  // decided the comparison — and it is the one that will not equal itself. Both sides refuse.
+  use super::cache::{EntryPart, triple_compare};
+  let entry = || (SimpleSpan::new(0, 1), FTok(f64::NAN), ());
+  let (want, got) = (entry(), entry());
+  let (part, decided) =
+    triple_compare::<NanPayloadLexer<'_>>((&want.0, &want.1, &want.2), (&got.0, &got.1, &got.2))
+      .expect("a NaN payload does not equal itself");
+  assert_eq!(part, EntryPart::Token);
+  assert_eq!(decided.expected(), Some("the token payload"));
+  assert_eq!(decided.got(), Some("the token payload"));
+}
+
+#[test]
+fn two_peeked_runs_that_differ_only_in_length_are_refused_nothing() {
+  // The purity comparison. A count is not a comparison of caller values, so a run that is longer
+  // than the one before it settles the verdict with no `PartialEq` involved — and a scan of one
+  // run still found the `NaN` in it and refused, over a `peek` that genuinely is not pure.
+  use super::cache::runs_decided;
+  let entry = || (SimpleSpan::new(0, 1), FTok(f64::NAN), ());
+  let first = [entry()];
+  let second: [(SimpleSpan, FTok, ()); 0] = [];
+  assert!(
+    runs_decided::<NanPayloadLexer<'_>>(&first, &second).is_none(),
+    "a length divergence consults no caller equality, so there is nothing to refuse"
+  );
+}
+
+#[test]
+fn a_peeked_run_is_probed_at_the_position_the_two_runs_disagree_at() {
+  // And where they do disagree at a position, the question is asked THERE. A scan answered from
+  // the first non-reflexive entry anywhere in one run, which need not be — and here is not — the
+  // position the two runs actually differ at.
+  use super::cache::runs_decided;
+  let head = || (SimpleSpan::new(0, 1), FTok(1.0), ());
+  let middle = |end: usize| (SimpleSpan::new(1, end), FTok(2.0), ());
+  let nan = || (SimpleSpan::new(4, 5), FTok(f64::NAN), ());
+  let first = [head(), middle(2), nan()];
+  let second = [head(), middle(3), nan()];
+  let (i, decided) =
+    runs_decided::<NanPayloadLexer<'_>>(&first, &second).expect("position 1 differs in its span");
+  assert_eq!(i, 1, "the divergence is at position 1, not at the NaN in 2");
+  assert!(
+    decided.expected().is_none() && decided.got().is_none(),
+    "a span decided position 1, and a span is reflexive"
+  );
+}

--- a/tokora/src/conformance/tests.rs
+++ b/tokora/src/conformance/tests.rs
@@ -3598,6 +3598,42 @@ fn an_error_payload_that_moves_between_two_integration_schedules_is_falsified() 
 }
 
 #[test]
+fn a_span_divergence_at_this_tier_is_still_reported_the_way_it_always_was() {
+  // The control for the extension, and the reason this is not a rewrite: the tier compares MORE
+  // than it did, and it must say exactly what it always said about a divergence the span decided.
+  // `Lexer::Span` is bounded `Ord`, so the comparison that drew the verdict is sound and there is
+  // nothing to refuse — same tier, same tag, same words. Only the rendering of the two sides
+  // grew, because an item now carries the payload the verdict is entitled to show.
+  let expected = [super::StreamItem::<InstanceFlipLexer<'_>>::Token(
+    VTok(7),
+    SimpleSpan::new(0, 1),
+  )];
+  let got = [super::StreamItem::<InstanceFlipLexer<'_>>::Token(
+    VTok(7),
+    SimpleSpan::new(1, 2),
+  )];
+  let msg = panic_message(|| {
+    super::assert_stream_eq::<InstanceFlipLexer<'_>>(
+      0,
+      "peek-heavy",
+      super::COMMITTED,
+      &expected,
+      &got,
+    );
+  });
+  assert!(
+    msg.contains(
+      "[input #0 integration/peek-heavy] position 0: committed token stream diverges: expected"
+    ),
+    "a span divergence must keep the tier's own verdict and wording, got: {msg}"
+  );
+  assert!(
+    !msg.contains("non-reflexive-payload"),
+    "the span decided it and a span is reflexive, so there is nothing to refuse, got: {msg}"
+  );
+}
+
+#[test]
 #[should_panic(expected = "cache conformance [cache non-reflexive-payload]")]
 fn the_cache_kit_diagnoses_a_non_reflexive_token_instead_of_blaming_the_cache() {
   // The cache tier draws its verdicts from the same population — its observable is the whole

--- a/tokora/src/guide/ch10_testing.md
+++ b/tokora/src/guide/ch10_testing.md
@@ -24,7 +24,9 @@ over a corpus with [`new`](crate::conformance::Harness::new) or
 [`over`](crate::conformance::Harness::over), then call
 [`run`](crate::conformance::Harness::run). It checks:
 
-1. **replay identity** — two fresh runs produce the identical token/span/slice sequence;
+1. **replay identity** — two fresh runs produce the identical token/span/slice sequence, and
+   identical means **by value**: the whole token, the whole error payload, never a rendering of
+   either and never the token's kind standing in for it;
 2. **state-resume faithfulness** — at *every* position, saving the state and resuming there
    reproduces the rest of the run. This is the prefix-replay assumption, verbatim;
 3. **monotone progress** — spans advance, none is empty, and the run terminates;
@@ -54,12 +56,22 @@ run still passes, and it still catches an item that *changes* — a token whose 
 **value** moved, a token that became an error, an error whose payload moved. See
 [`Lexer::read_frontier`](crate::Lexer::read_frontier) for what declaring the class buys back.
 
-Comparing the *value* is why this tier — and only this tier — asks for `PartialEq` on your token
-and on its error type. It is one derive on a data type, and it is what makes the comparison
-total: every field participates, including the one you add next year. The alternative, a
-comparison key written by hand, is a projection, and the field it forgets is exactly the field
-that drifts. Calc's `Tok` and `LexError` already derive it; a vocabulary that cannot keeps
-[`run`](crate::conformance::Harness::run) and loses this tier.
+Comparing the *value* is why the kit asks for `PartialEq` on your token and on its error type. It
+is one derive on a data type, and it is what makes the comparison total: every field
+participates, including the one you add next year. The alternative, a comparison key written by
+hand, is a projection, and the field it forgets is exactly the field that drifts. Calc's `Tok`
+and `LexError` already derive it. Both entry points ask for it:
+[`run`](crate::conformance::Harness::run) compared an error's `Debug` rendering and a token's
+*kind* until 0.10.0, so its replay-identity green meant less than the word said — two unequal
+error values that print alike passed, and a payload rendering a counter reddened a conforming
+lexer. A vocabulary whose token or error genuinely cannot be `PartialEq` loses the kit and
+recovers it with a hand-written impl or a newtype.
+
+One thing `PartialEq` does *not* promise is reflexivity, and a payload holding an `f64` that can
+be `NaN` is not equal to itself. That is your obligation, not the kit's — hand-write the impl
+that says what equality means for such a type — but the kit will not misreport it: a comparison
+decided by a value that will not equal itself is refused, tagged `non-reflexive-payload` and
+naming the component, instead of being reported as a conformance failure of your lexer.
 
 ```rust
 # use tokora::{Token as TokenT, logos::{self, Logos}};

--- a/tokora/src/guide/ch10_testing.md
+++ b/tokora/src/guide/ch10_testing.md
@@ -68,10 +68,19 @@ lexer. A vocabulary whose token or error genuinely cannot be `PartialEq` loses t
 recovers it with a hand-written impl or a newtype.
 
 One thing `PartialEq` does *not* promise is reflexivity, and a payload holding an `f64` that can
-be `NaN` is not equal to itself. That is your obligation, not the kit's — hand-write the impl
-that says what equality means for such a type — but the kit will not misreport it: a comparison
-decided by a value that will not equal itself is refused, tagged `non-reflexive-payload` and
-naming the component, instead of being reported as a conformance failure of your lexer.
+be `NaN` is not equal to itself. `Eq` and `Ord` *do* promise it — but they are markers, and
+nothing checks the promise, so a `Kind`, a span, an offset or a source slice can break it too.
+Either way it is your obligation, not the kit's — hand-write the impl that says what equality
+means for such a type — and either way the kit will not misreport it: a comparison decided by a
+value that will not equal itself is refused, tagged `non-reflexive-payload` and naming the
+component, instead of being reported as a conformance failure of your lexer.
+
+The kit refuses only when it has nothing better to say. A difference it *can* convict on — one at
+the discriminant, one in item count, or one between two values that each equal themselves —
+outranks a comparison it cannot use, wherever both are available: two runs yielding `[Tok(NaN)]`
+and `[Tok(NaN), Tok(0.0)]` are reported as a length mismatch, because the extra item proves the
+divergence whatever `NaN` does. The refusal is the answer of last resort, and it means the kit
+searched and found nothing it could stand behind.
 
 ```rust
 # use tokora::{Token as TokenT, logos::{self, Logos}};


### PR DESCRIPTION
Closes #269. Closes #295.