### PR TITLE
docs(many): the two families rest on the same byte, so the exception stage 2 documents is resilience and not the cursor (#259)

### DIFF
--- a/tokora/src/parser/collect.rs
+++ b/tokora/src/parser/collect.rs
@@ -3,6 +3,28 @@ use core::marker::PhantomData;
 use crate::input::Complete;
 
 /// A parser that collects results into a container.
+///
+/// # Where the input rests, and what the reported span therefore covers
+///
+/// The span this combinator hands back — directly, as the `L::Span` of a borrowed collection, and
+/// inside the `Spanned<Container, L::Span>` of an owning one — is built with
+/// [`InputRef::span_since`](crate::InputRef::span_since), which reads
+/// [`InputRef::cursor`](crate::InputRef::cursor): the **lookahead front**, not the committed
+/// watermark.
+///
+/// A repetition construct learns that its elements have run out by *looking* at the token that
+/// ends them, and a declined peek leaves that token in the lookahead cache. So the reported end is
+/// the **start of the next token**, trailing trivia included, whenever the construct stopped that
+/// way, and the end of the last token consumed when it looked no further — at end of input, or
+/// after committing a closing delimiter, or on the failure arm. Over `1 2 3    +` the collection
+/// ends at the `3` and the reported span ends at the `+`, four bytes later.
+///
+/// This is uniform across every repetition driver: plain and separated, `while` and not,
+/// delimited and not, all rest in the same place, so a span does not change with the combinator
+/// that produced it. `tokora/tests/repetition_behavioural_matrix.rs`'s
+/// `a_construct_rests_at_the_lookahead_front` holds it over all forty-eight of them. A caller that
+/// needs an end past no trivia wants [`InputRef::span`](crate::InputRef::span)'s end instead — the
+/// committed watermark, which is the end of the last token the parse actually took.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Collect<P, Container, Ctx, Lang: ?Sized = (), Cmpl = Complete> {
   pub(crate) parser: P,

--- a/tokora/src/parser/many/mod.rs
+++ b/tokora/src/parser/many/mod.rs
@@ -143,6 +143,116 @@
 //! cannot drift silently in either direction — narrower, if `Accept` starts being gated; or wider,
 //! if the decline/stall/closer exits above stop being gated and the section's non-vacuity controls
 //! stop noticing.
+//!
+//! # The eight element loops, and which of their differences are essential
+//!
+//! [#259](https://github.com/al8n/tokora/issues/259)'s progress-and-terminal-stop criterion
+//! admits two answers — a **clearly identified shared engine** *or* **deliberately documented
+//! exceptions**. This section is the per-loop verdict on which of the two each difference is. It
+//! was decided against `tokora/tests/repetition_behavioural_matrix.rs` rather than by reading,
+//! and the rule it was decided by is: a difference is **incidental** when a property can be
+//! stated that all eight loops satisfy, and **essential** when stating it requires naming a
+//! loop — the naming is then the documented exception, and the matrix carries it as an
+//! assertion rather than as a skipped case.
+//!
+//! The eight are `repeated`, `repeated_while`, `sep/parse`, `sep/delim`, `sep_while/parse`,
+//! `sep_while/delim`, `delim/repeated` and `delim/repeated_while`.
+//!
+//! ## What all eight already share
+//!
+//! Counted comment-blind, the way `END_STATE_CENSUS` counts, so a prose mention is not a site.
+//!
+//! | law | one mechanism, in every loop | sites per loop |
+//! |---|---|---|
+//! | progress | one stall test, `new_committed <= committed` over `span().end()` — never the cache-front cursor | 1, in all eight |
+//! | terminal scanner stop | `latch_snapshot()` beside `scanner_trip_snapshot()`, taken once per collection | 1 + 1, in all eight |
+//! | descent budget trip | `inp.trip_snapshot()`, inside the element loop, so once per element | 1, in all eight |
+//! | an element's `Err` | [`file_element_failure`] | 1 in each try-driven loop, 0 in each `*_while` one — the resilience axis, and nothing else, decides who files one |
+//! | an element's absence | [`absence_after_element`], on every decline and every stall exit | 1 to 6, one per absence exit; the delimited loops have more exits because a close probe follows each |
+//! | a real closer | [`close_after_element`] | 1 to 3 in each delimited loop, 0 in each undelimited one |
+//! | one admitted element | [`admit_element`] | 1 or 4, except `sep/delim` and `sep_while/delim`, which reach it through `sep{,_while}/parse`'s own `handle_continue` and carry no admission at all |
+//! | what is collected | layer A7: one abstract fixture reaches one collection whichever of the four structural shapes runs it | — |
+//! | where the input rests | layer B9: all eight come to rest at the lookahead front | — |
+//!
+//! ## The verdicts
+//!
+//! | loop | what it does that the others do not | verdict |
+//! |---|---|---|
+//! | `repeated` | files an element's `Err` as a diagnostic and goes on; stops on the element's own decline. Returns the span its [`RepeatedHandler::on_stop`] built | **essential** on resilience — layer A6 asserts it against the `*_while` twin. **Incidental** on the stop-hook return: `repeated_while` computes the same span itself and throws the handler's away |
+//! | `repeated_while` | asks a caller condition over a `W`-wide decision window; never files an element failure; binds `span_since` before the stop hook. Like all four `*_while` loops it is written for `Complete` alone, where the try-driven four are generic over `Cmpl` | **essential** on resilience and on the window — that pair *is* what `while` means. The `Complete` restriction is essential by mechanism and **unmeasured**: a fixed-width decision window cannot tell a short read from a truncated one, and the matrix runs `Complete` only. **Incidental** on the stop-hook shape |
+//! | `sep/parse` | peeks a separator slot before every element through `try_expect_or_stop`, and runs a four-arm `State` machine over it | **essential** — the slot is what `Separated` means. It contributes its own tokens and its own diagnostics and nothing else: over `junk_middle` it records one diagnostic where `repeated` records none, and A7 shows the collection is unchanged |
+//! | `sep/delim` | the same state machine under an opener and a closer, with the slot probed by `try_expect_map` because the same position may hold the closer | **essential** on both counts. The three-way probe exists because a delimited list's separator slot is also a close position; the undelimited form has no closer there and needs the terminal re-raise instead |
+//! | `sep_while/parse` | `sep/parse`'s slot with `repeated_while`'s condition | **essential**, as the union of the two axes above |
+//! | `sep_while/delim` | `sep/delim`'s slot and closer with `repeated_while`'s condition | **essential**, as the union of the three axes above |
+//! | `delim/repeated` | a delimited *plain* loop that re-states `repeated`'s element loop instead of wrapping it; takes its count hook and its stop hook as two separate arguments, a third stop-hook shape; implements **one** destination contract | **essential** on the delimiter alone. **Incidental** on the other three — `sep/delim` is delimited too and reuses its undelimited sibling's handlers, carries one hook, and implements four contracts |
+//! | `delim/repeated_while` | the same three, with `repeated_while`'s condition | same verdict, same evidence |
+//!
+//! ## Where the input rests, and why it is not a family difference
+//!
+//! Every driver builds its reported span with [`InputRef::span_since`](crate::InputRef::span_since),
+//! which reads [`InputRef::cursor`](crate::InputRef::cursor) — the lookahead front, documented on
+//! that method as *the start of the first cached token, otherwise the current position*. So a
+//! repetition construct's reported end runs to the start of the next token, **trailing trivia
+//! included**, whenever it stopped by looking at a token it did not consume, and to the end of the
+//! last token it consumed when it looked no further.
+//!
+//! That is uniform, and stage 2 had to measure it because this crate's own prose said otherwise —
+//! that `repeated` rests at the end of its last token while `separated` rests at the start of the
+//! next one, so a caller's span would differ by which combinator it picked. It does not: both
+//! reach the stop through a peek that declined, and a declined peek leaves the token cached
+//! whether the peek came from the separator slot or from the element parser's own lookahead. On
+//! `1 2 3    +` under `repeated` and on `1 , 2 , 3    +` under `separated`, both report an end
+//! four bytes past the last element, at the `+`; both commit only as far as the `3`. Layer B9
+//! states it over all forty-eight rows, and the difference is in the **arm** —
+//! peeked-and-declined against consumed-to-the-end — not in the family.
+//!
+//! ## Two API-surface asymmetries, both incidental
+//!
+//! * **`delim/repeated` and `delim/repeated_while` implement only the owning
+//!   `Collect<_, Container>`.** Their undelimited siblings implement three destination contracts
+//!   (owning to `Container`, owning to `Spanned<Container>`, borrowed to `L::Span`) and the four
+//!   separated loops implement four. Being delimited is not what stops them: `sep/delim` and
+//!   `sep_while/delim` are delimited and implement all four. The borrowed contract is the only one
+//!   that lets a caller see the container on the **failure** arm, which is layer B8's whole
+//!   subject, so the two loops missing it are the two the matrix cannot ask that question of.
+//! * **`Separated` and `SeparatedWhile` expose no `at_least(n).at_most(m)` chaining.** Ten
+//!   [`Apply`](crate::parser::Apply) impls exist and all ten are `Repeated`'s or `RepeatedWhile`'s;
+//!   the two cardinality builders reach `Bounded` through direct constructors instead. The missing
+//!   pair is `Apply<Bounded<P>> for AtLeast<P>` and its `AtMost` mirror — three lines each,
+//!   mentioning no separator, forwarding to a `Bounded<Separated<..>>` that already drives. It
+//!   costs the matrix's A2 relation half its subject: `bounded(n, n)`, `at_least(n).at_most(n)`
+//!   and `at_most(n).at_least(n)` can only be related where three paths exist.
+//!
+//! ## What a consolidation pass could take, in order of what each one buys
+//!
+//! Only the incidental findings are here; the essential ones above are the exceptions the
+//! criterion asks to be documented rather than removed.
+//!
+//! 1. **`delim/repeated` and `delim/repeated_while` re-state the plain element loop instead of
+//!    wrapping it.** Two files, 593 lines, each carrying its own stall test, its own
+//!    [`admit_element`] call and its own absence exits, and `delim/repeated` its own
+//!    [`file_element_failure`] gate besides — where `sep/delim` and `sep_while/delim` drive the
+//!    *same* state handlers their undelimited siblings do and carry no admission at all. It is the
+//!    largest incidental difference and the one that pays twice: the two missing destination
+//!    contracts are missing *because* the loop is spelled
+//!    `parse_repeated(inp, container, counts, on_stop)` rather than as `Repeated::parse` under a
+//!    delimiter, so a driver that wrapped would inherit both, and the matrix's borrowed half would
+//!    cover eight drivers instead of six. The instruction-count gate is what bounds the cost.
+//! 2. **Three stop-hook shapes for one end-of-construct pass.** [`RepeatedHandler::on_stop`]
+//!    returning the span (`repeated` uses it, `repeated_while` discards it and rebuilds the same
+//!    span itself), `EndStateHandler`'s four state-dispatched methods, and a bare
+//!    `FnOnce(usize, &mut InputRef, &L::Span) -> Result<(), _>` closure in the two delimited plain
+//!    loops. `END_STATE_CENSUS` exists partly to pin which of two success-exit spellings each
+//!    driver uses; one shape retires that half of it.
+//! 3. **`Apply<Bounded<P>> for AtLeast<P>` and its `AtMost` mirror, for `Separated` and
+//!    `SeparatedWhile`.** Four small impls. They buy the builder parity above and let layer A2 —
+//!    the relation over three construction paths to one cardinality — cover eight drivers instead
+//!    of four.
+//! 4. **The descent baseline's placement**, beside the element attempt in `repeated` and
+//!    `delim/repeated` and at the top of the cycle in the other six. Lowest: the widened window is
+//!    already argued at each site (nothing between the two points can descend, so the reading is
+//!    the one the element attempt would have given), so unifying it buys uniformity and no
+//!    behaviour, and costs re-making that argument once per driver.
 
 // `UnexpectedEot` reaches this family's descendants through their `use super::*`; the drivers
 // under `repeated*/`, `sep*/` and `delim/` all name it in a `From` bound and none of them import

--- a/tokora/tests/repetition_behavioural_matrix.rs
+++ b/tokora/tests/repetition_behavioural_matrix.rs
@@ -416,8 +416,9 @@ const TAIL: Fixture = Fixture {
   cells: &[Cell::Ok(7), Cell::Ok(8)],
 };
 
-/// The source's tokens, lexed **without** tokora: the independent side of the position property.
-fn lexed(src: &str) -> Vec<(TokenKind, usize)> {
+/// The source's tokens, lexed **without** tokora: the independent side of the position
+/// properties. Each entry is `(kind, start, end)`; B9 needs the end, B3 and B4 only the start.
+fn lexed(src: &str) -> Vec<(TokenKind, usize, usize)> {
   let mut out = Vec::new();
   let mut lex = Token::lexer(src);
   while let Some(tok) = lex.next() {
@@ -425,6 +426,7 @@ fn lexed(src: &str) -> Vec<(TokenKind, usize)> {
     out.push((
       TokenKind::from(&tok.expect("the fixture renderings lex cleanly")),
       span.start,
+      span.end,
     ));
   }
   out
@@ -595,7 +597,7 @@ macro_rules! variants {
             Ok((second.ok(), accepts))
           }
           let joined = format!("{src} {tail}");
-          let starts: Vec<usize> = lexed(&joined).into_iter().map(|(_, s)| s).collect();
+          let starts: Vec<usize> = lexed(&joined).into_iter().map(|(_, s, _)| s).collect();
           PLAN.with(|p| *p.borrow_mut() = (starts, lexed(src).len()));
           Parser::with_context(ParserContext::new(Fatal::new()))
             .apply(go)
@@ -750,7 +752,15 @@ variants! {
 // storage and can read it on the **failure** arm, which the owning form cannot expose. Six of the
 // eight drivers implement it; `delim/repeated` and `delim/repeated_while` implement only the
 // owning form, so they have no row here. That asymmetry is a fact about the crate rather than a
-// gap in this file, and it is the reason the main table above is the owning one.
+// gap in this file, and it is the reason the main table above is the owning one. #259 stage 2
+// found it **incidental** rather than forced — `sep/delim` and `sep_while/delim` are delimited
+// too and implement the borrowed contract — so these rows return when those two drivers do.
+//
+// The count is twenty-four against the main table's forty-eight, and the two subtractions are
+// different in kind. Fourteen rows are the two drivers above, which have no borrowed impl to
+// drive. The other ten are the `exact2*` spellings: three construction paths to one cardinality
+// is A2's subject, and relating them through a second ownership contract asks nothing A2 and A5
+// do not already ask separately.
 
 /// One row of the borrowed-destination table.
 struct Borrowed {
@@ -851,6 +861,8 @@ borrowed_variants! { te, pe => {
     (&mut te).separated_by_comma().at_least(2).delimited::<Bracket<(), (), ()>>();
   b_dsep_max2: Comma true ~ dsep_max2 =
     (&mut te).separated_by_comma().at_most(2).delimited::<Bracket<(), (), ()>>();
+  b_dsep_bnd13: Comma true ~ dsep_bnd13 =
+    (&mut te).separated_by_comma().bounded(1, 3).delimited::<Bracket<(), (), ()>>();
 
   b_dsepw_unb: Comma true ~ dsepw_unb =
     (&mut pe).separated_by_comma_while::<_, U1>(decide_num::<Ctx<'_>>)
@@ -860,6 +872,9 @@ borrowed_variants! { te, pe => {
       .delimited::<Bracket<(), (), ()>>();
   b_dsepw_max2: Comma true ~ dsepw_max2 =
     (&mut pe).separated_by_comma_while::<_, U1>(decide_num::<Ctx<'_>>).at_most(2)
+      .delimited::<Bracket<(), (), ()>>();
+  b_dsepw_bnd13: Comma true ~ dsepw_bnd13 =
+    (&mut pe).separated_by_comma_while::<_, U1>(decide_num::<Ctx<'_>>).bounded(1, 3)
       .delimited::<Bracket<(), (), ()>>();
 }}
 
@@ -1047,8 +1062,8 @@ fn the_input_rests_at_the_end_of_what_was_consumed() {
       let (_, end) = obs.consumed;
       let want: Vec<TokenKind> = lexed(&src)
         .into_iter()
-        .filter(|(_, start)| *start >= end)
-        .map(|(k, _)| k)
+        .filter(|(_, start, _)| *start >= end)
+        .map(|(k, _, _)| k)
         .collect();
       r.check(want == obs.rest, || {
         format!(
@@ -1073,14 +1088,13 @@ fn the_input_rests_at_the_end_of_what_was_consumed() {
 ///
 /// # Why the statement is about tokens rather than about an offset
 ///
-/// The two families do not stop at the same *byte*. After `repeated` returns, the input's
-/// lookahead cursor sits at the end of the last token it consumed; after `separated` returns, it
-/// sits at the start of the next token, past the whitespace between them, because the separator
-/// slot was peeked. `InputRef::span_since` — which is what the drivers themselves build every
-/// reported span from — reads that cursor, so the difference reaches the spans a caller sees.
-/// It is a real cross-family difference and it belongs to #259's stage 2 verdict on which driver
-/// differences are essential; it is **not** a difference about which tokens the construct took,
-/// and that is the question this property asks.
+/// Which tokens a construct took and which *byte* it came to rest on are two questions, and this
+/// property asks the first. The second is `a_construct_rests_at_the_lookahead_front`, and it
+/// exists because this file once carried the wrong answer to it here: that `repeated` rests at
+/// the end of the last token it consumed while `separated` rests at the start of the next one,
+/// so a caller's span differed by family. Measured, it does not — both rest at the lookahead
+/// front, because both reach it through a peek that declined, and B9 states that as a law over
+/// all eight drivers rather than as an aside.
 ///
 /// Stated over clean fixtures only. On a fixture containing an element the parser refuses, where
 /// a construct rests is a **policy** difference between the resilient and non-resilient families,
@@ -1111,10 +1125,10 @@ fn a_successful_construct_rests_just_past_the_last_element_it_kept() {
         // leaves nothing.
         Vec::new()
       } else if elements.is_empty() {
-        toks.iter().map(|(k, _)| *k).collect()
+        toks.iter().map(|(k, _, _)| *k).collect()
       } else {
         let after = base + stride * (elements.len() - 1) + 1;
-        toks[after..].iter().map(|(k, _)| *k).collect()
+        toks[after..].iter().map(|(k, _, _)| *k).collect()
       };
       r.check(want == obs.rest, || {
         format!(
@@ -1247,6 +1261,63 @@ fn a_failed_borrowed_attempt_holds_only_what_it_parsed() {
         format!(
           "{}/{} on {src:?}: the container held {container:?} against an accept log of {accepts:?}",
           b.name, fx.name
+        )
+      });
+    }
+  }
+  r.finish();
+}
+
+/// **B9 — a construct comes to rest at the lookahead front, and every one of the eight does.**
+///
+/// B3 says the resting position is *consistent* with what was left behind and B4 says which
+/// tokens those are. Neither pins the **byte**, and the byte is what a caller gets: every driver
+/// builds its reported span with `InputRef::span_since`, which reads `InputRef::cursor` — the
+/// lookahead (cache-front) position, documented on that method as "the start of the first cached
+/// token; otherwise the current position". So the reported end runs to the start of the next
+/// token, **trailing trivia included**, whenever the construct stopped by looking at a token it
+/// did not consume, and to the end of the last token it consumed when it looked at nothing more.
+///
+/// A construct that succeeded over a clean fixture always stopped by looking — it cannot know the
+/// elements ran out without asking — so on that arm the two cases collapse into one statement
+/// with an oracle outside the driver: **the end of the consumed region is the start of the first
+/// token still in the input, or the end of the source's last token when none is.** Both sides
+/// come from re-lexing with `logos` directly and from the tokens drained afterwards.
+///
+/// This is #259 stage 2's answer to whether the resting byte is a per-driver difference. It is
+/// not: all forty-eight rows satisfy one statement that names no driver, so the difference is in
+/// the *arm* — peeked-and-declined against consumed-to-the-end — and not in the family. What a
+/// caller may not assume is that the span stops at the last element: `1 2 3    +` and
+/// `1 , 2 , 3    +` both report an end four bytes past the last element, under `repeated` and
+/// under `separated` alike.
+#[test]
+fn a_construct_rests_at_the_lookahead_front() {
+  let mut r = Report::new(
+    "LAYER B9 — the reported end is the lookahead front: the start of the first token left \
+     behind, or the end of the last token consumed when nothing is",
+  );
+  for v in VARIANTS {
+    for fx in FIXTURES.iter().filter(|f| f.is_clean()) {
+      let src = v.render(fx);
+      let obs = (v.run)(&src);
+      if obs.elements.is_none() {
+        continue;
+      }
+      let toks = lexed(&src);
+      let (_, end) = obs.consumed;
+      // `rest` was drained from the same input, so its length names which of this source's
+      // tokens is the first one left.
+      let want = match toks.len().checked_sub(obs.rest.len()) {
+        Some(i) if i < toks.len() => toks[i].1,
+        _ => toks.last().map_or(0, |(_, _, e)| *e),
+      };
+      r.check(end == want, || {
+        format!(
+          "{}/{} on {src:?}: rested at {end}, and the lookahead front is {want} ({} token(s) \
+           left behind)",
+          v.name,
+          fx.name,
+          obs.rest.len()
         )
       });
     }
@@ -1546,6 +1617,70 @@ fn the_while_and_try_families_diverge_on_an_element_failure() {
   r.finish();
 }
 
+/// **A7 — the separator and the delimiter are wrappers, not element loops.**
+///
+/// The axis nothing else in this file compares. A1 pairs a driver with its `*_while` twin, A4
+/// pairs a driver with its delimited form, and both pairs render one fixture identically — so
+/// neither can look across the *separator*, whose renderings differ (`1 2 3` against `1,2,3`) and
+/// which therefore never appears on either side of `relate`. Four of the eight drivers were
+/// consequently never compared with the other four on anything.
+///
+/// The statement that closes it is about the abstract fixture rather than the source: **a
+/// driver's collection is decided by the fixture and by the resilience axis alone.** Which of the
+/// four structural shapes — plain, separated, delimited, delimited-and-separated — is doing the
+/// collecting must not change *what* is collected; a shape contributes its own tokens and its own
+/// diagnostics and nothing else. That is #259's "clearly identified shared engine", stated as
+/// behaviour: eight drivers, one element loop, and the separator and the delimiter riding on top
+/// of it.
+///
+/// Two things are deliberately outside the comparison, because a shape is entitled to them:
+///
+/// * **the consumed region and the tokens left behind** — a separated rendering has separators in
+///   it and a delimited one has brackets, so the same collection sits over a different token
+///   count. A4 and B4 hold those.
+/// * **the diagnostic vector** — a separator slot and a closer are each something to complain
+///   about that a plain repetition does not have. Over `junk_middle` the four shapes record none,
+///   one, one and two diagnostics: the count is the plain shape's plus one per wrapper, and every
+///   extra one is the wrapper's own.
+///
+/// The resilience axis stays *inside* it, one family at a time, because A6 already declares that
+/// difference: over `bad_first` the four try-driven shapes all keep `[2, 3]` and the four
+/// `*_while` shapes all refuse. Both halves are asserted here — the property is that the split is
+/// along resilience and along nothing else.
+#[test]
+fn the_four_structural_shapes_collect_the_same_elements() {
+  let mut r = Report::new(
+    "LAYER A7 — plain, separated, delimited and delimited-separated are one element loop under \
+     three wrappers: within a resilience family they must return the same collection",
+  );
+  for family in [
+    ["rep", "sep", "drep", "dsep"],
+    ["repw", "sepw", "drepw", "dsepw"],
+  ] {
+    // Every cardinality all eight drivers accept. The `exact2lm` / `exact2ml` rows are the
+    // `repeated` family's alone and are A2's subject, not this one.
+    for card in ["unb", "min2", "max2", "bnd13", "exact2b"] {
+      let base = variant(&format!("{}_{card}", family[0]));
+      for fx in FIXTURES {
+        let want = (base.run)(&base.render(fx)).elements;
+        for shape in &family[1..] {
+          let v = variant(&format!("{shape}_{card}"));
+          let src = v.render(fx);
+          let got = (v.run)(&src).elements;
+          r.check(got == want, || {
+            format!(
+              "{}/{} on {src:?}: this shape returned {got:?} where {} returned {want:?} over the \
+               same fixture",
+              v.name, fx.name, base.name
+            )
+          });
+        }
+      }
+    }
+  }
+  r.finish();
+}
+
 // ══════════════════════════════════════════════════════════════════════════════
 // The table itself
 // ══════════════════════════════════════════════════════════════════════════════
@@ -1567,7 +1702,7 @@ fn every_declared_driver_has_a_row() {
   );
   assert_eq!(
     BORROWED.len(),
-    22,
+    24,
     "the borrowed-destination table changed size; every row here must name a main-table twin"
   );
   assert_eq!(FIXTURES.len(), 10, "the fixture set changed size");


### PR DESCRIPTION
Stage 2 of #259. Stage 1 (#331) built the behavioural matrix; this uses it to decide, per element loop, whether each behavioural difference is **essential** — a consequence of what that combinator means, and therefore one of the criterion's *deliberately documented exceptions* — or **incidental**, and therefore a consolidation candidate. A verdict is the deliverable. **No behavioural change: the `tokora/src` diff is comment lines only.**

The rule the verdicts were reached by: a difference is incidental when a property can be stated that all eight loops satisfy, and essential when stating it requires naming a loop. The naming is then the documented exception, and the matrix carries it as an assertion rather than as a skipped case.

## The lead question: the resting byte. The premise was false.

The matrix's own B4 prose asserted that `repeated` and `separated` do not stop at the same byte — that `repeated` rests at the end of the last token it consumed and `separated` at the start of the next one, because the separator slot was peeked, and that a caller's span therefore changed with the combinator they picked.

Measured, it does not. Every driver builds its reported span with `InputRef::span_since`, which reads `InputRef::cursor` — the lookahead front — and **both families reach their stop through a peek that declined**: `separated` through `try_expect_or_stop` at the separator slot, `repeated` through the element parser's own lookahead. A declined peek leaves the token cached either way, so both rest on it.

| source | combinator | reported span | committed end |
|---|---|---|---|
| `1 2 3    +` | `repeated` | `(0, 9)` | `5` |
| `1 , 2 , 3    +` | `separated` | `(0, 13)` | `9` |
| `1 2 3` | `repeated` | `(0, 5)` | `5` |
| `1 , 2 , 3` | `separated` | `(0, 9)` | `9` |

Both report an end four bytes past the last element, at the `+`; both commit only as far as the `3`; at end of input both rest on the committed end. The difference is in the **arm** — peeked-and-declined against consumed-to-the-end — not in the family, and it is uniform over all forty-eight matrix rows.

That is not a per-driver exception, so it is documented as a shared rule instead: on `Collect` (public, where a caller reads the `L::Span` it hands back) and in `parser::many`'s header.

## Two new matrix properties, both planted

**B9 — `a_construct_rests_at_the_lookahead_front`.** The reported end is the start of the first token still in the input, or the end of the last token consumed when there is none. Both sides come from re-lexing with `logos` directly. Swapping the oracle to the other candidate position reds **144 of 288 cells**, so the two positions are distinguishable in the data and B9 pins a specific one.

**A7 — `the_four_structural_shapes_collect_the_same_elements`.** The axis nothing compared. A1 pairs a driver with its `*_while` twin and A4 with its delimited form; both need one rendering on each side, so no relation ever crossed the *separator* (`1 2 3` against `1,2,3`) and four of the eight drivers were never compared with the other four on anything. A7 relates the four structural shapes over the abstract fixture instead.

Planting a dropped first element into `sep/parse::handle_continue` and `sep_while/parse::handle_continue` — two edits that reach all four separated shapes, since the two delimited separated loops drive those same handlers:

| relation | with the plant |
|---|---|
| A1 `a_while_driver_stops_where_its_try_driven_sibling_stops` | green |
| A2 `the_three_ways_to_spell_one_bound_agree` | green |
| A4 `a_delimiter_does_not_change_what_is_collected_inside_it` | green |
| A5 `the_owning_and_borrowed_contracts_collect_the_same_elements` | green |
| A6 `the_while_and_try_families_diverge_on_an_element_failure` | green |
| **A7** | **red, 130 of 300 cells** |

## The verdicts

Essential, and documented as exceptions in `parser::many`'s header:

- **resilience** — the four try-driven loops file an element's `Err` as a diagnostic and continue; the four `*_while` ones end the collection. The comment-blind census is one `file_element_failure` call in each try-driven loop and zero in each `*_while` one — exactly along that axis and along no other.
- **the decision window** — a caller condition over `W` tokens is what `while` *is*.
- **the separator slot** and **the delimiter** — each contributes its own tokens and its own diagnostics and nothing else. Over `junk_middle` the four shapes record none, one, one and two diagnostics: the plain shape's count plus one per wrapper.
- **`sep/delim` and `sep_while/delim` probing the slot with `try_expect_map` rather than `try_expect_or_stop`** — a delimited list's separator position is also a close position, and the three-way answer is what classifies it; the undelimited form has no closer there and needs the terminal re-raise instead.

Incidental, listed in the header in the order a consolidation pass should take them:

1. **`delim/repeated` and `delim/repeated_while` re-state the plain element loop instead of wrapping it** — 593 lines, each with its own stall test, its own `admit_element` call and its own absence exits, where `sep/delim` and `sep_while/delim` drive their undelimited siblings' handlers and carry no admission at all. It pays twice: the missing destination contracts are missing *because* the loop is spelled `parse_repeated(inp, container, counts, on_stop)`.
2. **Three stop-hook shapes for one end-of-construct pass** — `RepeatedHandler::on_stop` returning the span (`repeated` uses it; `repeated_while` discards it and rebuilds the same span), `EndStateHandler`'s four state-dispatched methods, and a bare `FnOnce(..) -> Result<(), _>` closure in the two delimited plain loops.
3. **`Apply<Bounded<P>> for AtLeast<P>` and its `AtMost` mirror, for `Separated` and `SeparatedWhile`** — four small impls; they would let A2 cover eight drivers instead of four.
4. **The descent baseline's placement** — lowest; the widened window is already argued at each site, so unifying it buys uniformity and no behaviour.

The two findings the stage-1 report raised, verdicted:

- **`delim/repeated` and `delim/repeated_while` implement only the owning `Collect<_, Container>`.** Incidental. Their undelimited siblings implement three destination contracts and the four separated loops implement four. Being delimited is not the obstacle — `sep/delim` and `sep_while/delim` are delimited and implement all four. The borrowed contract is the only one that shows a caller the container on the **failure** arm, which is layer B8's whole subject.
- **`Separated`/`SeparatedWhile` expose no `at_least(n).at_most(m)` chaining.** Incidental. All ten `Apply` impls in the crate are `Repeated`'s or `RepeatedWhile`'s; the two separated builders reach `Bounded` through direct constructors. The missing pair is three lines each and mentions no separator.

Unmeasured, and recorded as such: the four `*_while` loops are written for `Complete` alone while the try-driven four are generic over `Cmpl`. It is essential by mechanism — a fixed-width decision window cannot tell a short read from a truncated one — but the matrix runs `Complete` only and cannot settle it.

## Also

Adds the two borrowed rows `dsep` and `dsepw` were missing at `bounded(1, 3)`. The impls exist (`sep/delim/bounded.rs` generates the `ref_type` block), so their absence was a gap in the table rather than in the crate; `BORROWED.len()` moves 22 -> 24, and the table's header now accounts for both subtractions from 48 separately.

## Validation

`cargo test -p tokora --features logos_0_16 --test repetition_behavioural_matrix` (17/17), `--lib` (1384/1384), `cargo clippy --all-targets` clean, `cargo fmt --check` clean, `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` and the bare-config `cargo doc --no-default-features` leg both clean.

One caveat worth recording: `parser::many` is a private module, so its `//!` header is prose rustdoc never link-checks. Verified directly — a planted `[\`ThisItemDoesNotExistAnywhere\`]` in that header passes `RUSTDOCFLAGS="-D warnings"`. Every link target in the new section was checked by hand against a real item instead. The caller-facing half is on `Collect`, which *is* checked.

Refs #259.
