### PR TITLE
feat(many)!: two delimited siblings already implement the borrowed contract, so a delimiter is not what withheld it from these two (#259)

### DIFF
--- a/tokora/src/parser/collect.rs
+++ b/tokora/src/parser/collect.rs
@@ -4,6 +4,25 @@ use crate::input::Complete;
 
 /// A parser that collects results into a container.
 ///
+/// # The three destinations, on every repetition driver
+///
+/// A collection can be asked for its container, for that container paired with the construct's
+/// span, or — when the caller owns the storage — for the span alone:
+///
+/// * `Collect<P, Container>` parsing to `Container`, the owning form;
+/// * `Collect<P, Container>` parsing to [`Spanned<Container, L::Span>`](crate::span::Spanned),
+///   the same transfer with the span beside it;
+/// * `Collect<&mut P, &mut Container>` parsing to `L::Span`, the **borrowed** form. It is the only
+///   one that leaves the caller holding the container on the **failure** arm, so it is how a
+///   partially-parsed collection is inspected after an error.
+///
+/// All three are available on every repetition driver — plain and separated, `while` and not,
+/// delimited and not. The separated families add a fourth arrangement for their separator
+/// policies. `tokora/tests/repetition_behavioural_matrix.rs`'s
+/// `the_owning_and_borrowed_contracts_collect_the_same_elements` holds the owning and borrowed
+/// forms to the same collection over every driver, and
+/// `a_failed_borrowed_attempt_holds_only_what_it_parsed` is what the borrowed one exists for.
+///
 /// # Where the input rests, and what the reported span therefore covers
 ///
 /// The span this combinator hands back — directly, as the `L::Span` of a borrowed collection, and

--- a/tokora/src/parser/many/delim/repeated/at_least.rs
+++ b/tokora/src/parser/many/delim/repeated/at_least.rs
@@ -68,3 +68,134 @@ where
       .map(|(_, collected)| collected)
   }
 }
+
+/// The **spanned owning** destination: the container and the construct's span together.
+///
+/// One of the two contracts this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<
+  'inp,
+  L,
+  P,
+  O,
+  Container,
+  Ctx,
+  Delim,
+  Lang: ?Sized,
+  Cmpl: crate::input::SurfaceIncomplete<'inp, L, Ctx, Lang>,
+> ParseInput<'inp, L, Spanned<Container, L::Span>, Ctx, Lang, Cmpl>
+  for Collect<
+    DelimitedBy<AtLeast<Repeated<P, O, L, Ctx, Lang, Cmpl>>, Delim>,
+    Container,
+    Ctx,
+    Lang,
+    Cmpl,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: TryParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + TooFewEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+  ) -> Result<Spanned<Container, L::Span>, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let minimum = self.parser.parser.minimum();
+    let min = minimum.get();
+
+    self
+      .attempt(|c| {
+        let Collect {
+          parser, container, ..
+        } = c;
+        DelimitedBy::<_, Delim>::new(parser.parser.parser_mut()).parse_repeated(
+          inp,
+          container,
+          &minimum,
+          |nums, inp, span| {
+            if min > nums {
+              inp
+                .emitter()
+                .emit_too_few(TooFew::of(span.clone(), nums, min))?;
+            }
+
+            Ok(())
+          },
+        )
+      })
+      .map(|(span, collected)| Spanned::new(span, collected))
+  }
+}
+
+/// The **borrowed** destination: the caller keeps the storage, so it can read what the construct
+/// admitted on the **failure** arm too, which the owning form cannot expose.
+///
+/// The second contract this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<
+  'inp,
+  'c,
+  L,
+  P,
+  O,
+  Container,
+  Ctx,
+  Delim,
+  Lang: ?Sized,
+  Cmpl: crate::input::SurfaceIncomplete<'inp, L, Ctx, Lang>,
+> ParseInput<'inp, L, L::Span, Ctx, Lang, Cmpl>
+  for Collect<
+    &'c mut DelimitedBy<AtLeast<Repeated<P, O, L, Ctx, Lang, Cmpl>>, Delim>,
+    &'c mut Container,
+    Ctx,
+    Lang,
+    Cmpl,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: TryParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + TooFewEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+  ) -> Result<L::Span, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let minimum = self.parser.parser.minimum();
+    let min = minimum.get();
+
+    DelimitedBy::<_, Delim>::new(self.parser.parser.parser_mut()).parse_repeated(
+      inp,
+      &mut self.container,
+      &minimum,
+      |nums, inp, span| {
+        if min > nums {
+          inp
+            .emitter()
+            .emit_too_few(TooFew::of(span.clone(), nums, min))?;
+        }
+
+        Ok(())
+      },
+    )
+  }
+}

--- a/tokora/src/parser/many/delim/repeated/at_most.rs
+++ b/tokora/src/parser/many/delim/repeated/at_most.rs
@@ -61,3 +61,116 @@ where
       .map(|(_, collected)| collected)
   }
 }
+
+/// The **spanned owning** destination: the container and the construct's span together.
+///
+/// One of the two contracts this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<
+  'inp,
+  L,
+  P,
+  O,
+  Container,
+  Ctx,
+  Delim,
+  Lang: ?Sized,
+  Cmpl: crate::input::SurfaceIncomplete<'inp, L, Ctx, Lang>,
+> ParseInput<'inp, L, Spanned<Container, L::Span>, Ctx, Lang, Cmpl>
+  for Collect<
+    DelimitedBy<AtMost<Repeated<P, O, L, Ctx, Lang, Cmpl>>, Delim>,
+    Container,
+    Ctx,
+    Lang,
+    Cmpl,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: TryParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + TooManyEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+  ) -> Result<Spanned<Container, L::Span>, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let maximum = self.parser.parser.maximum();
+
+    self
+      .attempt(|c| {
+        let Collect {
+          parser, container, ..
+        } = c;
+        DelimitedBy::<_, Delim>::new(parser.parser.parser_mut()).parse_repeated(
+          inp,
+          container,
+          &maximum,
+          |_, _, _| Ok(()),
+        )
+      })
+      .map(|(span, collected)| Spanned::new(span, collected))
+  }
+}
+
+/// The **borrowed** destination: the caller keeps the storage, so it can read what the construct
+/// admitted on the **failure** arm too, which the owning form cannot expose.
+///
+/// The second contract this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<
+  'inp,
+  'c,
+  L,
+  P,
+  O,
+  Container,
+  Ctx,
+  Delim,
+  Lang: ?Sized,
+  Cmpl: crate::input::SurfaceIncomplete<'inp, L, Ctx, Lang>,
+> ParseInput<'inp, L, L::Span, Ctx, Lang, Cmpl>
+  for Collect<
+    &'c mut DelimitedBy<AtMost<Repeated<P, O, L, Ctx, Lang, Cmpl>>, Delim>,
+    &'c mut Container,
+    Ctx,
+    Lang,
+    Cmpl,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: TryParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + TooManyEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+  ) -> Result<L::Span, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let maximum = self.parser.parser.maximum();
+
+    DelimitedBy::<_, Delim>::new(self.parser.parser.parser_mut()).parse_repeated(
+      inp,
+      &mut self.container,
+      &maximum,
+      |_, _, _| Ok(()),
+    )
+  }
+}

--- a/tokora/src/parser/many/delim/repeated/bounded.rs
+++ b/tokora/src/parser/many/delim/repeated/bounded.rs
@@ -71,3 +71,136 @@ where
       .map(|(_, collected)| collected)
   }
 }
+
+/// The **spanned owning** destination: the container and the construct's span together.
+///
+/// One of the two contracts this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<
+  'inp,
+  L,
+  P,
+  O,
+  Container,
+  Ctx,
+  Delim,
+  Lang: ?Sized,
+  Cmpl: crate::input::SurfaceIncomplete<'inp, L, Ctx, Lang>,
+> ParseInput<'inp, L, Spanned<Container, L::Span>, Ctx, Lang, Cmpl>
+  for Collect<
+    DelimitedBy<Bounded<Repeated<P, O, L, Ctx, Lang, Cmpl>>, Delim>,
+    Container,
+    Ctx,
+    Lang,
+    Cmpl,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: TryParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + TooManyEmitter<'inp, L, Lang>
+    + TooFewEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+  ) -> Result<Spanned<Container, L::Span>, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let limits = self.parser.parser.to_with();
+    let min = self.parser.parser.minimum().get();
+
+    self
+      .attempt(|c| {
+        let Collect {
+          parser, container, ..
+        } = c;
+        DelimitedBy::<_, Delim>::new(parser.parser.parser_mut()).parse_repeated(
+          inp,
+          container,
+          &limits,
+          |nums, inp, span| {
+            if min > nums {
+              inp
+                .emitter()
+                .emit_too_few(TooFew::of(span.clone(), nums, min))?;
+            }
+
+            Ok(())
+          },
+        )
+      })
+      .map(|(span, collected)| Spanned::new(span, collected))
+  }
+}
+
+/// The **borrowed** destination: the caller keeps the storage, so it can read what the construct
+/// admitted on the **failure** arm too, which the owning form cannot expose.
+///
+/// The second contract this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<
+  'inp,
+  'c,
+  L,
+  P,
+  O,
+  Container,
+  Ctx,
+  Delim,
+  Lang: ?Sized,
+  Cmpl: crate::input::SurfaceIncomplete<'inp, L, Ctx, Lang>,
+> ParseInput<'inp, L, L::Span, Ctx, Lang, Cmpl>
+  for Collect<
+    &'c mut DelimitedBy<Bounded<Repeated<P, O, L, Ctx, Lang, Cmpl>>, Delim>,
+    &'c mut Container,
+    Ctx,
+    Lang,
+    Cmpl,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: TryParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + TooManyEmitter<'inp, L, Lang>
+    + TooFewEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+  ) -> Result<L::Span, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let limits = self.parser.parser.to_with();
+    let min = self.parser.parser.minimum().get();
+
+    DelimitedBy::<_, Delim>::new(self.parser.parser.parser_mut()).parse_repeated(
+      inp,
+      &mut self.container,
+      &limits,
+      |nums, inp, span| {
+        if min > nums {
+          inp
+            .emitter()
+            .emit_too_few(TooFew::of(span.clone(), nums, min))?;
+        }
+
+        Ok(())
+      },
+    )
+  }
+}

--- a/tokora/src/parser/many/delim/repeated/unbounded.rs
+++ b/tokora/src/parser/many/delim/repeated/unbounded.rs
@@ -46,3 +46,102 @@ where
       .map(|(_, collected)| collected)
   }
 }
+
+/// The **spanned owning** destination: the container and the construct's span together.
+///
+/// One of the two contracts this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<
+  'inp,
+  L,
+  P,
+  O,
+  Container,
+  Ctx,
+  Delim,
+  Lang: ?Sized,
+  Cmpl: crate::input::SurfaceIncomplete<'inp, L, Ctx, Lang>,
+> ParseInput<'inp, L, Spanned<Container, L::Span>, Ctx, Lang, Cmpl>
+  for Collect<DelimitedBy<Repeated<P, O, L, Ctx, Lang, Cmpl>, Delim>, Container, Ctx, Lang, Cmpl>
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: TryParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang> + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+  ) -> Result<Spanned<Container, L::Span>, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    self
+      .attempt(|c| {
+        let Collect {
+          parser, container, ..
+        } = c;
+        DelimitedBy::<_, Delim>::new(&mut parser.parser).parse_repeated(
+          inp,
+          container,
+          &Unbounded,
+          |_, _, _| Ok(()),
+        )
+      })
+      .map(|(span, collected)| Spanned::new(span, collected))
+  }
+}
+
+/// The **borrowed** destination: the caller keeps the storage, so it can read what the construct
+/// admitted on the **failure** arm too, which the owning form cannot expose.
+///
+/// The second contract this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<
+  'inp,
+  'c,
+  L,
+  P,
+  O,
+  Container,
+  Ctx,
+  Delim,
+  Lang: ?Sized,
+  Cmpl: crate::input::SurfaceIncomplete<'inp, L, Ctx, Lang>,
+> ParseInput<'inp, L, L::Span, Ctx, Lang, Cmpl>
+  for Collect<
+    &'c mut DelimitedBy<Repeated<P, O, L, Ctx, Lang, Cmpl>, Delim>,
+    &'c mut Container,
+    Ctx,
+    Lang,
+    Cmpl,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: TryParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang> + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+  ) -> Result<L::Span, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    DelimitedBy::<_, Delim>::new(&mut self.parser.parser).parse_repeated(
+      inp,
+      &mut self.container,
+      &Unbounded,
+      |_, _, _| Ok(()),
+    )
+  }
+}

--- a/tokora/src/parser/many/delim/repeated_while/at_least.rs
+++ b/tokora/src/parser/many/delim/repeated_while/at_least.rs
@@ -65,3 +65,119 @@ where
       .map(|(_, collected)| collected)
   }
 }
+
+/// The **spanned owning** destination: the container and the construct's span together.
+///
+/// One of the two contracts this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<'inp, L, P, O, Condition, Container, Ctx, Delim, W, Lang: ?Sized>
+  ParseInput<'inp, L, Spanned<Container, L::Span>, Ctx, Lang>
+  for Collect<
+    DelimitedBy<AtLeast<RepeatedWhile<P, Condition, O, W, L, Ctx, Lang>>, Delim>,
+    Container,
+    Ctx,
+    Lang,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: ParseInput<'inp, L, O, Ctx, Lang>,
+  Condition: Decision<'inp, L, Ctx::Emitter, W, Lang>,
+  W: Window,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + SeparatedEmitter<'inp, L, Lang>
+    + TooFewEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang>,
+  ) -> Result<Spanned<Container, L::Span>, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let minimum = self.parser.parser.minimum();
+    let min = minimum.get();
+
+    self
+      .attempt(|c| {
+        let Collect {
+          parser, container, ..
+        } = c;
+        DelimitedBy::<_, Delim>::new(parser.parser.parser_mut()).parse_repeated(
+          inp,
+          container,
+          &minimum,
+          |nums, inp, span| {
+            if min > nums {
+              inp
+                .emitter()
+                .emit_too_few(TooFew::of(span.clone(), nums, min))?;
+            }
+
+            Ok(())
+          },
+        )
+      })
+      .map(|(span, collected)| Spanned::new(span, collected))
+  }
+}
+
+/// The **borrowed** destination: the caller keeps the storage, so it can read what the construct
+/// admitted on the **failure** arm too, which the owning form cannot expose.
+///
+/// The second contract this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<'inp, 'c, L, P, O, Condition, Container, Ctx, Delim, W, Lang: ?Sized>
+  ParseInput<'inp, L, L::Span, Ctx, Lang>
+  for Collect<
+    &'c mut DelimitedBy<AtLeast<RepeatedWhile<P, Condition, O, W, L, Ctx, Lang>>, Delim>,
+    &'c mut Container,
+    Ctx,
+    Lang,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: ParseInput<'inp, L, O, Ctx, Lang>,
+  Condition: Decision<'inp, L, Ctx::Emitter, W, Lang>,
+  W: Window,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + SeparatedEmitter<'inp, L, Lang>
+    + TooFewEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang>,
+  ) -> Result<L::Span, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let minimum = self.parser.parser.minimum();
+    let min = minimum.get();
+
+    DelimitedBy::<_, Delim>::new(self.parser.parser.parser_mut()).parse_repeated(
+      inp,
+      &mut self.container,
+      &minimum,
+      |nums, inp, span| {
+        if min > nums {
+          inp
+            .emitter()
+            .emit_too_few(TooFew::of(span.clone(), nums, min))?;
+        }
+
+        Ok(())
+      },
+    )
+  }
+}

--- a/tokora/src/parser/many/delim/repeated_while/at_most.rs
+++ b/tokora/src/parser/many/delim/repeated_while/at_most.rs
@@ -53,3 +53,99 @@ where
       .map(|(_, collected)| collected)
   }
 }
+
+/// The **spanned owning** destination: the container and the construct's span together.
+///
+/// One of the two contracts this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<'inp, L, P, O, Condition, Container, Ctx, Delim, W, Lang: ?Sized>
+  ParseInput<'inp, L, Spanned<Container, L::Span>, Ctx, Lang>
+  for Collect<
+    DelimitedBy<AtMost<RepeatedWhile<P, Condition, O, W, L, Ctx, Lang>>, Delim>,
+    Container,
+    Ctx,
+    Lang,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: ParseInput<'inp, L, O, Ctx, Lang>,
+  Condition: Decision<'inp, L, Ctx::Emitter, W, Lang>,
+  W: Window,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + TooManyEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang>,
+  ) -> Result<Spanned<Container, L::Span>, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let maximum = self.parser.parser.maximum();
+
+    self
+      .attempt(|c| {
+        let Collect {
+          parser, container, ..
+        } = c;
+        DelimitedBy::<_, Delim>::new(parser.parser.parser_mut()).parse_repeated(
+          inp,
+          container,
+          &maximum,
+          |_, _, _| Ok(()),
+        )
+      })
+      .map(|(span, collected)| Spanned::new(span, collected))
+  }
+}
+
+/// The **borrowed** destination: the caller keeps the storage, so it can read what the construct
+/// admitted on the **failure** arm too, which the owning form cannot expose.
+///
+/// The second contract this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<'inp, 'c, L, P, O, Condition, Container, Ctx, Delim, W, Lang: ?Sized>
+  ParseInput<'inp, L, L::Span, Ctx, Lang>
+  for Collect<
+    &'c mut DelimitedBy<AtMost<RepeatedWhile<P, Condition, O, W, L, Ctx, Lang>>, Delim>,
+    &'c mut Container,
+    Ctx,
+    Lang,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: ParseInput<'inp, L, O, Ctx, Lang>,
+  Condition: Decision<'inp, L, Ctx::Emitter, W, Lang>,
+  W: Window,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + TooManyEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang>,
+  ) -> Result<L::Span, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let maximum = self.parser.parser.maximum();
+
+    DelimitedBy::<_, Delim>::new(self.parser.parser.parser_mut()).parse_repeated(
+      inp,
+      &mut self.container,
+      &maximum,
+      |_, _, _| Ok(()),
+    )
+  }
+}

--- a/tokora/src/parser/many/delim/repeated_while/bounded.rs
+++ b/tokora/src/parser/many/delim/repeated_while/bounded.rs
@@ -63,3 +63,119 @@ where
       .map(|(_, collected)| collected)
   }
 }
+
+/// The **spanned owning** destination: the container and the construct's span together.
+///
+/// One of the two contracts this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<'inp, L, P, O, Condition, Container, Ctx, Delim, W, Lang: ?Sized>
+  ParseInput<'inp, L, Spanned<Container, L::Span>, Ctx, Lang>
+  for Collect<
+    DelimitedBy<Bounded<RepeatedWhile<P, Condition, O, W, L, Ctx, Lang>>, Delim>,
+    Container,
+    Ctx,
+    Lang,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: ParseInput<'inp, L, O, Ctx, Lang>,
+  Condition: Decision<'inp, L, Ctx::Emitter, W, Lang>,
+  W: Window,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + TooManyEmitter<'inp, L, Lang>
+    + TooFewEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang>,
+  ) -> Result<Spanned<Container, L::Span>, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let limits = self.parser.parser.to_with();
+    let min = self.parser.parser.minimum().get();
+
+    self
+      .attempt(|c| {
+        let Collect {
+          parser, container, ..
+        } = c;
+        DelimitedBy::<_, Delim>::new(parser.parser.parser_mut()).parse_repeated(
+          inp,
+          container,
+          &limits,
+          |nums, inp, span| {
+            if min > nums {
+              inp
+                .emitter()
+                .emit_too_few(TooFew::of(span.clone(), nums, min))?;
+            }
+
+            Ok(())
+          },
+        )
+      })
+      .map(|(span, collected)| Spanned::new(span, collected))
+  }
+}
+
+/// The **borrowed** destination: the caller keeps the storage, so it can read what the construct
+/// admitted on the **failure** arm too, which the owning form cannot expose.
+///
+/// The second contract this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<'inp, 'c, L, P, O, Condition, Container, Ctx, Delim, W, Lang: ?Sized>
+  ParseInput<'inp, L, L::Span, Ctx, Lang>
+  for Collect<
+    &'c mut DelimitedBy<Bounded<RepeatedWhile<P, Condition, O, W, L, Ctx, Lang>>, Delim>,
+    &'c mut Container,
+    Ctx,
+    Lang,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: ParseInput<'inp, L, O, Ctx, Lang>,
+  Condition: Decision<'inp, L, Ctx::Emitter, W, Lang>,
+  W: Window,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang>
+    + TooManyEmitter<'inp, L, Lang>
+    + TooFewEmitter<'inp, L, Lang>
+    + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang>,
+  ) -> Result<L::Span, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    let limits = self.parser.parser.to_with();
+    let min = self.parser.parser.minimum().get();
+
+    DelimitedBy::<_, Delim>::new(self.parser.parser.parser_mut()).parse_repeated(
+      inp,
+      &mut self.container,
+      &limits,
+      |nums, inp, span| {
+        if min > nums {
+          inp
+            .emitter()
+            .emit_too_few(TooFew::of(span.clone(), nums, min))?;
+        }
+
+        Ok(())
+      },
+    )
+  }
+}

--- a/tokora/src/parser/many/delim/repeated_while/unbounded.rs
+++ b/tokora/src/parser/many/delim/repeated_while/unbounded.rs
@@ -44,3 +44,91 @@ where
       .map(|(_, collected)| collected)
   }
 }
+
+/// The **spanned owning** destination: the container and the construct's span together.
+///
+/// One of the two contracts this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<'inp, L, P, O, Condition, Container, Ctx, Delim, W, Lang: ?Sized>
+  ParseInput<'inp, L, Spanned<Container, L::Span>, Ctx, Lang>
+  for Collect<
+    DelimitedBy<RepeatedWhile<P, Condition, O, W, L, Ctx, Lang>, Delim>,
+    Container,
+    Ctx,
+    Lang,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: ParseInput<'inp, L, O, Ctx, Lang>,
+  Condition: Decision<'inp, L, Ctx::Emitter, W, Lang>,
+  W: Window,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang> + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: Default + ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang>,
+  ) -> Result<Spanned<Container, L::Span>, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    self
+      .attempt(|c| {
+        let Collect {
+          parser, container, ..
+        } = c;
+        DelimitedBy::<_, Delim>::new(&mut parser.parser).parse_repeated(
+          inp,
+          container,
+          &Unbounded,
+          |_, _, _| Ok(()),
+        )
+      })
+      .map(|(span, collected)| Spanned::new(span, collected))
+  }
+}
+
+/// The **borrowed** destination: the caller keeps the storage, so it can read what the construct
+/// admitted on the **failure** arm too, which the owning form cannot expose.
+///
+/// The second contract this family did not implement until
+/// [#259](https://github.com/al8n/tokora/issues/259)'s stage 3.
+impl<'inp, 'c, L, P, O, Condition, Container, Ctx, Delim, W, Lang: ?Sized>
+  ParseInput<'inp, L, L::Span, Ctx, Lang>
+  for Collect<
+    &'c mut DelimitedBy<RepeatedWhile<P, Condition, O, W, L, Ctx, Lang>, Delim>,
+    &'c mut Container,
+    Ctx,
+    Lang,
+  >
+where
+  Delim: Delimiter<'inp, L, Lang>,
+  L: Lexer<'inp>,
+  P: ParseInput<'inp, L, O, Ctx, Lang>,
+  Condition: Decision<'inp, L, Ctx::Emitter, W, Lang>,
+  W: Window,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Ctx::Emitter: FullContainerEmitter<'inp, L, Lang> + UnclosedEmitter<'inp, L, Lang>,
+  <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  Container: ContainerT<O> + DelimiterHandler<'inp, L>,
+{
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang>,
+  ) -> Result<L::Span, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseContext<'inp, L, Lang>,
+  {
+    DelimitedBy::<_, Delim>::new(&mut self.parser.parser).parse_repeated(
+      inp,
+      &mut self.container,
+      &Unbounded,
+      |_, _, _| Ok(()),
+    )
+  }
+}

--- a/tokora/tests/repeated_delim_extra.rs
+++ b/tokora/tests/repeated_delim_extra.rs
@@ -1,0 +1,193 @@
+#![cfg(all(feature = "std", feature = "combinators", feature = "logos_0_16"))]
+
+//! The **spanned owning** destination on the two plain delimited families, `delim/repeated` and
+//! `delim/repeated_while`, over all four count variants.
+//!
+//! Spelled the way the *plain* families spell it — `Collect<..>` parsed straight to
+//! `Spanned<Container, L::Span>`, no `With<.., PhantomSpan>` wrapper, which is the separated
+//! families' shape and is what `sep_delim_extra.rs` and `sep_while_delim_extra.rs` exercise. A
+//! delimited plain list is the plain loop under a delimiter, so it inherits the plain loop's
+//! destination shape and not its delimited neighbour's.
+//!
+//! These two families had no file here because they had no spanned impl to exercise: they
+//! implemented the owning destination alone until #259 stage 3. The borrowed destination's
+//! counterpart is `repetition_behavioural_matrix.rs`'s borrowed table, whose eight `b_drep_*` /
+//! `b_drepw_*` rows arrived in the same change.
+//!
+//! Eight impls, eight rows: the four `unbounded` / `at_least` / `at_most` / `bounded`
+//! specialisations of each family. The bounds are chosen so every row lands on the SUCCESS arm —
+//! an impl that returned the span of an empty collection would pass a smoke test that only asked
+//! whether it returned, so each row asserts the container came back with the elements in it and
+//! the span covers the delimiters.
+
+mod common;
+
+use common::E;
+use tokora::EmitterView;
+
+use generic_arraydeque::typenum::U1;
+use tokora::{
+  Accumulator, Emitter, InputRef, Parse, ParseContext, ParseInput, Parser, ParserContext,
+  SimpleSpan, TryParseInput,
+  cache::Peeked,
+  emitter::{
+    Fatal, FullContainerEmitter, SeparatedEmitter, TooFewEmitter, TooManyEmitter, UnclosedEmitter,
+  },
+  parser::Action,
+  punct::Bracket,
+  span::Spanned,
+  try_parse_input::ParseAttempt,
+};
+
+use common::{TestLexer, Token};
+
+fn full_ctx() -> ParserContext<'static, TestLexer<'static>, Fatal<E>> {
+  ParserContext::new(Fatal::new())
+}
+
+/// The `TryParseInput` element `delim/repeated` drives: a number, or a decline.
+fn try_num<'inp, Ctx>(
+  inp: &mut InputRef<'inp, '_, TestLexer<'inp>, Ctx>,
+) -> Result<ParseAttempt<i64>, E>
+where
+  Ctx: ParseContext<'inp, TestLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, TestLexer<'inp>, Error = E>,
+{
+  inp
+    .try_expect(|t| matches!(t.data(), Token::Num(_)))
+    .map(|opt| match opt {
+      None => ParseAttempt::Decline,
+      Some(tok) => ParseAttempt::Accept(match tok.into_data() {
+        Token::Num(n) => n,
+        _ => unreachable!(),
+      }),
+    })
+}
+
+/// The `ParseInput` element `delim/repeated_while` drives, with `decide_num` as its condition.
+fn parse_num<'inp, Ctx>(inp: &mut InputRef<'inp, '_, TestLexer<'inp>, Ctx>) -> Result<i64, E>
+where
+  Ctx: ParseContext<'inp, TestLexer<'inp>>,
+  Ctx::Emitter: Emitter<'inp, TestLexer<'inp>, Error = E>,
+{
+  match inp.next()? {
+    None => Err(E),
+    Some(tok) => match tok.into_data() {
+      Token::Num(n) => Ok(n),
+      _ => Err(E),
+    },
+  }
+}
+
+fn decide_num<'inp, Ctx>(
+  mut peeked: Peeked<'_, 'inp, TestLexer<'inp>, U1>,
+  _: EmitterView<'_, 'inp, TestLexer<'inp>, Ctx::Emitter>,
+) -> Result<Action, <Ctx::Emitter as Emitter<'inp, TestLexer<'inp>>>::Error>
+where
+  Ctx: ParseContext<'inp, TestLexer<'inp>>,
+{
+  Ok(match peeked.pop_front() {
+    None => Action::Stop,
+    Some(tok) => {
+      let tok = tok
+        .as_maybe_ref()
+        .map(|t| t.token().copied(), |t| t.token())
+        .into_inner();
+      if matches!(**tok.data(), Token::Num(_)) {
+        Action::Continue
+      } else {
+        Action::Stop
+      }
+    }
+  })
+}
+
+/// `[1 2 3]` — three elements, so it satisfies every bound spelled below.
+const INPUT: &str = "[1 2 3]";
+
+macro_rules! drep_spanned {
+  ($name:ident, { $($bound:tt)* }) => {
+    paste::paste! {
+      fn [<$name _sp>]<'inp, Ctx>(
+        inp: &mut InputRef<'inp, '_, TestLexer<'inp>, Ctx>,
+      ) -> Result<Spanned<Vec<i64>, SimpleSpan>, E>
+      where
+        Ctx: ParseContext<'inp, TestLexer<'inp>>,
+        Ctx::Emitter: Emitter<'inp, TestLexer<'inp>, Error = E>
+          + FullContainerEmitter<'inp, TestLexer<'inp>>
+          + UnclosedEmitter<'inp, TestLexer<'inp>>
+          + TooFewEmitter<'inp, TestLexer<'inp>>
+          + TooManyEmitter<'inp, TestLexer<'inp>>,
+      {
+        try_num
+          .repeated()
+          $($bound)*
+          .delimited::<Bracket<(), (), ()>>()
+          .collect()
+          .parse_input(inp)
+      }
+
+      #[test]
+      fn [<$name _spanned>]() {
+        let r = Parser::with_context(full_ctx())
+          .apply([<$name _sp>])
+          .parse_str(INPUT)
+          .unwrap();
+        assert_eq!(r.data(), &vec![1, 2, 3]);
+        assert_eq!(r.span().start(), 0);
+        assert_eq!(r.span().end(), INPUT.len());
+      }
+    }
+  };
+}
+
+macro_rules! drepw_spanned {
+  ($name:ident, { $($bound:tt)* }) => {
+    paste::paste! {
+      fn [<$name _sp>]<'inp, Ctx>(
+        inp: &mut InputRef<'inp, '_, TestLexer<'inp>, Ctx>,
+      ) -> Result<Spanned<Vec<i64>, SimpleSpan>, E>
+      where
+        Ctx: ParseContext<'inp, TestLexer<'inp>>,
+        Ctx::Emitter: Emitter<'inp, TestLexer<'inp>, Error = E>
+          + FullContainerEmitter<'inp, TestLexer<'inp>>
+          + UnclosedEmitter<'inp, TestLexer<'inp>>
+          + SeparatedEmitter<'inp, TestLexer<'inp>>
+          + TooFewEmitter<'inp, TestLexer<'inp>>
+          + TooManyEmitter<'inp, TestLexer<'inp>>,
+      {
+        parse_num
+          .repeated_while::<_, U1>(decide_num::<Ctx>)
+          $($bound)*
+          .delimited::<Bracket<(), (), ()>>()
+          .collect()
+          .parse_input(inp)
+      }
+
+      #[test]
+      fn [<$name _spanned>]() {
+        let r = Parser::with_context(full_ctx())
+          .apply([<$name _sp>])
+          .parse_str(INPUT)
+          .unwrap();
+        assert_eq!(r.data(), &vec![1, 2, 3]);
+        assert_eq!(r.span().start(), 0);
+        assert_eq!(r.span().end(), INPUT.len());
+      }
+    }
+  };
+}
+
+// ── delim/repeated ────────────────────────────────────────────────────────────
+
+drep_spanned!(drep_unbounded, {});
+drep_spanned!(drep_at_least, { .at_least(2) });
+drep_spanned!(drep_at_most, { .at_most(3) });
+drep_spanned!(drep_bounded, { .bounded(1, 3) });
+
+// ── delim/repeated_while ──────────────────────────────────────────────────────
+
+drepw_spanned!(drepw_unbounded, {});
+drepw_spanned!(drepw_at_least, { .at_least(2) });
+drepw_spanned!(drepw_at_most, { .at_most(3) });
+drepw_spanned!(drepw_bounded, { .bounded(1, 3) });

--- a/tokora/tests/repetition_behavioural_matrix.rs
+++ b/tokora/tests/repetition_behavioural_matrix.rs
@@ -749,18 +749,16 @@ variants! {
 // ── The borrowed destination ──────────────────────────────────────────────────
 //
 // `Collect<&mut _, &mut Container>` is the other ownership contract: the caller keeps the
-// storage and can read it on the **failure** arm, which the owning form cannot expose. Six of the
-// eight drivers implement it; `delim/repeated` and `delim/repeated_while` implement only the
-// owning form, so they have no row here. That asymmetry is a fact about the crate rather than a
-// gap in this file, and it is the reason the main table above is the owning one. #259 stage 2
-// found it **incidental** rather than forced — `sep/delim` and `sep_while/delim` are delimited
-// too and implement the borrowed contract — so these rows return when those two drivers do.
+// storage and can read it on the **failure** arm, which the owning form cannot expose. **All
+// eight** drivers implement it. Two of them did not until #259 stage 3: `delim/repeated` and
+// `delim/repeated_while` implemented only the owning form, and stage 2 found that **incidental**
+// rather than forced — `sep/delim` and `sep_while/delim` are delimited too and implement the
+// borrowed contract — so the rows returned when those two drivers did.
 //
-// The count is twenty-four against the main table's forty-eight, and the two subtractions are
-// different in kind. Fourteen rows are the two drivers above, which have no borrowed impl to
-// drive. The other ten are the `exact2*` spellings: three construction paths to one cardinality
-// is A2's subject, and relating them through a second ownership contract asks nothing A2 and A5
-// do not already ask separately.
+// The count is thirty-two against the main table's forty-eight, and the sixteen missing rows are
+// all one kind now: the `exact2*` spellings. Three construction paths to one cardinality is A2's
+// subject, and relating them through a second ownership contract asks nothing A2 and A5 do not
+// already ask separately.
 
 /// One row of the borrowed-destination table.
 struct Borrowed {
@@ -875,6 +873,26 @@ borrowed_variants! { te, pe => {
       .delimited::<Bracket<(), (), ()>>();
   b_dsepw_bnd13: Comma true ~ dsepw_bnd13 =
     (&mut pe).separated_by_comma_while::<_, U1>(decide_num::<Ctx<'_>>).bounded(1, 3)
+      .delimited::<Bracket<(), (), ()>>();
+
+  b_drep_unb: Space true ~ drep_unb = te.repeated().delimited::<Bracket<(), (), ()>>();
+  b_drep_min2: Space true ~ drep_min2 =
+    te.repeated().at_least(2).delimited::<Bracket<(), (), ()>>();
+  b_drep_max2: Space true ~ drep_max2 =
+    te.repeated().at_most(2).delimited::<Bracket<(), (), ()>>();
+  b_drep_bnd13: Space true ~ drep_bnd13 =
+    te.repeated().bounded(1, 3).delimited::<Bracket<(), (), ()>>();
+
+  b_drepw_unb: Space true ~ drepw_unb =
+    pe.repeated_while::<_, U1>(decide_num::<Ctx<'_>>).delimited::<Bracket<(), (), ()>>();
+  b_drepw_min2: Space true ~ drepw_min2 =
+    pe.repeated_while::<_, U1>(decide_num::<Ctx<'_>>).at_least(2)
+      .delimited::<Bracket<(), (), ()>>();
+  b_drepw_max2: Space true ~ drepw_max2 =
+    pe.repeated_while::<_, U1>(decide_num::<Ctx<'_>>).at_most(2)
+      .delimited::<Bracket<(), (), ()>>();
+  b_drepw_bnd13: Space true ~ drepw_bnd13 =
+    pe.repeated_while::<_, U1>(decide_num::<Ctx<'_>>).bounded(1, 3)
       .delimited::<Bracket<(), (), ()>>();
 }}
 
@@ -1538,8 +1556,10 @@ fn a_delimiter_does_not_change_what_is_collected_inside_it() {
 /// loops that have drifted — the multiplication #259's evidence section describes, in the one
 /// place the crate genuinely writes a driver twice.
 ///
-/// Only the six drivers that implement both contracts have a row; `delim/repeated` and
-/// `delim/repeated_while` implement the owning form alone.
+/// All eight drivers have a row: `delim/repeated` and `delim/repeated_while` implemented the
+/// owning form alone until #259 stage 3 gave them the other two contracts. Each row is also this
+/// file's non-vacuity guard for its borrowed twin — a borrowed path that collected nothing would
+/// disagree with an owning twin that collected, rather than passing every property quietly.
 #[test]
 fn the_owning_and_borrowed_contracts_collect_the_same_elements() {
   let mut r = Report::new(
@@ -1702,7 +1722,7 @@ fn every_declared_driver_has_a_row() {
   );
   assert_eq!(
     BORROWED.len(),
-    24,
+    32,
     "the borrowed-destination table changed size; every row here must name a main-table twin"
   );
   assert_eq!(FIXTURES.len(), 10, "the fixture set changed size");


### PR DESCRIPTION
`delim/repeated` and `delim/repeated_while` implement the **owning** destination alone. Their six
siblings implement all three. This gives them the other two, and nothing else.

## The gap, and why the delimiter is not the reason for it

A collection can be asked for three things:

| destination | spelling | what it gives back |
| --- | --- | --- |
| owning | `Collect<P, Container>` | the container |
| spanned owning | `Collect<P, Container>` → `Spanned<Container, L::Span>` | the container beside the construct's span |
| **borrowed** | `Collect<&mut P, &mut Container>` → `L::Span` | the span — the caller already holds the container, **on the failure arm too** |

Six of the eight repetition drivers implement all three. `delim/repeated` and `delim/repeated_while`
implemented only the first.

[#259](https://github.com/al8n/tokora/issues/259) stage 2's verdict table judged that asymmetry
**incidental** rather than forced, and the evidence is next door: `sep/delim` and `sep_while/delim`
are delimited too, and they implement the borrowed contract. A delimiter does not stop a caller from
owning the container. What stopped these two is that each of their specialisations spells its own
call to `parse_repeated`, so a destination that wants a different container type has to be written
out per specialisation — and nobody had.

## What this adds

Sixteen `ParseInput` impls: the spanned-owning and the borrowed destination on each of the eight
`unbounded` / `at_least` / `at_most` / `bounded` specialisations of the two families. Each one calls
the **same** `parse_repeated` the owning impl beside it already calls, with the same bound and the
same `on_stop` closure.

No loop body is duplicated, no signature changes, nothing is removed: **892 lines added** under
`parser/many/`, 0 deleted. Plus the caller-facing note on `Collect` that now says all three
destinations are available on every driver, and the two test files below — 1,138 insertions and 14
deletions across eleven files in total.

## What carries it

The behavioural matrix's borrowed table goes from **twenty-four rows over six drivers to thirty-two
over all eight**.

* **B8** — `a_failed_borrowed_attempt_holds_only_what_it_parsed` — is the property that could not be
  asked before. What a collection holds on the **failure** arm is a question only the borrowed
  contract exposes, so for these two drivers there was no arm to look at. It now reaches every
  driver.
* **A5** — `the_owning_and_borrowed_contracts_collect_the_same_elements` — now relates all eight.
  Each new row is also that file's non-vacuity guard for its twin: a borrowed path that collected
  nothing would *disagree* with an owning twin that collected, rather than passing every property
  quietly.

The matrix's seventeen properties are unchanged and green with the eight new rows (17 passed,
0 failed).

Those eight rows cover the eight **borrowed** impls. The other eight — the **spanned owning** form
— get a new `repeated_delim_extra.rs`, which is exactly what `sep_delim_extra.rs` and
`sep_while_delim_extra.rs` already are for the two separated delimited drivers: the two plain
families had no such file because they had no spanned impl to put in it. Each of its eight rows
asserts the container came back with its elements *and* that the span runs from the opener to the
closer, since an impl that returned the span of an empty collection would pass a smoke test that
only asked whether it returned. (8 passed, 0 failed.)

Without those two files, **half of these sixteen impls would ship with no caller anywhere in the
repository** — and, as the measurement below shows, an impl nothing instantiates is an impl nothing
has run.

One thing writing them settled: the spanned form here is `Collect<..>` parsed straight to
`Spanned<Container, L::Span>`, with **no** `With<.., PhantomSpan>` wrapper. That is the *plain*
families' spelling, not the separated families'. A delimited plain list is the plain loop under a
delimiter, so it inherits the plain loop's destination shape — drafting the tests against the
separated idiom is how that got confirmed rather than assumed.

The structural censuses do not move. `gate_census` and `end_state_census` scan `delim/repeated.rs`
and `delim/repeated_while.rs`, which this does not touch; all four census tests pass unedited. A
comment-blind site census over the eight element-loop sources is **identical to `main`'s** — one
`loop {`, one stall test, one descent baseline and one scanner baseline in each. This adds
destinations, not loops.

## Cost: zero, measured

`ci/icount/run.sh` against `main`:

| workload | base Ir/iter | head Ir/iter | delta |
| --- | ---: | ---: | ---: |
| at_least | 214,881 | 214,881 | +0.000% |
| at_most | 212,909 | 212,909 | +0.000% |
| at_most_shallow | 316,210 | 316,210 | +0.000% |
| delimited | 293,778 | 293,778 | +0.000% |
| exactly | 211,983 | 211,983 | +0.000% |
| repeated | 146,391 | 146,391 | +0.000% |
| repeated_while | 214,508 | 214,508 | +0.000% |
| scan_drain | 124,392 | 124,392 | +0.000% |
| sep_while | 343,766 | 343,766 | +0.000% |
| sep_while_shallow | 453,428 | 453,428 | +0.000% |
| separated | 240,956 | 240,956 | +0.000% |
| separated_while | 277,519 | 277,519 | +0.000% |
| separated_while_shallow | 424,467 | 424,467 | +0.000% |

The two `tokora-icount` binaries are **byte-identical**: sha256
`15cb82090d296075bdcde28bbe46d913ac34763e7fb0b512238b40d5202933d1` on both sides. That is not luck —
the instrument's `delimited` workload is `.separated_by_comma().delimited_by_parens()`, so it
instantiates `sep/delim` and never either of these two families, and an uninstantiated generic emits
no code.

Run in a container on Linux/aarch64 with valgrind 3.19, not on CI's runner. Absolute Ir counts are a
property of the instruction set and are **not** comparable to x86_64's; the percentages and the
binary hash are what carry across.

## Relationship to #333

#333 landed these contracts *and* a consolidation of the two delimited element loops onto a shared
`drive_elements` in one change, and its icount gate flagged `at_most_shallow` at +1.030%. A
three-arm isolation run separated the two halves: this one is free — the binary above is
byte-identical to `main`'s — and the extraction is the entire cost. So they ship apart. #333 is
being rebased onto this branch and reduced to the extraction alone, where the trade can be judged on
its own numbers.

## `!`

`Collect<&mut DelimitedBy<Repeated<..>, D>, &mut C>`, its `Spanned` sibling and their four `*_while`
counterparts are new public `ParseInput` impls. Nothing is removed; the marker is for the inference
that new impls can perturb at a call site.

Part of #259.
